### PR TITLE
add yasumi creation by ISO3166-2 code

### DIFF
--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -189,8 +189,8 @@ class Yasumi
      * Create a new holiday provider instance.
      *
      * A new holiday provider instance can be created using this function. You can use one of the providers included
-     * already with Yasumi, or your own provider by giving the name of your class in the first parameter. Your provider
-     * class needs to implement the 'ProviderInterface' class.
+     * already with Yasumi, or your own provider by giving the 'const ID', corresponding to the ISO3166-2 Code, set in
+     * your class in the first parameter. Your provider class needs to implement the 'ProviderInterface' class.
      *
      * @param string $iso3166_2  ISO3166-2 Coded region, holiday provider will be searched for
      * @param int    $year   year for which the country provider needs to be created. Year needs to be a valid integer
@@ -200,7 +200,7 @@ class Yasumi
      * @throws RuntimeException         If no such holiday provider is found
      * @throws InvalidArgumentException if the year parameter is not between 1000 and 9999
      * @throws UnknownLocaleException   if the locale parameter is invalid
-     * @throws InvalidArgumentException if the holiday provider for the given country does not exist
+     * @throws InvalidArgumentException if the holiday provider for the given ISO3166-2 code does not exist
      *
      * @return AbstractProvider An instance of class $class is created and returned
      */

--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -186,6 +186,43 @@ class Yasumi
     }
 
     /**
+     * Create a new holiday provider instance.
+     *
+     * A new holiday provider instance can be created using this function. You can use one of the providers included
+     * already with Yasumi, or your own provider by giving the name of your class in the first parameter. Your provider
+     * class needs to implement the 'ProviderInterface' class.
+     *
+     * @param string $iso3166_2  ISO3166-2 Coded region, holiday provider will be searched for
+     * @param int    $year   year for which the country provider needs to be created. Year needs to be a valid integer
+     *                       between 1000 and 9999.
+     * @param string $locale The locale to use. If empty we'll use the default locale (en_US)
+     *
+     * @throws RuntimeException         If no such holiday provider is found
+     * @throws InvalidArgumentException if the year parameter is not between 1000 and 9999
+     * @throws UnknownLocaleException   if the locale parameter is invalid
+     * @throws InvalidArgumentException if the holiday provider for the given country does not exist
+     *
+     * @return AbstractProvider An instance of class $class is created and returned
+     */
+    public static function createByISO3166_2($iso3166_2, $year = null, $locale = self::DEFAULT_LOCALE){
+        $providers = self::getProviders();
+
+        $class = isset($providers[$iso3166_2])
+            ? $providers[$iso3166_2]
+            : false;
+
+        if($class === false){
+            throw new InvalidArgumentException(sprintf('Unable to find holiday provider by ISO3166-2 "%s".', $iso3166_2));
+        }
+
+        return self::create(
+            $class,
+            $year,
+            $locale
+        );
+    }
+    
+    /**
      * Returns a list of available locales.
      *
      * @return array list of available locales

--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -206,7 +206,6 @@ class Yasumi
      */
     public static function createByISO3166_2($iso3166_2, $year = null, $locale = self::DEFAULT_LOCALE)
     {
-
         $availableProviders = self::getProviders();
 
         if (false === isset($availableProviders[$iso3166_2])) {

--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -204,14 +204,15 @@ class Yasumi
      *
      * @return AbstractProvider An instance of class $class is created and returned
      */
-    public static function createByISO3166_2($iso3166_2, $year = null, $locale = self::DEFAULT_LOCALE){
+    public static function createByISO3166_2($iso3166_2, $year = null, $locale = self::DEFAULT_LOCALE)
+    {
         $providers = self::getProviders();
 
         $class = isset($providers[$iso3166_2])
             ? $providers[$iso3166_2]
             : false;
 
-        if($class === false){
+        if ($class === false) {
             throw new InvalidArgumentException(sprintf('Unable to find holiday provider by ISO3166-2 "%s".', $iso3166_2));
         }
 
@@ -221,7 +222,7 @@ class Yasumi
             $locale
         );
     }
-    
+
     /**
      * Returns a list of available locales.
      *

--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -206,18 +206,15 @@ class Yasumi
      */
     public static function createByISO3166_2($iso3166_2, $year = null, $locale = self::DEFAULT_LOCALE)
     {
-        $providers = self::getProviders();
 
-        $class = isset($providers[$iso3166_2])
-            ? $providers[$iso3166_2]
-            : false;
+        $availableProviders = self::getProviders();
 
-        if ($class === false) {
+        if (false === isset($availableProviders[$iso3166_2])) {
             throw new InvalidArgumentException(sprintf('Unable to find holiday provider by ISO3166-2 "%s".', $iso3166_2));
         }
 
         return self::create(
-            $class,
+            $availableProviders[$iso3166_2],
             $year,
             $locale
         );


### PR DESCRIPTION
See [issue](https://github.com/azuyalabs/yasumi/issues/61)

I needed the option to create a yasumi instance by ISO3166-2 Code. As far as I can see, the `const ID` in the providers corresponces to this code. Therefore I created this simple wrapper.

I wasn't able to create test etc. for this wrapper. I think this should be added before mergen