### PR TITLE
Update Yasumi::create to allow for the instantiation of external holiday providers

### DIFF
--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -72,6 +72,11 @@ class Yasumi
     {
         // Find and return holiday provider instance
         $providerClass = sprintf('Yasumi\Provider\%s', str_replace('/', '\\', $class));
+
+        if (class_exists($class) && (new \ReflectionClass($class))->implementsInterface(ProviderInterface::class)) {
+            $providerClass = $class;
+        }
+
         if (! class_exists($providerClass) || $class === 'AbstractProvider') {
             throw new InvalidArgumentException(sprintf('Unable to find holiday provider "%s".', $class));
         }

--- a/tests/Base/YasumiTest.php
+++ b/tests/Base/YasumiTest.php
@@ -68,6 +68,16 @@ class YasumiTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests that classes that Yasumi allows external classes that extend the ProviderInterface.
+     */
+    public function testCreateWithAbstractExtension()
+    {
+        $class = \Yasumi\tests\YasumiExternalProvider::class;
+        $instance = Yasumi::create($class, 2016);
+        $this->assertInstanceOf($class, $instance);
+    }
+
+    /**
      * Tests that an Yasumi\Exception\UnknownLocaleException is thrown in case an invalid locale is given.
      *
      * @expectedException \Yasumi\Exception\UnknownLocaleException

--- a/tests/YasumiExternalProvider.php
+++ b/tests/YasumiExternalProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Yasumi\tests;
+
+use Yasumi\ProviderInterface;
+
+class YasumiExternalProvider implements ProviderInterface
+{
+    /**
+     * Initialize country holidays.
+     */
+    public function initialize()
+    {
+        // We don't actually have to do anything here.
+    }
+}


### PR DESCRIPTION
I thought it was kind of silly that Yasumi can only load it's own holiday providers (using Yasumi::create), so I wrote this update that allows it to instantiate external ones.

External Holiday providers must be an instance of ProviderInterface.
