### PR TITLE
Require php calendar extension to prevent breaking sites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     }
   ],
   "require": {
-    "php": ">=5.6.0"
+    "php": ">=5.6.0",
+    "ext-calendar": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.8|~5.7",


### PR DESCRIPTION
I've accidentally taken down a production site because the server did not have the calendar extension installed, and I was not aware that I needed it (or that it existed actually).
Since it's a hard dependency for the library to function, that should be more obvious :-)