### PR TITLE
Correct a typo in the English translation for 敬老の日

### DIFF
--- a/src/Yasumi/Provider/Japan.php
+++ b/src/Yasumi/Provider/Japan.php
@@ -262,7 +262,7 @@ class Japan extends AbstractProvider
         }
         if (! is_null($date)) {
             $this->addHoliday(new Holiday('respectfortheAgedDay',
-                ['en_US' => 'Respect for the Age Day', 'ja_JP' => '敬老の日'], $date, $this->locale));
+                ['en_US' => 'Respect for the Aged Day', 'ja_JP' => '敬老の日'], $date, $this->locale));
         }
     }
 


### PR DESCRIPTION
Changes "Respect for the Age Day" to "Respect for the Aged Day"