### PR TITLE
Update Yasumi::getProviders for platform agnosticism

### DIFF
--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -123,9 +123,11 @@ class Yasumi
             return $providers;
         }
 
+        $ds = DIRECTORY_SEPARATOR;
+
         $extension     = 'php';
         $providers     = [];
-        $filesIterator = new \RecursiveIteratorIterator(new RecursiveDirectoryIterator(__DIR__ . '/Provider/'),
+        $filesIterator = new \RecursiveIteratorIterator(new RecursiveDirectoryIterator(__DIR__ . $ds . 'Provider' . $ds),
             RecursiveIteratorIterator::SELF_FIRST);
 
         foreach ($filesIterator as $file) {
@@ -135,7 +137,10 @@ class Yasumi
                 continue;
             }
 
-            $provider = preg_replace('#^.+/Provider/(.+)\.php$#', '$1', $file->getPathName());
+            $quotedDs = preg_quote($ds);
+            $regex = "#^.+{$quotedDs}Provider{$quotedDs}(.+)\\.php$#";
+
+            $provider = preg_replace($regex, '$1', $file->getPathName());
 
             $providers[] = $provider;
         }


### PR DESCRIPTION
Discovered while running tests on #29, Yasumi::getProviders does not work as expected on Windows!

This commit updates Yasumi::getProviders so that instead of hardcoding the unix-style / it instead listens for whatever PHP specifies as the DIRECTORY_SEPARATOR.