### PR TITLE
Added Portugal holiday provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Yasumi currently supports 59 countries (including sub-regions):
 * New Zealand
 * Norway
 * Poland
+* Portugal
 * Slovakia
 * Spain (including the sub-regions Andalusia, Aragon, Asturias, Balearic Islands, Basque Country, Canary Islands, Cantabria, Castile and León, Castile-La Mancha, Catalonia, Ceuta, Madrid Autonomous Community, Extremadura, Galicia, La Rioja, Melilla, Navarra Chartered Community, Murcia Region, Valencian Community)
 * Sweden
@@ -238,6 +239,7 @@ The tests are organized in some test suites to make testing a bit more easier:
 * "NewZealand"    : For separately testing the New Zealand Holiday Provider
 * "Norway"        : For separately testing the Norway Holiday Provider
 * "Poland"        : For separately testing the Poland Holiday Provider
+* "Portugal"      : For separately testing the Portugal Holiday Provider
 * "Slovakia"      : For separately testing the Slovakia Holiday Provider
 * "Spain"         : For separately testing the Spain Holiday Provider
 * "Sweden"        : For separately testing the Sweden Holiday Provider

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -61,7 +61,7 @@ class Portugal extends AbstractProvider
      */
     public function calculateAllSaintsDay()
     {
-        if($this->year <= 2013 || $this->year >= 2016) {
+        if ($this->year <= 2013 || $this->year >= 2016) {
             $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
         }
     }
@@ -72,7 +72,7 @@ class Portugal extends AbstractProvider
      */
     public function calculateCorpusChristi()
     {
-        if($this->year <= 2013 || $this->year >= 2016) {
+        if ($this->year <= 2013 || $this->year >= 2016) {
             $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
         }
     }

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\Provider;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+
+/**
+ * Holidays for Portugal.
+ *
+ * @link https://pt.wikipedia.org/wiki/Feriados_em_Portugal
+ *
+ * @package Yasumi\Provider
+ */
+class Portugal extends AbstractProvider
+{
+    use CommonHolidays, ChristianHolidays;
+
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or subregion.
+     */
+    const ID = 'PT';
+
+    /**
+     * Initialize holidays for Portugal.
+     */
+    public function initialize()
+    {
+        $this->timezone = 'Europe/Lisbon';
+
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
+        $this->calculateCarnationRevolutionDay();
+        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
+        $this->calculateCorpusChristi();
+        $this->calculatePortugalDay();
+        $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale));
+        $this->calculatePortugueseRepublicDay();
+        $this->calculateAllSaintsDay();
+        $this->calculateRestorationOfIndependenceDay();
+        $this->addHoliday($this->immaculateConception($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
+    }
+
+    /**
+     * In Portugal, between 2013 andd 2015 (inclusive) this holiday did not happen due to government deliberation.
+     * It was restored in 2016.
+     */
+    public function calculateAllSaintsDay()
+    {
+        if($this->year <= 2013 || $this->year >= 2016) {
+            $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
+        }
+    }
+
+    /**
+     * In Portugal, between 2013 andd 2015 (inclusive) this holiday did not happen due to government deliberation.
+     * It was restored in 2016.
+     */
+    public function calculateCorpusChristi()
+    {
+        if($this->year <= 2013 || $this->year >= 2016) {
+            $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
+        }
+    }
+
+    /*
+     * Carnation Revolution (25th of April 1974) / Revolução dos Cravos (25 de Abril 1974)
+     *
+     * The Carnation Revolution (Portuguese: Revolução dos Cravos), also referred to as the 25 April (Portuguese: 25 de
+     * Abril), was initially a military coup in Lisbon, Portugal, on 25 April 1974 which overthrew the regime of the
+     * Estado Novo. The revolution started as a military coup organized by the Armed Forces Movement (Portuguese:
+     * Movimento das Forças Armadas, MFA) composed of military officers who opposed the regime, but the movement was
+     * soon coupled with an unanticipated and popular campaign of civil resistance. This movement would lead to the
+     * fall of the Estado Novo and the withdrawal of Portugal from its African colonies and East Timor. The name
+     * "Carnation Revolution" comes from the fact that almost no shots were fired and when the population took to the
+     * streets to celebrate the end of the dictatorship and war in the colonies, carnations were put into the muzzles
+     * of rifles and on the uniforms of the army men. In Portugal, the 25th of April is a national holiday, known as
+     * Freedom Day (Portuguese: Dia da Liberdade), to celebrate the event.
+     *
+     * @link https://en.wikipedia.org/wiki/Carnation_Revolution
+     */
+    public function calculateCarnationRevolutionDay()
+    {
+        if ($this->year >= 1974) {
+            $this->addHoliday(new Holiday('25thApril', ['pt_PT' => 'Dia da Liberdade'],
+                new DateTime("$this->year-04-25", new DateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_NATIONAL));
+        }
+    }
+
+    /**
+     * Establishment of the Portuguese Republic / Implantação da República Portuguesa
+     *
+     * The establishment of the Portuguese Republic was the result of a coup d'état organised by the Portuguese
+     * Republican Party which, on 5 October 1910, deposed the constitutional monarchy and established a republican
+     * regime in Portugal. The subjugation of the country to British colonial interests, the royal family's
+     * expenses, the power of the Church, the political and social instability, the system of alternating power of the
+     * two political parties (Progressive and Regenerador), João Franco's dictatorship, an apparent inability to adapt
+     * to modern times – all contributed to an unrelenting erosion of the Portuguese monarchy. The proponents of the
+     * republic, particularly the Republican Party, found ways to take advantage of the situation. The Republican Party
+     * presented itself as the only one that had a programme that was capable of returning to the country its lost
+     * status and place Portugal on the way of progress.
+     *
+     * @link https://en.wikipedia.org/wiki/5_October_1910_revolution
+     */
+    public function calculatePortugueseRepublicDay()
+    {
+        if ($this->year >= 1910) {
+            $this->addHoliday(new Holiday('portugueseRepublic', ['pt_PT' => 'Implantação da República Portuguesa'],
+                new DateTime("$this->year-10-05", new DateTimeZone($this->timezone)), $this->locale));
+        }
+    }
+
+    /**
+     * Restoration of Independence / Reguesstauração da Independência
+     *
+     * There is no Wikipedia article referencing this holiday directly so we are using the War that motivated the
+     * holiday instead until we can find something better.
+     *
+     * The Portuguese Restoration War (Portuguese: Guerra da Restauração; Spanish: Guerra de Restauración portuguesa)
+     * was the name given by nineteenth-century 'romantic' historians to the war between Portugal and Spain that began
+     * with the Portuguese revolution of 1640 and ended with the Treaty of Lisbon in 1668. The revolution of 1640 ended
+     * the 60-year rule of Portugal by the Spanish Habsburgs. The period from 1640 to 1668 was marked by periodic
+     * skirmishes between Portugal and Spain, as well as short episodes of more serious warfare, much of it occasioned
+     * by Spanish and Portuguese entanglements with non-Iberian powers. Spain was involved in the Thirty Years' War
+     * until 1648 and the Franco–Spanish War until 1659, while Portugal was involved in the Dutch–Portuguese War until
+     * 1663. In the seventeenth century and afterwards, this period of sporadic conflict was simply known, in Portugal
+     * and elsewhere, as the Acclamation War. The war established the House of Braganza as Portugal's new ruling
+     * dynasty, replacing the House of Habsburg. This ended the so-called Iberian Union.
+     *
+     * @link https://pt.wikipedia.org/wiki/Restauração_da_Independência (portuguese link)
+     * @link https://pt.wikipedia.org/wiki/Guerra_da_Restauração (english link)
+     */
+    public function calculateRestorationOfIndependenceDay()
+    {
+        // The Wikipedia article mentions that this has been a holiday since the second of half of the XIX century.
+        if (($this->year >= 1850 && $this->year <= 2013) || $this->year >= 2016) {
+            $this->addHoliday(new Holiday('restorationOfIndependence', ['pt_PT' => 'Restauração da Independência'],
+                new DateTime("$this->year-12-01", new DateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_NATIONAL));
+        }
+    }
+
+    /**
+     * Day of Portugal, Camões and the Portuguese Communities / Dia de Portugal, de Camões e das Comunidades Portuguesas
+     *
+     * The Wikipedia article mentions that this holiday changed names during the Portuguese dictatorship that ran
+     * between 1933 and 1974 (ended with the Carnation Revolution). This is the name that is currently standing.
+     *
+     * Portugal Day, officially Day of Portugal, Camões, and the Portuguese Communities (Portuguese: Dia de Portugal,
+     * de Camões e das Comunidades Portuguesas), is Portugal's National Day celebrated annually on 10 June. Although
+     * officially observed only in Portugal, Portuguese citizens and emigrants throughout the world celebrate this
+     * holiday. The date commemorates the death of national literary icon Luís de Camões on 10 June 1580.
+     *
+     * @link https://en.wikipedia.org/wiki/Portugal_Day
+     */
+    public function calculatePortugalDay()
+    {
+        if ($this->year <= 1932 || $this->year >= 1974) {
+            $this->addHoliday(new Holiday('portugalDay',
+                ['pt_PT' => 'Dia de Portugal'],
+                new DateTime("$this->year-06-10", new DateTimeZone($this->timezone)), $this->locale));
+        }
+    }
+}

--- a/src/Yasumi/data/translations/allSaintsDay.php
+++ b/src/Yasumi/data/translations/allSaintsDay.php
@@ -23,6 +23,7 @@ return [
     'nl_BE' => 'Allerheiligen',
     'nl_NL' => 'Allerheiligen',
     'pl_PL' => 'Uroczystość Wszystkich Świętych',
+    'pt_PT' => 'Dia de todos os Santos',
     'sk_SK' => 'Sviatok Všetkých svätých',
     'sv_SE' => 'alla helgons dag',
 ];

--- a/src/Yasumi/data/translations/assumptionOfMary.php
+++ b/src/Yasumi/data/translations/assumptionOfMary.php
@@ -23,4 +23,5 @@ return [
     'nl_NL' => 'Onze Lieve Vrouw hemelvaart',
     'pl_PL' => 'Wniebowzięcie Najświętszej Marii Panny',
     'sk_SK' => 'Nanebovzatie Panny Márie',
+    'pt_PT' => 'Assunção de Nossa Senhora',
 ];

--- a/src/Yasumi/data/translations/carnationRevolutionDay.php
+++ b/src/Yasumi/data/translations/carnationRevolutionDay.php
@@ -10,12 +10,8 @@
  *  @author Sacha Telgenhof <stelgenhof@gmail.com>
  */
 
-// Translation for Father's Day
+// Translation for the Carnation Revolution Day
 return [
-    'el_GR' => 'Γιορτή του πατέρα',
-    'en_US' => 'Father\'s Day',
-    'nl_BE' => 'Vaderdag',
-    'nl_NL' => 'Vaderdag',
-    'pt_PT' => 'Dia do Pai',
-    'sk_SK' => 'Deň otcov',
+    'en_US' => 'Freedom Day',
+    'pt_PT' => 'Dia da Liberdade',
 ];

--- a/src/Yasumi/data/translations/christmasDay.php
+++ b/src/Yasumi/data/translations/christmasDay.php
@@ -30,6 +30,7 @@ return [
     'nl_NL' => 'Kerstmis',
     'pl_PL' => 'pierwszy dzień Bożego Narodzenia',
     'pt_BR' => 'Natal',
+    'pt_PT' => 'Natal',
     'ru_UA' => 'Рождество',
     'sk_SK' => 'Prvý sviatok vianočný',
     'sv_SE' => 'juldagen',

--- a/src/Yasumi/data/translations/christmasEve.php
+++ b/src/Yasumi/data/translations/christmasEve.php
@@ -15,6 +15,7 @@ return [
     'cs_CZ' => 'Štědrý den',
     'cy_GB' => 'Noswyl Nadolig',
     'en_US' => 'Christmas Eve',
+    'pt_PT' => 'Véspera de Natal',
     'sk_SK' => 'Štedrý deň',
     'sv_SE' => 'julafton',
 ];

--- a/src/Yasumi/data/translations/corpusChristi.php
+++ b/src/Yasumi/data/translations/corpusChristi.php
@@ -18,4 +18,5 @@ return [
     'hr_HR' => 'Tijelovo',
     'pl_PL' => 'Boże Ciało',
     'pt_BR' => 'Corpus Christi',
+    'pt_PT' => 'Corpo de Deus',
 ];

--- a/src/Yasumi/data/translations/easter.php
+++ b/src/Yasumi/data/translations/easter.php
@@ -24,6 +24,7 @@ return [
     'nl_NL' => 'Eerste Paasdag',
     'pl_PL' => 'Wielkanoc',
     'pt_BR' => 'Páscoa',
+    'pt_PT' => 'Páscoa',
     'ru_UA' => 'Пасха',
     'sv_SE' => 'påskdagen',
     'uk_UA' => 'Великдень',

--- a/src/Yasumi/data/translations/goodFriday.php
+++ b/src/Yasumi/data/translations/goodFriday.php
@@ -29,6 +29,7 @@ return [
     'nl_NL' => 'Goede Vrijdag',
     'pl_PL' => 'Wielki Piątek',
     'pt_BR' => 'Sexta feira santa',
+    'pt_PT' => 'Sexta-feira Santa',
     'sk_SK' => 'Veľký piatok',
     'sv_SE' => 'långfredagen',
 ];

--- a/src/Yasumi/data/translations/immaculateConception.php
+++ b/src/Yasumi/data/translations/immaculateConception.php
@@ -16,4 +16,5 @@ return [
     'en_US' => 'Immaculate Conception',
     'es_ES' => 'Inmaculada Concepción',
     'it_IT' => 'Immacolata Concezione',
+    'pt_PT' => 'Dia da Imaculada Conceição',
 ];

--- a/src/Yasumi/data/translations/internationalWorkersDay.php
+++ b/src/Yasumi/data/translations/internationalWorkersDay.php
@@ -27,6 +27,7 @@ return [
     'nl_NL' => 'Dag van de arbeid',
     'pl_PL' => 'Święto Pracy',
     'pt_BR' => 'Dia internacional do trabalhador',
+    'pt_PT' => 'Dia do Trabalhador',
     'ru_UA' => 'День международной солидарности трудящихся',
     'sk_SK' => 'Sviatok práce',
     'sv_SE' => 'Första maj',

--- a/src/Yasumi/data/translations/mothersDay.php
+++ b/src/Yasumi/data/translations/mothersDay.php
@@ -16,5 +16,6 @@ return [
     'en_US' => 'Mother\'s Day',
     'nl_BE' => 'Moederdag',
     'nl_NL' => 'Moederdag',
+    'pt_PT' => 'Dia da Mãe',
     'sk_SK' => 'Deň matiek',
 ];

--- a/src/Yasumi/data/translations/newYearsDay.php
+++ b/src/Yasumi/data/translations/newYearsDay.php
@@ -31,6 +31,7 @@ return [
     'nl_NL' => 'Nieuwjaar',
     'pl_PL' => 'Nowy Rok',
     'pt_BR' => 'Ano novo',
+    'pt_PT' => 'Dia de Ano Novo',
     'ru_UA' => 'Новый Год',
     'sk_SK' => 'Deň vzniku Slovenskej republiky',
     'sv_SE' => 'nyårsdagen',

--- a/src/Yasumi/data/translations/portugalDay.php
+++ b/src/Yasumi/data/translations/portugalDay.php
@@ -10,12 +10,8 @@
  *  @author Sacha Telgenhof <stelgenhof@gmail.com>
  */
 
-// Translation for Father's Day
+// Translation for Portugal Day
 return [
-    'el_GR' => 'Γιορτή του πατέρα',
-    'en_US' => 'Father\'s Day',
-    'nl_BE' => 'Vaderdag',
-    'nl_NL' => 'Vaderdag',
-    'pt_PT' => 'Dia do Pai',
-    'sk_SK' => 'Deň otcov',
+    'en_US' => 'Portugal Day',
+    'pt_PT' => 'Dia de Portugal',
 ];

--- a/src/Yasumi/data/translations/portugueseRepublicDay.php
+++ b/src/Yasumi/data/translations/portugueseRepublicDay.php
@@ -10,12 +10,8 @@
  *  @author Sacha Telgenhof <stelgenhof@gmail.com>
  */
 
-// Translation for Father's Day
+// Translation for Implantation of the Portuguese Republic Day
 return [
-    'el_GR' => 'Γιορτή του πατέρα',
-    'en_US' => 'Father\'s Day',
-    'nl_BE' => 'Vaderdag',
-    'nl_NL' => 'Vaderdag',
-    'pt_PT' => 'Dia do Pai',
-    'sk_SK' => 'Deň otcov',
+    'en_US' => 'Implantation of the Portuguese Republic',
+    'pt_PT' => 'Implantação da República Portuguesa',
 ];

--- a/src/Yasumi/data/translations/restorationOfIndepence.php
+++ b/src/Yasumi/data/translations/restorationOfIndepence.php
@@ -10,12 +10,8 @@
  *  @author Sacha Telgenhof <stelgenhof@gmail.com>
  */
 
-// Translation for Father's Day
+// Translation for Armistice Day
 return [
-    'el_GR' => 'Γιορτή του πατέρα',
-    'en_US' => 'Father\'s Day',
-    'nl_BE' => 'Vaderdag',
-    'nl_NL' => 'Vaderdag',
-    'pt_PT' => 'Dia do Pai',
-    'sk_SK' => 'Deň otcov',
+    'en_US' => 'Restoration of Independence',
+    'pt_PT' => 'Restauração da Independência',
 ];

--- a/src/Yasumi/data/translations/valentinesDay.php
+++ b/src/Yasumi/data/translations/valentinesDay.php
@@ -19,4 +19,5 @@ return [
     'nl_BE' => 'Valentijnsdag',
     'nl_NL' => 'Valentijnsdag',
     'pl_PL' => 'Walentynki',
+    'pt_PT' => 'Dia dos Namorados',
 ];

--- a/tests/Portugal/AllSaintsDayTest.php
+++ b/tests/Portugal/AllSaintsDayTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class containing tests for All Saints Day in Portugal.
+ */
+class AllSaintsDayTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'allSaintsDay';
+
+    /**
+     * Holiday was abolished by the portuguese government in 2014.
+     */
+    const HOLIDAY_YEAR_ABOLISHED = 2014;
+
+    /**
+     * Holiday was restored by the portuguese government in 2016.
+     */
+    const HOLIDAY_YEAR_RESTORED = 2016;
+
+    /**
+     * Tests the holiday defined in this test.
+     */
+    public function testHoliday()
+    {
+        $year = 2016;
+        $expected = new DateTime("$year-11-01", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+
+        $year = 2013;
+        $expected = new DateTime("$year-11-01", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Test that the holiday did not happen in 2014 and 2015.
+     */
+    public function testNotHoliday()
+    {
+        $year = $this->generateRandomYear(2014, 2015);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+    }
+
+    /**
+     * Tests translated name of Corpus Christi.
+     */
+    public function testTranslation()
+    {
+        $year = $this->generateRandomYear(self::HOLIDAY_YEAR_RESTORED);
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $year, [self::LOCALE => 'Dia de todos os Santos']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        // After restoration
+        $year = $this->generateRandomYear(self::HOLIDAY_YEAR_RESTORED);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+
+        // Before abolishment
+        $year = $this->generateRandomYear(1000, self::HOLIDAY_YEAR_ABOLISHED - 1);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/AssumptionOfMaryTest.php
+++ b/tests/Portugal/AssumptionOfMaryTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class for testing the day of the Assumption of Mary in Portugal.
+ */
+class AssumptionOfMaryTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = 'assumptionOfMary';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int      $year     the year for which the holiday defined in this test needs to be tested
+     * @param DateTime $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test.
+     *
+     * @return array list of test dates for the day of the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        return $this->generateRandomDates(8, 15, self::TIMEZONE);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $this->generateRandomYear(),
+            [self::LOCALE => 'Assunção de Nossa Senhora']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/CarnationRevolutionDayTest.php
+++ b/tests/Portugal/CarnationRevolutionDayTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class for testing Portugal Day in Portugal.
+ */
+class CarnationRevolutionDayTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The year in which the holiday was established
+     */
+    const ESTABLISHMENT_YEAR = 1974;
+
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = '25thApril';
+
+    /**
+     * Test that the holiday is valid after the year of establishment
+     */
+    public function testHolidayAfterEstablishment()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $expected = new DateTime("$year-04-25", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Tests that the holiday is not a holiday before the year of establishment
+     */
+    public function testNotHolidayBeforeEstablishment()
+    {
+        $year = $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $year, [self::LOCALE => 'Dia da Liberdade']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/ChristmasTest.php
+++ b/tests/Portugal/ChristmasTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class for testing Christmas in Portugal.
+ */
+class ChristmasTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'christmasDay';
+
+    /**
+     * Tests Christmas Day.
+     *
+     * @dataProvider ChristmasDayDataProvider
+     *
+     * @param int      $year     the year for which Christmas Day needs to be tested
+     * @param DateTime $expected the expected date
+     */
+    public function testChristmasDay($year, $expected)
+    {
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of Christmas Day.
+     *
+     * @return array list of test dates for Christmas Day
+     */
+    public function ChristmasDayDataProvider()
+    {
+        return $this->generateRandomDates(12, 25, self::TIMEZONE);
+    }
+
+    /**
+     * Tests translated name of Christmas Day.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $this->generateRandomYear(),
+            [self::LOCALE => 'Natal']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/CorpusChristiTest.php
+++ b/tests/Portugal/CorpusChristiTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class containing tests for Corpus Christi in Portugal.
+ */
+class CorpusChristiTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'corpusChristi';
+
+    /**
+     * Holiday was abolished by the portuguese government in 2014.
+     */
+    const HOLIDAY_YEAR_ABOLISHED = 2014;
+
+    /**
+     * Holiday was restored by the portuguese government in 2016.
+     */
+    const HOLIDAY_YEAR_RESTORED = 2016;
+
+    /**
+     * Tests the holiday defined in this test.
+     */
+    public function testHoliday()
+    {
+        $year = 2016;
+        $expected = new DateTime("$year-5-26", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Test that the holiday did not happen in 2014 and 2015.
+     */
+    public function testNotHoliday()
+    {
+        $year = $this->generateRandomYear(2014, 2015);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+    }
+
+    /**
+     * Tests translated name of Corpus Christi.
+     */
+    public function testTranslation()
+    {
+        $year = $this->generateRandomYear(self::HOLIDAY_YEAR_RESTORED);
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $year, [self::LOCALE => 'Corpo de Deus']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        // Before abolishment
+        $year = $this->generateRandomYear(1000, self::HOLIDAY_YEAR_ABOLISHED - 1);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);
+
+        // After restoration
+        $year = $this->generateRandomYear(self::HOLIDAY_YEAR_RESTORED);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);
+    }
+}

--- a/tests/Portugal/EasterTest.php
+++ b/tests/Portugal/EasterTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class containing tests for Easter in Norway.
+ */
+class EasterTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = 'easter';
+
+    /**
+     * Tests the holiday defined in this test.
+     */
+    public function testHoliday()
+    {
+        $year = 2016;
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year,
+            new DateTime("$year-03-27", new DateTimeZone(self::TIMEZONE)));
+    }
+
+    /**
+     * Tests translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $this->generateRandomYear(),
+            [self::LOCALE => 'Páscoa']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/GoodFridayTest.php
+++ b/tests/Portugal/GoodFridayTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class containing tests for Good Friday in Norway.
+ */
+class GoodFridayTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = 'goodFriday';
+
+    /**
+     * Tests the holiday defined in this test.
+     */
+    public function testHoliday()
+    {
+        $year = 2016;
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year,
+            new DateTime("$year-3-25", new DateTimeZone(self::TIMEZONE)));
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $this->generateRandomYear(),
+            [self::LOCALE => 'Sexta-feira Santa']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/ImmaculateConceptionTest.php
+++ b/tests/Portugal/ImmaculateConceptionTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class for testing the day of Immaculate Conception in Portugal.
+ */
+class ImmaculateConceptionTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = 'immaculateConception';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int      $year     the year for which the holiday defined in this test needs to be tested
+     * @param DateTime $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test.
+     *
+     * @return array list of test dates for the day of the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        return $this->generateRandomDates(12, 8, self::TIMEZONE);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $this->generateRandomYear(),
+            [self::LOCALE => 'Dia da Imaculada Conceição']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/InternationalWorkersDayTest.php
+++ b/tests/Portugal/InternationalWorkersDayTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class containing tests for International Workers' Day (i.e. Labour Day) in Portugal.
+ */
+class InternationalWorkersDayTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'internationalWorkersDay';
+
+    /**
+     * Tests International Workers' Day.
+     *
+     * @dataProvider InternationalWorkersDayDataProvider
+     *
+     * @param int      $year     the year for which International Workers' Day needs to be tested
+     * @param DateTime $expected the expected date
+     */
+    public function testInternationalWorkersDay($year, $expected)
+    {
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Tests translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $this->generateRandomYear(),
+            [self::LOCALE => 'Dia do Trabalhador']);
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of International Workers' Day.
+     *
+     * @return array list of test dates for International Workers' Day
+     */
+    public function InternationalWorkersDayDataProvider()
+    {
+        return $this->generateRandomDates(5, 1, self::TIMEZONE);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/NewYearsDayTest.php
+++ b/tests/Portugal/NewYearsDayTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class for testing New Years Day in Portugal.
+ */
+class NewYearsDayTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = 'newYearsDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int      $year     the year for which the holiday defined in this test needs to be tested
+     * @param DateTime $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        return $this->generateRandomDates(1, 1, self::TIMEZONE);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $this->generateRandomYear(),
+            [self::LOCALE => 'Dia de Ano Novo']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/PortugalBaseTestCase.php
+++ b/tests/Portugal/PortugalBaseTestCase.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use PHPUnit_Framework_TestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the Portugal holiday provider.
+ */
+abstract class PortugalBaseTestCase extends PHPUnit_Framework_TestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    const REGION = 'Portugal';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    const TIMEZONE = 'Europe/Lisbon';
+
+    /**
+     * Locale that is considered common for this provider
+     */
+    const LOCALE = 'pt_PT';
+}

--- a/tests/Portugal/PortugalDayTest.php
+++ b/tests/Portugal/PortugalDayTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Provider\Portugal;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class for testing Portugal Day in Portugal.
+ */
+class PortugalDayTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The year in which the holiday was abolished
+     */
+    const ESTABLISHMENT_YEAR_BEFORE = 1932;
+
+    /**
+     * The year in which the holiday was restored
+     */
+    const ESTABLISHMENT_YEAR_AFTER = 1974;
+
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = 'portugalDay';
+
+    /**
+     * Tests the holiday defined in this test before it was abolished.
+     * @see Portugal::calculatePortugalDay()
+     */
+    public function testHolidayBeforeAbolishment()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR_BEFORE);
+        $expected = new DateTime("$year-06-10", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Tests the holiday defined in this test after it was restored
+     * @see Portugal::calculatePortugalDay()
+     */
+    public function testHolidayAfterRestoration()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR_AFTER);
+        $expected = new DateTime("$year-06-10", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Tests that the holiday defined in this test does not exist during the period that it was abolished
+     * @see Portugal::calculatePortugalDay()
+     */
+    public function testNotHolidayDuringAbolishment()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR_BEFORE + 1, self::ESTABLISHMENT_YEAR_AFTER - 1);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+
+        $year = 1933;
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+
+        $year = 1973;
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR_BEFORE);
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $year, [self::LOCALE => 'Dia de Portugal']);
+
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR_AFTER);
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $year, [self::LOCALE => 'Dia de Portugal']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $year = $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR_BEFORE);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR_AFTER);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/PortugalTest.php
+++ b/tests/Portugal/PortugalTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in Poland.
+ */
+class PortugalTest extends PortugalBaseTestCase
+{
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all national holidays in Portugal are defined by the provider class
+     */
+    public function testNationalHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'internationalWorkersDay',
+            'corpusChristi',
+            'easter',
+            'goodFriday',
+            'assumptionOfMary',
+            'allSaintsDay',
+            'immaculateConception',
+            'christmasDay',
+            '25thApril',
+            'portugueseRepublic',
+            'restorationOfIndependence',
+            'portugalDay'
+        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+    }
+
+    /**
+     * Tests if all observed holidays in Portugal are defined by the provider class
+     */
+    public function testObservedHolidays()
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+    }
+
+    /**
+     * Tests if all seasonal holidays in Portugal are defined by the provider class
+     */
+    public function testSeasonalHolidays()
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_SEASON);
+    }
+
+    /**
+     * Tests if all bank holidays in Portugal are defined by the provider class
+     */
+    public function testBankHolidays()
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_BANK);
+    }
+
+    /**
+     * Tests if all other holidays in PortugalPortugal are defined by the provider class
+     */
+    public function testOtherHolidays()
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1900);
+    }
+}

