### PR TITLE
Update secondChristmasDay.php

### DIFF
--- a/src/Yasumi/data/translations/secondChristmasDay.php
+++ b/src/Yasumi/data/translations/secondChristmasDay.php
@@ -20,7 +20,7 @@ return [
     'en_AU' => 'Boxing Day',
     'en_GB' => 'Boxing Day',
     'en_NZ' => 'Boxing Day',
-    'en_US' => 'Boxing Day',
+    'en_US' => 'Second Christmas Day',
     'en_ZA' => 'Day of Goodwill',
     'fi_FI' => '2. joulupäivä',
     'nb_NO' => 'Andre juledag',


### PR DESCRIPTION
Boxing Day concept does not exist in the US. This should be instead "Second Christmas Day".