--- a/tests/Portugal/PortugueseRepublicDayTest.php
+++ b/tests/Portugal/PortugueseRepublicDayTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class for testing Restoration of Independence Day in Portugal.
+ */
+class PortugueseRepublicDayTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1910;
+
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = 'portugueseRepublic';
+
+    /**
+     * Tests the holiday defined in this test on or after establishment.
+     */
+    public function testHolidayOnAfterEstablishment()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+
+        $expected = new DateTime("$year-10-05", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+
+        $year = self::ESTABLISHMENT_YEAR;
+        $expected = new DateTime("$year-10-05", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $year = $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+
+        $year = self::ESTABLISHMENT_YEAR - 1;
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR), [self::LOCALE => 'Implantação da República Portuguesa']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR), Holiday::TYPE_NATIONAL);
+    }
+}

--- a/tests/Portugal/RestorationOfIndependenceTest.php
+++ b/tests/Portugal/RestorationOfIndependenceTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ *  This file is part of the Yasumi package.
+ *
+ *  Copyright (c) 2015 - 2016 AzuyaLabs
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Portugal;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Holiday;
+
+/**
+ * Class for testing Restoration of Independence Day in Portugal.
+ */
+class RestorationOfIndependenceTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1850;
+
+    /**
+     * Holiday was abolished by the portuguese government in 2014.
+     */
+    const HOLIDAY_YEAR_ABOLISHED = 2014;
+
+    /**
+     * Holiday was restored by the portuguese government in 2016.
+     */
+    const HOLIDAY_YEAR_RESTORED = 2016;
+
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = 'restorationOfIndependence';
+
+    /**
+     * Tests the holiday defined in this test on or after establishment.
+     */
+    public function testHolidayOnAfterEstablishment()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::HOLIDAY_YEAR_ABOLISHED);
+
+        $expected = new DateTime("$year-12-01", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+
+        $year = 1850;
+        $expected = new DateTime("$year-12-01", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Test that the holiday if in effect in 2016 and later dates.
+     */
+    public function testHolidayOnAfterRestoration()
+    {
+        $year = 2016;
+
+        $expected = new DateTime("$year-12-01", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+
+        $year = $this->generateRandomYear(self::HOLIDAY_YEAR_RESTORED);
+
+        $expected = new DateTime("$year-12-01", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Test that the holiday did not happen in 2014 and 2015.
+     */
+    public function testNotHolidayDuringAbolishment()
+    {
+        $year = $this->generateRandomYear(2014, 2015);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $year = $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+
+        $year = 1849;
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY, $year, [self::LOCALE => 'Restauração da Independência']);
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        // After establishment and before abolishment
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::HOLIDAY_YEAR_ABOLISHED - 1);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+
+        // After restoration
+        $this->generateRandomYear(self::HOLIDAY_YEAR_RESTORED);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+    }
+}


### PR DESCRIPTION
Hey Sacha and maintainers,

I have created a provider for holidays in Portugal. The 2016 calendar in Portugal has 13 national holidays and I included only those 13. I plan on including some regional holidays as well in the future as well as past holidays that no longer exist (e.g. the 10th of June holiday had a different name between 1933 and 1973).

A few of the holidays present in 2016 were abolished in 2014 and restored this year (2016) and that factor is taken into account in the provider.

These three holidays are:
- Corpus Christi
- Restoration of Independence (1st of December)
- All Saints Day

I await your feedback.

Thank you and best regards,
Ricardo Velhote