### PR TITLE
Renaming 'National' type to 'Official'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Added Holiday Provider for Switzerland. [\#56](https://github.com/azuyalabs/yasumi/pull/56) ([qligier](https://github.com/qligier))
 
 ### Changed
+- Renamed the holiday type NATIONAL to OFFICIAL. Subregions may have official holidays and the name NATIONAL doesn't suit these situations.
 - Upgraded PHP-CS-Fixer to version 2.4
 
 ### Fixed

--- a/src/Yasumi/Filters/OfficialHolidaysFilter.php
+++ b/src/Yasumi/Filters/OfficialHolidaysFilter.php
@@ -18,7 +18,7 @@ use Yasumi\Holiday;
 /**
  * OfficialHolidaysFilter is a class for filtering all official holidays.
  *
- * OfficialHolidaysFilter is a class that returns all holidays that are considered official (i.e. national) of any given
+ * OfficialHolidaysFilter is a class that returns all holidays that are considered official of any given
  * holiday provider.
  *
  * Example usage:
@@ -28,12 +28,12 @@ use Yasumi\Holiday;
 class OfficialHolidaysFilter extends FilterIterator
 {
     /**
-     * Checks whether the current element of the iterator is a national/official holiday.
+     * Checks whether the current element of the iterator is an official holiday.
      *
      * @return bool
      */
     public function accept()
     {
-        return $this->getInnerIterator()->current()->getType() === Holiday::TYPE_NATIONAL;
+        return $this->getInnerIterator()->current()->getType() === Holiday::TYPE_OFFICIAL;
     }
 }

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -23,9 +23,9 @@ use Yasumi\Exception\UnknownLocaleException;
 class Holiday extends DateTime implements JsonSerializable
 {
     /**
-     * Type definition for National/Federal holidays.
+     * Type definition for Official (i.e. National/Federal) holidays.
      */
-    const TYPE_NATIONAL = 'national';
+    const TYPE_OFFICIAL = 'official';
 
     /**
      * Type definition for Observance holidays.
@@ -89,9 +89,9 @@ class Holiday extends DateTime implements JsonSerializable
      * @param DateTime $date          A DateTime instance representing the date of the holiday
      * @param string   $displayLocale Locale (i.e. language) in which the holiday information needs to be
      *                                displayed in. (Default 'en_US')
-     * @param string   $type          The type of holiday. Use the following constants: TYPE_NATIONAL,
-     *                                TYPE_OBSERVANCE, TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a
-     *                                national holiday is considered.
+     * @param string   $type          The type of holiday. Use the following constants: TYPE_OFFICIAL,
+     *                                TYPE_OBSERVANCE, TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an
+     *                                official holiday is considered.
      *
      * @throws UnknownLocaleException
      * @throws \InvalidArgumentException
@@ -101,7 +101,7 @@ class Holiday extends DateTime implements JsonSerializable
         array $names,
         $date,
         $displayLocale = self::DEFAULT_LOCALE,
-        $type = self::TYPE_NATIONAL
+        $type = self::TYPE_OFFICIAL
     ) {
         // Validate if short name is not empty
         if (empty($shortName)) {
@@ -136,7 +136,7 @@ class Holiday extends DateTime implements JsonSerializable
     /**
      * Returns what type this holiday is.
      *
-     * @return string the type of holiday (national, observance, season or bank).
+     * @return string the type of holiday (official, observance, season, bank or other).
      */
     public function getType()
     {

--- a/src/Yasumi/Provider/Australia.php
+++ b/src/Yasumi/Provider/Australia.php
@@ -40,7 +40,7 @@ class Australia extends AbstractProvider
      */
     public function initialize()
     {
-        // National Holidays
+        // Official Holidays
         $this->calculateAustraliaDay();
         $this->calculateNewYearHolidays();
         $this->calculateAnzacDay();

--- a/src/Yasumi/Provider/Austria.php
+++ b/src/Yasumi/Provider/Austria.php
@@ -51,7 +51,7 @@ class Austria extends AbstractProvider
         $this->addHoliday($this->ascensionDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
         $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_NATIONAL));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->immaculateConception($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));

--- a/src/Yasumi/Provider/ChristianHolidays.php
+++ b/src/Yasumi/Provider/ChristianHolidays.php
@@ -37,15 +37,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Easter need to be created
      * @param string $timezone the timezone in which Easter is celebrated
      * @param string $locale   the locale for which Easter need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function easter($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function easter($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday('easter', [], $easter = $this->calculateEaster($year, $timezone), $locale, $type);
     }
@@ -62,15 +62,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Easter Monday need to be created
      * @param string $timezone the timezone in which Easter Monday is celebrated
      * @param string $locale   the locale for which Easter Monday need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function easterMonday($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function easterMonday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'easterMonday',
@@ -93,15 +93,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Ascension need to be created
      * @param string $timezone the timezone in which Ascension is celebrated
      * @param string $locale   the locale for which Ascension need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function ascensionDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function ascensionDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'ascensionDay',
@@ -121,15 +121,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Pentecost need to be created
      * @param string $timezone the timezone in which Pentecost is celebrated
      * @param string $locale   the locale for which Pentecost need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function pentecost($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function pentecost($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'pentecost',
@@ -149,15 +149,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Pentecost (Whitmonday) need to be created
      * @param string $timezone the timezone in which Pentecost (Whitmonday) is celebrated
      * @param string $locale   the locale for which Pentecost (Whitmonday) need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function pentecostMonday($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function pentecostMonday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'pentecostMonday',
@@ -180,7 +180,7 @@ trait ChristianHolidays
      * @param int    $year     the year for which Corpus Christi need to be created
      * @param string $timezone the timezone in which Corpus Christi is celebrated
      * @param string $locale   the locale for which Corpus Christi need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a type of 'other' is considered.
      *
      * @return \Yasumi\Holiday
@@ -212,7 +212,7 @@ trait ChristianHolidays
      * @param int    $year     the year for which Christmas Eve needs to be created
      * @param string $timezone the timezone in which Christmas Eve is celebrated
      * @param string $locale   the locale for which Christmas Eve need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default observance is considered.
      *
      * @return \Yasumi\Holiday
@@ -241,15 +241,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Christmas Day need to be created
      * @param string $timezone the timezone in which Christmas Day is celebrated
      * @param string $locale   the locale for which Christmas Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function christmasDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function christmasDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'christmasDay',
@@ -270,15 +270,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which the Second Christmas Day / Boxing Day need to be created
      * @param string $timezone the timezone in which the Second Christmas Day / Boxing Day is celebrated
      * @param string $locale   the locale for which the Second Christmas Day / Boxing Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function secondChristmasDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function secondChristmasDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'secondChristmasDay',
@@ -302,15 +302,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which All Saints' Day need to be created
      * @param string $timezone the timezone in which All Saints' Day is celebrated
      * @param string $locale   the locale for which All Saints' Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function allSaintsDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function allSaintsDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday('allSaintsDay', [], new DateTime("$year-11-1", new DateTimeZone($timezone)), $locale, $type);
     }
@@ -327,15 +327,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which the day of the Assumption of Mary need to be created
      * @param string $timezone the timezone in which the day of the Assumption of Mary is celebrated
      * @param string $locale   the locale for which the day of the Assumption of Mary need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function assumptionOfMary($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function assumptionOfMary($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'assumptionOfMary',
@@ -356,15 +356,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Good Friday need to be created
      * @param string $timezone the timezone in which Good Friday is celebrated
      * @param string $locale   the locale for which Good Friday need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function goodFriday($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function goodFriday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'goodFriday',
@@ -389,15 +389,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Epiphany need to be created
      * @param string $timezone the timezone in which Epiphany is celebrated
      * @param string $locale   the locale for which Epiphany need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function epiphany($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function epiphany($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday('epiphany', [], new DateTime("$year-1-6", new DateTimeZone($timezone)), $locale, $type);
     }
@@ -414,15 +414,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Ash Wednesday need to be created
      * @param string $timezone the timezone in which Ash Wednesday is celebrated
      * @param string $locale   the locale for which Ash Wednesday need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function ashWednesday($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function ashWednesday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'ashWednesday',
@@ -446,15 +446,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Immaculate Conception need to be created
      * @param string $timezone the timezone in which Immaculate Conception is celebrated
      * @param string $locale   the locale for which Immaculate Conception need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function immaculateConception($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function immaculateConception($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'immaculateConception',
@@ -479,15 +479,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which St. Stephen's Day need to be created
      * @param string $timezone the timezone in which St. Stephen's Day is celebrated
      * @param string $locale   the locale for which St. Stephen's Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function stStephensDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function stStephensDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'stStephensDay',
@@ -512,15 +512,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which St. Joseph's Day need to be created
      * @param string $timezone the timezone in which St. Joseph's Day is celebrated
      * @param string $locale   the locale for which St. Joseph's Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function stJosephsDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function stJosephsDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday('stJosephsDay', [], new DateTime("$year-3-19", new DateTimeZone($timezone)), $locale, $type);
     }
@@ -538,15 +538,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which Maundy Thursday need to be created
      * @param string $timezone the timezone in which Maundy Thursday is celebrated
      * @param string $locale   the locale for which Maundy Thursday need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function maundyThursday($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function maundyThursday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'maundyThursday',
@@ -570,15 +570,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which St. George's Day need to be created
      * @param string $timezone the timezone in which St. George's Day is celebrated
      * @param string $locale   the locale for which St. George's Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function stGeorgesDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function stGeorgesDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday('stGeorgesDay', [], new DateTime("$year-4-23", new DateTimeZone($timezone)), $locale, $type);
     }
@@ -597,15 +597,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which St. John's Day need to be created
      * @param string $timezone the timezone in which St. John's Day is celebrated
      * @param string $locale   the locale for which St. John's Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function stJohnsDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function stJohnsDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday('stJohnsDay', [], new DateTime("$year-06-24", new DateTimeZone($timezone)), $locale, $type);
     }
@@ -624,15 +624,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which the Annunciation needs to be created
      * @param string $timezone the timezone in which the Annunciation is celebrated
      * @param string $locale   the locale for which the Annunciation need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function annunciation($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function annunciation($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'annunciation',
@@ -685,15 +685,15 @@ trait ChristianHolidays
      * @param int    $year     the year for which St. John's Day need to be created
      * @param string $timezone the timezone in which St. John's Day is celebrated
      * @param string $locale   the locale for which St. John's Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function reformationDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function reformationDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'reformationDay',

--- a/src/Yasumi/Provider/CommonHolidays.php
+++ b/src/Yasumi/Provider/CommonHolidays.php
@@ -38,15 +38,15 @@ trait CommonHolidays
      * @param int    $year     the year for which New Year's Day need to be created
      * @param string $timezone the timezone in which New Year's Day is celebrated
      * @param string $locale   the locale for which New Year's Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function newYearsDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function newYearsDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday('newYearsDay', [], new DateTime("$year-1-1", new DateTimeZone($timezone)), $locale, $type);
     }
@@ -65,15 +65,15 @@ trait CommonHolidays
      * @param int    $year     the year for which International Workers' Day need to be created
      * @param string $timezone the timezone in which International Workers' Day is celebrated
      * @param string $locale   the locale for which International Workers' Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function internationalWorkersDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function internationalWorkersDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'internationalWorkersDay',
@@ -98,15 +98,15 @@ trait CommonHolidays
      * @param int    $year     the year for which Valentine's Day need to be created
      * @param string $timezone the timezone in which Valentine's Day is celebrated
      * @param string $locale   the locale for which Valentine's Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function valentinesDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function valentinesDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'valentinesDay',
@@ -129,15 +129,15 @@ trait CommonHolidays
      * @param int    $year     the year for which World Animal Day need to be created
      * @param string $timezone the timezone in which World Animal Day is celebrated
      * @param string $locale   the locale for which World Animal Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function worldAnimalDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function worldAnimalDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'worldAnimalDay',
@@ -162,15 +162,15 @@ trait CommonHolidays
      * @param int    $year     the year for which St. Martin's Day need to be created
      * @param string $timezone the timezone in which St. Martin's Day is celebrated
      * @param string $locale   the locale for which St. Martin's Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function stMartinsDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function stMartinsDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'stMartinsDay',
@@ -194,15 +194,15 @@ trait CommonHolidays
      * @param int    $year     the year for which Father's Day need to be created
      * @param string $timezone the timezone in which Father's Day is celebrated
      * @param string $locale   the locale for which Father's Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function fathersDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function fathersDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'fathersDay',
@@ -226,15 +226,15 @@ trait CommonHolidays
      * @param int    $year     the year for which Mother's Day need to be created
      * @param string $timezone the timezone in which Mother's Day is celebrated
      * @param string $locale   the locale for which Mother's Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function mothersDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function mothersDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'mothersDay',
@@ -258,15 +258,15 @@ trait CommonHolidays
      * @param int    $year     the year for which Victory in Europe Day need to be created
      * @param string $timezone the timezone in which Victory in Europe Day is celebrated
      * @param string $locale   the locale for which Victory in Europe Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function victoryInEuropeDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function victoryInEuropeDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'victoryInEuropeDay',
@@ -292,15 +292,15 @@ trait CommonHolidays
      * @param int    $year     the year for which Armistice Day need to be created
      * @param string $timezone the timezone in which Armistice Day is celebrated
      * @param string $locale   the locale for which Armistice Day need to be displayed in.
-     * @param string $type     The type of holiday. Use the following constants: TYPE_NATIONAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a national holiday is considered.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
      * @return \Yasumi\Holiday
      *
      * @throws \Yasumi\Exception\UnknownLocaleException
      * @throws \InvalidArgumentException
      */
-    public function armisticeDay($year, $timezone, $locale, $type = Holiday::TYPE_NATIONAL)
+    public function armisticeDay($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
     {
         return new Holiday(
             'armisticeDay',

--- a/src/Yasumi/Provider/Croatia.php
+++ b/src/Yasumi/Provider/Croatia.php
@@ -49,7 +49,7 @@ class Croatia extends AbstractProvider
         $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_NATIONAL));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));

--- a/src/Yasumi/Provider/NewZealand.php
+++ b/src/Yasumi/Provider/NewZealand.php
@@ -40,7 +40,7 @@ class NewZealand extends AbstractProvider
     {
         $this->timezone = 'Pacific/Auckland';
 
-        // National Holidays
+        // Official Holidays
         $this->calculateNewYearHolidays();
         $this->calculateWaitangiDay();
         $this->calculateAnzacDay();

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -85,7 +85,7 @@ class Portugal extends AbstractProvider
                 ['pt_PT' => 'Dia da Liberdade'],
                 new DateTime("$this->year-04-25", new DateTimeZone($this->timezone)),
                 $this->locale,
-                Holiday::TYPE_NATIONAL
+                Holiday::TYPE_OFFICIAL
             ));
         }
     }
@@ -208,7 +208,7 @@ class Portugal extends AbstractProvider
                 ['pt_PT' => 'Restauração da Independência'],
                 new DateTime("$this->year-12-01", new DateTimeZone($this->timezone)),
                 $this->locale,
-                Holiday::TYPE_NATIONAL
+                Holiday::TYPE_OFFICIAL
             ));
         }
     }

--- a/src/Yasumi/Provider/Slovakia.php
+++ b/src/Yasumi/Provider/Slovakia.php
@@ -66,7 +66,7 @@ class Slovakia extends AbstractProvider
         $this->timezone = 'Europe/Bratislava';
 
         // 1.1.
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_NATIONAL));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         // 6.1.
         $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale, Holiday::TYPE_BANK));
         // 1.5.
@@ -123,7 +123,7 @@ class Slovakia extends AbstractProvider
         ],
             new DateTime($this->year . '-07-05', new DateTimeZone($this->timezone)),
             $this->locale,
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         ));
     }
 
@@ -145,7 +145,7 @@ class Slovakia extends AbstractProvider
         ],
             new DateTime($this->year . '-08-29', new DateTimeZone($this->timezone)),
             $this->locale,
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         ));
     }
 
@@ -167,7 +167,7 @@ class Slovakia extends AbstractProvider
         ],
             new DateTime($this->year . '-09-01', new DateTimeZone($this->timezone)),
             $this->locale,
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         ));
     }
 
@@ -210,7 +210,7 @@ class Slovakia extends AbstractProvider
         ],
             new DateTime($this->year . '-11-17', new DateTimeZone($this->timezone)),
             $this->locale,
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         ));
     }
 }

--- a/src/Yasumi/Provider/Sweden.php
+++ b/src/Yasumi/Provider/Sweden.php
@@ -53,7 +53,7 @@ class Sweden extends AbstractProvider
         $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
         $this->calculatestJohnsDay(); // aka Midsummer's Day
         $this->calculateAllSaintsDay();
-        $this->addHoliday($this->christmasEve($this->year, $this->timezone, $this->locale, Holiday::TYPE_NATIONAL));
+        $this->addHoliday($this->christmasEve($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
 

--- a/src/Yasumi/Provider/Switzerland.php
+++ b/src/Yasumi/Provider/Switzerland.php
@@ -73,7 +73,7 @@ class Switzerland extends AbstractProvider
                 $translations,
                 new DateTime($this->year . '-08-01', new DateTimeZone($this->timezone)),
                 $this->locale,
-                Holiday::TYPE_NATIONAL
+                Holiday::TYPE_OFFICIAL
             ));
         } elseif ($this->year >= 1899 || $this->year === 1891) {
             $this->addHoliday(new Holiday(

--- a/tests/Australia/AnzacDayTest.php
+++ b/tests/Australia/AnzacDayTest.php
@@ -105,7 +105,7 @@ class AnzacDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInterf
             $this->region,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Australia/AustraliaDayTest.php
+++ b/tests/Australia/AustraliaDayTest.php
@@ -64,7 +64,7 @@ class AustraliaDayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(2000), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(2000), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/AustraliaTest.php
+++ b/tests/Australia/AustraliaTest.php
@@ -25,9 +25,9 @@ class AustraliaTest extends AustraliaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Australia are defined by the provider class
+     * Tests if all official holidays in Australia are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -37,7 +37,7 @@ class AustraliaTest extends AustraliaBaseTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-        ], $this->region, $this->year, Holiday::TYPE_NATIONAL);
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/BoxingDayTest.php
+++ b/tests/Australia/BoxingDayTest.php
@@ -87,6 +87,6 @@ class BoxingDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/ChristmasDayTest.php
+++ b/tests/Australia/ChristmasDayTest.php
@@ -87,6 +87,6 @@ class ChristmasDayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/EasterMondayTest.php
+++ b/tests/Australia/EasterMondayTest.php
@@ -84,6 +84,6 @@ class EasterMondayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/GoodFridayTest.php
+++ b/tests/Australia/GoodFridayTest.php
@@ -83,6 +83,6 @@ class GoodFridayTest extends AustraliaBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/LabourDayTest.php
+++ b/tests/Australia/LabourDayTest.php
@@ -77,6 +77,6 @@ abstract class LabourDayTest extends AustraliaBaseTestCase implements YasumiTest
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/NewYearsDayTest.php
+++ b/tests/Australia/NewYearsDayTest.php
@@ -88,6 +88,6 @@ class NewYearsDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/QueensBirthdayTest.php
+++ b/tests/Australia/QueensBirthdayTest.php
@@ -99,7 +99,7 @@ abstract class QueensBirthdayTest extends AustraliaBaseTestCase implements Yasum
             $this->region,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Australia/Victoria/AFLGrandFinalFridayTest.php
+++ b/tests/Australia/Victoria/AFLGrandFinalFridayTest.php
@@ -71,7 +71,7 @@ class AFLGrandFinalFridayTest extends VictoriaBaseTestCase implements YasumiTest
             $this->region,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::LAST_KNOWN_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 

--- a/tests/Australia/Victoria/VictoriaTest.php
+++ b/tests/Australia/Victoria/VictoriaTest.php
@@ -28,9 +28,9 @@ class VictoriaTest extends AustraliaTest
     protected $year;
 
     /**
-     * Tests if all national holidays in Australia are defined by the provider class
+     * Tests if all official holidays in Victoria (Australia) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -43,7 +43,7 @@ class VictoriaTest extends AustraliaTest
             'queensBirthday',
             'labourDay',
             'aflGrandFinalFriday'
-        ], $this->region, $this->year, Holiday::TYPE_NATIONAL);
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Austria/AllSaintsDayTest.php
+++ b/tests/Austria/AllSaintsDayTest.php
@@ -67,6 +67,6 @@ class AllSaintsDayTest extends AustriaBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/AscensionDayTest.php
+++ b/tests/Austria/AscensionDayTest.php
@@ -59,6 +59,6 @@ class AscensionDayTest extends AustriaBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/AssumptionOfMaryTest.php
+++ b/tests/Austria/AssumptionOfMaryTest.php
@@ -67,6 +67,6 @@ class AssumptionOfMaryTest extends AustriaBaseTestCase implements YasumiTestCase
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/AustriaTest.php
+++ b/tests/Austria/AustriaTest.php
@@ -25,9 +25,9 @@ class AustriaTest extends AustriaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Austria are defined by the provider class
+     * Tests if all official holidays in Austria are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'ascensionDay',
@@ -43,7 +43,7 @@ class AustriaTest extends AustriaBaseTestCase
             'christmasDay',
             'secondChristmasDay',
             'nationalDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Austria/ChristmasTest.php
+++ b/tests/Austria/ChristmasTest.php
@@ -67,6 +67,6 @@ class ChristmasTest extends AustriaBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/CorpusChristiTest.php
+++ b/tests/Austria/CorpusChristiTest.php
@@ -61,6 +61,6 @@ class CorpusChristiTest extends AustriaBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/EasterMondayTest.php
+++ b/tests/Austria/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends AustriaBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/EasterTest.php
+++ b/tests/Austria/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends AustriaBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/EpiphanyTest.php
+++ b/tests/Austria/EpiphanyTest.php
@@ -67,6 +67,6 @@ class EpiphanyTest extends AustriaBaseTestCase implements YasumiTestCaseInterfac
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/ImmaculateConceptionTest.php
+++ b/tests/Austria/ImmaculateConceptionTest.php
@@ -67,6 +67,6 @@ class ImmaculateConceptionTest extends AustriaBaseTestCase implements YasumiTest
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/InternationalWorkersDayTest.php
+++ b/tests/Austria/InternationalWorkersDayTest.php
@@ -67,6 +67,6 @@ class InternationalWorkersDayTest extends AustriaBaseTestCase implements YasumiT
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/NationalDayTest.php
+++ b/tests/Austria/NationalDayTest.php
@@ -80,7 +80,7 @@ class NationalDayTest extends AustriaBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Austria/NewYearsDayTest.php
+++ b/tests/Austria/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends AustriaBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/PentecostMondayTest.php
+++ b/tests/Austria/PentecostMondayTest.php
@@ -59,6 +59,6 @@ class PentecostMondayTest extends AustriaBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Austria/SecondChristmasDayTest.php
+++ b/tests/Austria/SecondChristmasDayTest.php
@@ -67,6 +67,6 @@ class SecondChristmasDayTest extends AustriaBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/AllSaintsDayTest.php
+++ b/tests/Belgium/AllSaintsDayTest.php
@@ -67,6 +67,6 @@ class AllSaintsDayTest extends BelgiumBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/ArmisticeDayTest.php
+++ b/tests/Belgium/ArmisticeDayTest.php
@@ -67,6 +67,6 @@ class ArmisticeDayTest extends BelgiumBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/AscensionDayTest.php
+++ b/tests/Belgium/AscensionDayTest.php
@@ -59,6 +59,6 @@ class AscensionDayTest extends BelgiumBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/AssumptionOfMaryTest.php
+++ b/tests/Belgium/AssumptionOfMaryTest.php
@@ -67,6 +67,6 @@ class AssumptionOfMaryTest extends BelgiumBaseTestCase implements YasumiTestCase
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/BelgiumTest.php
+++ b/tests/Belgium/BelgiumTest.php
@@ -25,9 +25,9 @@ class BelgiumTest extends BelgiumBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Belgium are defined by the provider class
+     * Tests if all official holidays in Belgium are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class BelgiumTest extends BelgiumBaseTestCase
             'allSaintsDay',
             'armisticeDay',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Belgium/ChristmasTest.php
+++ b/tests/Belgium/ChristmasTest.php
@@ -67,6 +67,6 @@ class ChristmasTest extends BelgiumBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/EasterMondayTest.php
+++ b/tests/Belgium/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends BelgiumBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/EasterTest.php
+++ b/tests/Belgium/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends BelgiumBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/InternationalWorkersDayTest.php
+++ b/tests/Belgium/InternationalWorkersDayTest.php
@@ -67,6 +67,6 @@ class InternationalWorkersDayTest extends BelgiumBaseTestCase implements YasumiT
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/NationalDayTest.php
+++ b/tests/Belgium/NationalDayTest.php
@@ -67,6 +67,6 @@ class NationalDayTest extends BelgiumBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/NewYearsDayTest.php
+++ b/tests/Belgium/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends BelgiumBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/PentecostTest.php
+++ b/tests/Belgium/PentecostTest.php
@@ -59,6 +59,6 @@ class PentecostTest extends BelgiumBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Belgium/pentecostMondayTest.php
+++ b/tests/Belgium/pentecostMondayTest.php
@@ -59,6 +59,6 @@ class pentecostMondayTest extends BelgiumBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Brazil/AllSoulsDayTest.php
+++ b/tests/Brazil/AllSoulsDayTest.php
@@ -70,6 +70,6 @@ class AllSoulsDayTest extends BrazilBaseTestCase implements YasumiTestCaseInterf
     public function testHolidayType()
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Brazil/BrazilTest.php
+++ b/tests/Brazil/BrazilTest.php
@@ -25,9 +25,9 @@ class BrazilTest extends BrazilBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Brazil are defined by the provider class
+     * Tests if all official holidays in Brazil are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -39,7 +39,7 @@ class BrazilTest extends BrazilBaseTestCase
             'allSoulsDay',
             'proclamationOfRepublicDay',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Brazil/ChristmasDayTest.php
+++ b/tests/Brazil/ChristmasDayTest.php
@@ -59,6 +59,6 @@ class ChristmasDayTest extends BrazilBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Brazil/GoodFridayTest.php
+++ b/tests/Brazil/GoodFridayTest.php
@@ -61,6 +61,6 @@ class GoodFridayTest extends BrazilBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Brazil/IndependenceDayTest.php
+++ b/tests/Brazil/IndependenceDayTest.php
@@ -75,6 +75,6 @@ class IndependenceDayTest extends BrazilBaseTestCase implements YasumiTestCaseIn
     public function testHolidayType()
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Brazil/InternationalWorkersDayTest.php
+++ b/tests/Brazil/InternationalWorkersDayTest.php
@@ -59,6 +59,6 @@ class InternationalWorkersDayTest extends BrazilBaseTestCase implements YasumiTe
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Brazil/NewYearsDayTest.php
+++ b/tests/Brazil/NewYearsDayTest.php
@@ -59,6 +59,6 @@ class NewYearsDayTest extends BrazilBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Brazil/OurLadyOfAparecidaDayTest.php
+++ b/tests/Brazil/OurLadyOfAparecidaDayTest.php
@@ -75,6 +75,6 @@ class OurLadyOfAparecidaDayTest extends BrazilBaseTestCase implements YasumiTest
     public function testHolidayType()
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Brazil/ProclamationOfRepublicDayTest.php
+++ b/tests/Brazil/ProclamationOfRepublicDayTest.php
@@ -75,6 +75,6 @@ class ProclamationOfRepublicDayTest extends BrazilBaseTestCase implements Yasumi
     public function testHolidayType()
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Brazil/TiradentesDayTest.php
+++ b/tests/Brazil/TiradentesDayTest.php
@@ -70,6 +70,6 @@ class TiradentesDayTest extends BrazilBaseTestCase implements YasumiTestCaseInte
     public function testHolidayType()
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Croatia/AllSaintsDayTest.php
+++ b/tests/Croatia/AllSaintsDayTest.php
@@ -67,6 +67,6 @@ class AllSaintsDayTest extends CroatiaBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Croatia/AntifascistStruggleDayTest.php
+++ b/tests/Croatia/AntifascistStruggleDayTest.php
@@ -80,7 +80,7 @@ class AntifascistStruggleDayTest extends CroatiaBaseTestCase implements YasumiTe
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Croatia/AssumptionOfMaryTest.php
+++ b/tests/Croatia/AssumptionOfMaryTest.php
@@ -67,6 +67,6 @@ class AssumptionOfMaryTest extends CroatiaBaseTestCase implements YasumiTestCase
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Croatia/ChristmasDayTest.php
+++ b/tests/Croatia/ChristmasDayTest.php
@@ -67,6 +67,6 @@ class ChristmasDayTest extends CroatiaBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Croatia/CorpusChristiTest.php
+++ b/tests/Croatia/CorpusChristiTest.php
@@ -61,6 +61,6 @@ class CorpusChristiTest extends CroatiaBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Croatia/EasterMondayTest.php
+++ b/tests/Croatia/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends CroatiaBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Croatia/EasterTest.php
+++ b/tests/Croatia/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends CroatiaBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Croatia/EpiphanyTest.php
+++ b/tests/Croatia/EpiphanyTest.php
@@ -67,6 +67,6 @@ class EpiphanyTest extends CroatiaBaseTestCase implements YasumiTestCaseInterfac
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Croatia/HomelandThanksgivingDayTest.php
+++ b/tests/Croatia/HomelandThanksgivingDayTest.php
@@ -80,7 +80,7 @@ class HomelandThanksgivingDayTest extends CroatiaBaseTestCase implements YasumiT
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Croatia/IndependenceDayTest.php
+++ b/tests/Croatia/IndependenceDayTest.php
@@ -80,7 +80,7 @@ class IndependenceDayTest extends CroatiaBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Croatia/InternationalWorkersDayTest.php
+++ b/tests/Croatia/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends CroatiaBaseTestCase implements YasumiT
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Croatia/NewYearsDayTest.php
+++ b/tests/Croatia/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends CroatiaBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Croatia/StStephensDayTest.php
+++ b/tests/Croatia/StStephensDayTest.php
@@ -67,6 +67,6 @@ class StStephensDayTest extends CroatiaBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Croatia/StatehoodDayTest.php
+++ b/tests/Croatia/StatehoodDayTest.php
@@ -80,7 +80,7 @@ class StatehoodDayTest extends CroatiaBaseTestCase implements YasumiTestCaseInte
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/CzechRepublic/ChristmasDayTest.php
+++ b/tests/CzechRepublic/ChristmasDayTest.php
@@ -71,6 +71,6 @@ class ChristmasDayTest extends CzechRepublicBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/CzechRepublicTest.php
+++ b/tests/CzechRepublic/CzechRepublicTest.php
@@ -29,9 +29,9 @@ class CzechRepublicTest extends CzechRepublicBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Finland are defined by the provider class
+     * Tests if all official holidays in Finland are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -46,7 +46,7 @@ class CzechRepublicTest extends CzechRepublicBaseTestCase
             'czechStateHoodDay',
             'independentCzechoslovakStateDay',
             'struggleForFreedomAndDemocracyDay',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/CzechRepublic/CzechStateHoodDayTest.php
+++ b/tests/CzechRepublic/CzechStateHoodDayTest.php
@@ -71,6 +71,6 @@ class CzechStateHoodDayTest extends CzechRepublicBaseTestCase implements YasumiT
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/EasterMondayTest.php
+++ b/tests/CzechRepublic/EasterMondayTest.php
@@ -63,6 +63,6 @@ class EasterMondayTest extends CzechRepublicBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/GoodFridayTest.php
+++ b/tests/CzechRepublic/GoodFridayTest.php
@@ -63,6 +63,6 @@ class GoodFridayTest extends CzechRepublicBaseTestCase implements YasumiTestCase
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/IndependentCzechoslovakStateDayTest.php
+++ b/tests/CzechRepublic/IndependentCzechoslovakStateDayTest.php
@@ -67,6 +67,6 @@ class IndependentCzechoslovakStateDayTest extends CzechRepublicBaseTestCase impl
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/InternationalWorkersDayTest.php
+++ b/tests/CzechRepublic/InternationalWorkersDayTest.php
@@ -61,7 +61,7 @@ class InternationalWorkersDayTest extends CzechRepublicBaseTestCase implements Y
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/CzechRepublic/JanHusDayTest.php
+++ b/tests/CzechRepublic/JanHusDayTest.php
@@ -67,6 +67,6 @@ class JanHusDayTest extends CzechRepublicBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/NewYearsDayTest.php
+++ b/tests/CzechRepublic/NewYearsDayTest.php
@@ -71,6 +71,6 @@ class NewYearsDayTest extends CzechRepublicBaseTestCase implements YasumiTestCas
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/SaintsCyrilAndMethodiusDayTest.php
+++ b/tests/CzechRepublic/SaintsCyrilAndMethodiusDayTest.php
@@ -71,6 +71,6 @@ class SaintsCyrilAndMethodiusDayTest extends CzechRepublicBaseTestCase implement
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/SecondChristmasDayTest.php
+++ b/tests/CzechRepublic/SecondChristmasDayTest.php
@@ -71,6 +71,6 @@ class SecondChristmasDayTest extends CzechRepublicBaseTestCase implements Yasumi
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/StruggleForFreedomAndDemocracyDayTest.php
+++ b/tests/CzechRepublic/StruggleForFreedomAndDemocracyDayTest.php
@@ -67,6 +67,6 @@ class StruggleForFreedomAndDemocracyDayTest extends CzechRepublicBaseTestCase im
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/VictoryInEuropeDayTest.php
+++ b/tests/CzechRepublic/VictoryInEuropeDayTest.php
@@ -71,6 +71,6 @@ class VictoryInEuropeDayTest extends CzechRepublicBaseTestCase implements Yasumi
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Denmark/AscensionDayTest.php
+++ b/tests/Denmark/AscensionDayTest.php
@@ -59,6 +59,6 @@ class AscensionDayTest extends DenmarkBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Denmark/ChristmasDayTest.php
+++ b/tests/Denmark/ChristmasDayTest.php
@@ -67,6 +67,6 @@ class ChristmasDayTest extends DenmarkBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Denmark/DenmarkTest.php
+++ b/tests/Denmark/DenmarkTest.php
@@ -25,9 +25,9 @@ class DenmarkTest extends DenmarkBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Denmark are defined by the provider class
+     * Tests if all official holidays in Denmark are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class DenmarkTest extends DenmarkBaseTestCase
             'pentecostMonday',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Denmark/EasterMondayTest.php
+++ b/tests/Denmark/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends DenmarkBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Denmark/EasterTest.php
+++ b/tests/Denmark/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends DenmarkBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Denmark/GoodFridayTest.php
+++ b/tests/Denmark/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends DenmarkBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Denmark/GreatPrayerDayTest.php
+++ b/tests/Denmark/GreatPrayerDayTest.php
@@ -80,7 +80,7 @@ class GreatPrayerDayTest extends DenmarkBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Denmark/MaundyThursdayTest.php
+++ b/tests/Denmark/MaundyThursdayTest.php
@@ -59,6 +59,6 @@ class MaundyThursdayTest extends DenmarkBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Denmark/NewYearsDayTest.php
+++ b/tests/Denmark/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends DenmarkBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Denmark/PentecostMondayTest.php
+++ b/tests/Denmark/PentecostMondayTest.php
@@ -59,6 +59,6 @@ class PentecostMondayTest extends DenmarkBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Denmark/PentecostTest.php
+++ b/tests/Denmark/PentecostTest.php
@@ -59,6 +59,6 @@ class PentecostTest extends DenmarkBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Denmark/SecondChristmasDayTest.php
+++ b/tests/Denmark/SecondChristmasDayTest.php
@@ -67,6 +67,6 @@ class SecondChristmasDayTest extends DenmarkBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/AllSaintsDayTest.php
+++ b/tests/Finland/AllSaintsDayTest.php
@@ -85,6 +85,6 @@ class AllSaintsDayTest extends FinlandBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/AscensionDayTest.php
+++ b/tests/Finland/AscensionDayTest.php
@@ -59,6 +59,6 @@ class AscensionDayTest extends FinlandBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/ChristmasDayTest.php
+++ b/tests/Finland/ChristmasDayTest.php
@@ -67,6 +67,6 @@ class ChristmasDayTest extends FinlandBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/EasterMondayTest.php
+++ b/tests/Finland/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends FinlandBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/EasterTest.php
+++ b/tests/Finland/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends FinlandBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/EpiphanyTest.php
+++ b/tests/Finland/EpiphanyTest.php
@@ -67,6 +67,6 @@ class EpiphanyTest extends FinlandBaseTestCase implements YasumiTestCaseInterfac
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/FinlandTest.php
+++ b/tests/Finland/FinlandTest.php
@@ -25,9 +25,9 @@ class FinlandTest extends FinlandBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Finland are defined by the provider class
+     * Tests if all official holidays in Finland are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -43,7 +43,7 @@ class FinlandTest extends FinlandBaseTestCase
             'independenceDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Finland/GoodFridayTest.php
+++ b/tests/Finland/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends FinlandBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/IndependenceDayTest.php
+++ b/tests/Finland/IndependenceDayTest.php
@@ -80,7 +80,7 @@ class IndependenceDayTest extends FinlandBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Finland/InternationalWorkersDayTest.php
+++ b/tests/Finland/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends FinlandBaseTestCase implements YasumiT
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Finland/NewYearsDayTest.php
+++ b/tests/Finland/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends FinlandBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/PentecostTest.php
+++ b/tests/Finland/PentecostTest.php
@@ -59,6 +59,6 @@ class PentecostTest extends FinlandBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/SecondChristmasDayTest.php
+++ b/tests/Finland/SecondChristmasDayTest.php
@@ -67,6 +67,6 @@ class SecondChristmasDayTest extends FinlandBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Finland/stJohnsDayTest.php
+++ b/tests/Finland/stJohnsDayTest.php
@@ -92,6 +92,6 @@ class stJohnsDayTest extends FinlandBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/AllSaintsDayTest.php
+++ b/tests/France/AllSaintsDayTest.php
@@ -57,7 +57,7 @@ class AllSaintsDayTest extends FranceBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/France/ArmisticeDayTest.php
+++ b/tests/France/ArmisticeDayTest.php
@@ -80,7 +80,7 @@ class ArmisticeDayTest extends FranceBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/France/AscensionDayTest.php
+++ b/tests/France/AscensionDayTest.php
@@ -59,6 +59,6 @@ class AscensionDayTest extends FranceBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/AssumptionOfMaryTest.php
+++ b/tests/France/AssumptionOfMaryTest.php
@@ -57,7 +57,7 @@ class AssumptionOfMaryTest extends FranceBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/France/BasRhin/BasRhinTest.php
+++ b/tests/France/BasRhin/BasRhinTest.php
@@ -25,9 +25,9 @@ class BasRhinTest extends BasRhinBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Bas-Rhin are defined by the provider class
+     * Tests if all official holidays in Bas-Rhin are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -43,7 +43,7 @@ class BasRhinTest extends BasRhinBaseTestCase
             'christmasDay',
             'stStephensDay',
             'bastilleDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/France/BasRhin/GoodFridayTest.php
+++ b/tests/France/BasRhin/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends BasRhinBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/BasRhin/stStephensDayTest.php
+++ b/tests/France/BasRhin/stStephensDayTest.php
@@ -67,6 +67,6 @@ class stStephensDayTest extends BasRhinBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/BastilleDayTest.php
+++ b/tests/France/BastilleDayTest.php
@@ -80,7 +80,7 @@ class BastilleDayTest extends FranceBaseTestCase implements YasumiTestCaseInterf
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/France/ChristmasDayTest.php
+++ b/tests/France/ChristmasDayTest.php
@@ -67,6 +67,6 @@ class ChristmasDayTest extends FranceBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/EasterMondayTest.php
+++ b/tests/France/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends FranceBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/FranceTest.php
+++ b/tests/France/FranceTest.php
@@ -25,9 +25,9 @@ class FranceTest extends FranceBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in France are defined by the provider class
+     * Tests if all official holidays in France are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class FranceTest extends FranceBaseTestCase
             'armisticeDay',
             'christmasDay',
             'bastilleDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/France/HautRhin/GoodFridayTest.php
+++ b/tests/France/HautRhin/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends HautRhinBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/HautRhin/HautRhinTest.php
+++ b/tests/France/HautRhin/HautRhinTest.php
@@ -25,9 +25,9 @@ class HautRhinTest extends HautRhinBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Haut-Rhin are defined by the provider class
+     * Tests if all official holidays in Haut-Rhin are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -43,7 +43,7 @@ class HautRhinTest extends HautRhinBaseTestCase
             'christmasDay',
             'stStephensDay',
             'bastilleDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/France/HautRhin/stStephensDayTest.php
+++ b/tests/France/HautRhin/stStephensDayTest.php
@@ -67,6 +67,6 @@ class stStephensDayTest extends HautRhinBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/InternationalWorkersDayTest.php
+++ b/tests/France/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends FranceBaseTestCase implements YasumiTe
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/France/Moselle/GoodFridayTest.php
+++ b/tests/France/Moselle/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends MoselleBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/Moselle/MoselleTest.php
+++ b/tests/France/Moselle/MoselleTest.php
@@ -25,9 +25,9 @@ class MoselleTest extends MoselleBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Moselle are defined by the provider class
+     * Tests if all official holidays in Moselle are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -43,7 +43,7 @@ class MoselleTest extends MoselleBaseTestCase
             'christmasDay',
             'stStephensDay',
             'bastilleDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/France/Moselle/stStephensDayTest.php
+++ b/tests/France/Moselle/stStephensDayTest.php
@@ -67,6 +67,6 @@ class stStephensDayTest extends MoselleBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/NewYearsDayTest.php
+++ b/tests/France/NewYearsDayTest.php
@@ -57,7 +57,7 @@ class NewYearsDayTest extends FranceBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/France/PentecostMondayTest.php
+++ b/tests/France/PentecostMondayTest.php
@@ -59,6 +59,6 @@ class PentecostMondayTest extends FranceBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/France/VictoryInEuropeDayTest.php
+++ b/tests/France/VictoryInEuropeDayTest.php
@@ -80,7 +80,7 @@ class VictoryInEuropeDayTest extends FranceBaseTestCase implements YasumiTestCas
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Germany/AscensionDayTest.php
+++ b/tests/Germany/AscensionDayTest.php
@@ -59,6 +59,6 @@ class AscensionDayTest extends GermanyBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/BadenWurttemberg/BadenWurttembergTest.php
+++ b/tests/Germany/BadenWurttemberg/BadenWurttembergTest.php
@@ -25,9 +25,9 @@ class BadenWurttembergTest extends BadenWurttembergBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Baden-Württemberg (Germany) are defined by the provider class
+     * Tests if all official holidays in Baden-Württemberg (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class BadenWurttembergTest extends BadenWurttembergBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/Bavaria/BavariaTest.php
+++ b/tests/Germany/Bavaria/BavariaTest.php
@@ -25,9 +25,9 @@ class BavariaTest extends BavariaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Bavaria (Germany) are defined by the provider class
+     * Tests if all official holidays in Bavaria (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class BavariaTest extends BavariaBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/Berlin/BerlinTest.php
+++ b/tests/Germany/Berlin/BerlinTest.php
@@ -25,9 +25,9 @@ class BerlinTest extends BerlinBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Berlin (Germany) are defined by the provider class
+     * Tests if all official holidays in Berlin (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class BerlinTest extends BerlinBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/Brandenburg/BrandenburgTest.php
+++ b/tests/Germany/Brandenburg/BrandenburgTest.php
@@ -25,9 +25,9 @@ class BrandenburgTest extends BrandenburgBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Brandenburg (Germany) are defined by the provider class
+     * Tests if all official holidays in Brandenburg (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $holidays = [
             'newYearsDay',
@@ -50,7 +50,7 @@ class BrandenburgTest extends BrandenburgBaseTestCase
             $holidays[] = 'reformationDay';
         }
 
-        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/Brandenburg/ReformationDayTest.php
+++ b/tests/Germany/Brandenburg/ReformationDayTest.php
@@ -96,7 +96,7 @@ class ReformationDayTest extends BrandenburgBaseTestCase implements YasumiTestCa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Germany/Bremen/BremenTest.php
+++ b/tests/Germany/Bremen/BremenTest.php
@@ -25,9 +25,9 @@ class BremenTest extends BremenBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Bremen (Germany) are defined by the provider class
+     * Tests if all official holidays in Bremen (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class BremenTest extends BremenBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/ChristmasTest.php
+++ b/tests/Germany/ChristmasTest.php
@@ -67,6 +67,6 @@ class ChristmasTest extends GermanyBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/EasterMondayTest.php
+++ b/tests/Germany/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends GermanyBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/GermanUnityDayTest.php
+++ b/tests/Germany/GermanUnityDayTest.php
@@ -80,7 +80,7 @@ class GermanUnityDayTest extends GermanyBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Germany/GermanyTest.php
+++ b/tests/Germany/GermanyTest.php
@@ -25,9 +25,9 @@ class GermanyTest extends GermanyBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Finland are defined by the provider class
+     * Tests if all official holidays in Finland are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'ascensionDay',
@@ -39,7 +39,7 @@ class GermanyTest extends GermanyBaseTestCase
             'newYearsDay',
             'pentecostMonday',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/GoodFridayTest.php
+++ b/tests/Germany/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends GermanyBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/Hamburg/HamburgTest.php
+++ b/tests/Germany/Hamburg/HamburgTest.php
@@ -25,9 +25,9 @@ class HamburgTest extends HamburgBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Hamburg (Germany) are defined by the provider class
+     * Tests if all official holidays in Hamburg (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class HamburgTest extends HamburgBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/Hesse/HesseTest.php
+++ b/tests/Germany/Hesse/HesseTest.php
@@ -25,9 +25,9 @@ class HesseTest extends HesseBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Hesse (Germany) are defined by the provider class
+     * Tests if all official holidays in Hesse (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class HesseTest extends HesseBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/InternationalWorkersDayTest.php
+++ b/tests/Germany/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends GermanyBaseTestCase implements YasumiT
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/LowerSaxony/LowerSaxonyTest.php
+++ b/tests/Germany/LowerSaxony/LowerSaxonyTest.php
@@ -25,9 +25,9 @@ class LowerSaxonyTest extends LowerSaxonyBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Lower Saxony (Germany) are defined by the provider class
+     * Tests if all official holidays in Lower Saxony (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class LowerSaxonyTest extends LowerSaxonyBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/MecklenburgWesternPomerania/MecklenburgWesternPomeraniaTest.php
+++ b/tests/Germany/MecklenburgWesternPomerania/MecklenburgWesternPomeraniaTest.php
@@ -25,9 +25,9 @@ class MecklenburgWesternPomeraniaTest extends MecklenburgWesternPomeraniaBaseTes
     protected $year;
 
     /**
-     * Tests if all national holidays in Mecklenburg-Western Pomerania (Germany) are defined by the provider class
+     * Tests if all official holidays in Mecklenburg-Western Pomerania (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $holidays = [
             'newYearsDay',
@@ -50,7 +50,7 @@ class MecklenburgWesternPomeraniaTest extends MecklenburgWesternPomeraniaBaseTes
             $holidays[] = 'reformationDay';
         }
 
-        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/MecklenburgWesternPomerania/ReformationDayTest.php
+++ b/tests/Germany/MecklenburgWesternPomerania/ReformationDayTest.php
@@ -83,7 +83,7 @@ class ReformationDayTest extends MecklenburgWesternPomeraniaBaseTestCase impleme
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Germany/NewYearsDayTest.php
+++ b/tests/Germany/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends GermanyBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/NorthRhineWestphalia/NorthRhineWestphaliaTest.php
+++ b/tests/Germany/NorthRhineWestphalia/NorthRhineWestphaliaTest.php
@@ -25,9 +25,9 @@ class NorthRhineWestphaliaTest extends NorthRhineWestphaliaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in North Rhine-Westphalia (Germany) are defined by the provider class
+     * Tests if all official holidays in North Rhine-Westphalia (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class NorthRhineWestphaliaTest extends NorthRhineWestphaliaBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/PentecostMondayTest.php
+++ b/tests/Germany/PentecostMondayTest.php
@@ -59,6 +59,6 @@ class PentecostMondayTest extends GermanyBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/ReformationDay2017Test.php
+++ b/tests/Germany/ReformationDay2017Test.php
@@ -87,7 +87,7 @@ class ReformationDay2017Test extends GermanyBaseTestCase implements YasumiTestCa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Germany/RhinelandPalatinate/RhinelandPalatinateTest.php
+++ b/tests/Germany/RhinelandPalatinate/RhinelandPalatinateTest.php
@@ -25,9 +25,9 @@ class RhinelandPalatinateTest extends RhinelandPalatinateBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Rhineland Palatinate (Germany) are defined by the provider class
+     * Tests if all official holidays in Rhineland Palatinate (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class RhinelandPalatinateTest extends RhinelandPalatinateBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/Saarland/SaarlandTest.php
+++ b/tests/Germany/Saarland/SaarlandTest.php
@@ -25,9 +25,9 @@ class SaarlandTest extends SaarlandBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Saarland (Germany) are defined by the provider class
+     * Tests if all official holidays in Saarland (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class SaarlandTest extends SaarlandBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/Saxony/ReformationDayTest.php
+++ b/tests/Germany/Saxony/ReformationDayTest.php
@@ -96,7 +96,7 @@ class ReformationDayTest extends SaxonyBaseTestCase implements YasumiTestCaseInt
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Germany/Saxony/SaxonyTest.php
+++ b/tests/Germany/Saxony/SaxonyTest.php
@@ -25,9 +25,9 @@ class SaxonyTest extends SaxonyBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Saxony (Germany) are defined by the provider class
+     * Tests if all official holidays in Saxony (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $holidays = [
             'newYearsDay',
@@ -50,7 +50,7 @@ class SaxonyTest extends SaxonyBaseTestCase
             $holidays[] = 'reformationDay';
         }
 
-        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/SaxonyAnhalt/ReformationDayTest.php
+++ b/tests/Germany/SaxonyAnhalt/ReformationDayTest.php
@@ -96,7 +96,7 @@ class ReformationDayTest extends SaxonyAnhaltBaseTestCase implements YasumiTestC
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Germany/SaxonyAnhalt/SaxonyAnhaltTest.php
+++ b/tests/Germany/SaxonyAnhalt/SaxonyAnhaltTest.php
@@ -25,9 +25,9 @@ class SaxonyAnhaltTest extends SaxonyAnhaltBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Saxony-Anhalt (Germany) are defined by the provider class
+     * Tests if all official holidays in Saxony-Anhalt (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $holidays = [
             'newYearsDay',
@@ -50,7 +50,7 @@ class SaxonyAnhaltTest extends SaxonyAnhaltBaseTestCase
             $holidays[] = 'reformationDay';
         }
 
-        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/SchleswigHolstein/SchleswigHolsteinTest.php
+++ b/tests/Germany/SchleswigHolstein/SchleswigHolsteinTest.php
@@ -25,9 +25,9 @@ class SchleswigHolsteinTest extends SchleswigHolsteinBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Schleswig-Holstein (Germany) are defined by the provider class
+     * Tests if all official holidays in Schleswig-Holstein (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class SchleswigHolsteinTest extends SchleswigHolsteinBaseTestCase
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Germany/SecondChristmasDayTest.php
+++ b/tests/Germany/SecondChristmasDayTest.php
@@ -67,6 +67,6 @@ class SecondChristmasDayTest extends GermanyBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/Thuringia/ReformationDayTest.php
+++ b/tests/Germany/Thuringia/ReformationDayTest.php
@@ -96,7 +96,7 @@ class ReformationDayTest extends ThuringiaBaseTestCase implements YasumiTestCase
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Germany/Thuringia/ThuringiaTest.php
+++ b/tests/Germany/Thuringia/ThuringiaTest.php
@@ -25,9 +25,9 @@ class ThuringiaTest extends ThuringiaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Thuringia (Germany) are defined by the provider class
+     * Tests if all official holidays in Thuringia (Germany) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $holidays = [
             'newYearsDay',
@@ -50,7 +50,7 @@ class ThuringiaTest extends ThuringiaBaseTestCase
             $holidays[] = 'reformationDay';
         }
 
-        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Greece/AnnunciationTest.php
+++ b/tests/Greece/AnnunciationTest.php
@@ -67,6 +67,6 @@ class AnnunciationTest extends GreeceBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Greece/AscensionDayTest.php
+++ b/tests/Greece/AscensionDayTest.php
@@ -59,6 +59,6 @@ class AscensionDayTest extends GreeceBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Greece/AssumptionOfMaryTest.php
+++ b/tests/Greece/AssumptionOfMaryTest.php
@@ -67,6 +67,6 @@ class AssumptionOfMaryTest extends GreeceBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Greece/ChristmasDayTest.php
+++ b/tests/Greece/ChristmasDayTest.php
@@ -67,6 +67,6 @@ class ChristmasDayTest extends GreeceBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Greece/CleanMondayTest.php
+++ b/tests/Greece/CleanMondayTest.php
@@ -59,6 +59,6 @@ class CleanMondayTest extends GreeceBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Greece/EasterMondayTest.php
+++ b/tests/Greece/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends GreeceBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Greece/EasterTest.php
+++ b/tests/Greece/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends GreeceBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Greece/EpiphanyTest.php
+++ b/tests/Greece/EpiphanyTest.php
@@ -67,6 +67,6 @@ class EpiphanyTest extends GreeceBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Greece/GreeceTest.php
+++ b/tests/Greece/GreeceTest.php
@@ -25,9 +25,9 @@ class GreeceTest extends GreeceBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Greece are defined by the provider class
+     * Tests if all official holidays in Greece are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -45,7 +45,7 @@ class GreeceTest extends GreeceBaseTestCase
             'cleanMonday',
             'independenceDay',
             'ohiDay',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Greece/IndepencenceDayTest.php
+++ b/tests/Greece/IndepencenceDayTest.php
@@ -80,7 +80,7 @@ class IndepencenceDayTest extends GreeceBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Greece/InternationalWorkersDayTest.php
+++ b/tests/Greece/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends GreeceBaseTestCase implements YasumiTe
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Greece/NewYearsDayTest.php
+++ b/tests/Greece/NewYearsDayTest.php
@@ -57,7 +57,7 @@ class NewYearsDayTest extends GreeceBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Greece/OhiDayTest.php
+++ b/tests/Greece/OhiDayTest.php
@@ -80,7 +80,7 @@ class OhiDayTest extends GreeceBaseTestCase implements YasumiTestCaseInterface
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Greece/PentecostMondayTest.php
+++ b/tests/Greece/PentecostMondayTest.php
@@ -59,6 +59,6 @@ class PentecostMondayTest extends GreeceBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Greece/PentecostTest.php
+++ b/tests/Greece/PentecostTest.php
@@ -59,6 +59,6 @@ class PentecostTest extends GreeceBaseTestCase implements YasumiTestCaseInterfac
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Greece/goodFridayTest.php
+++ b/tests/Greece/goodFridayTest.php
@@ -59,6 +59,6 @@ class goodFridayTest extends GreeceBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Hungary/AllSaintsDayTest.php
+++ b/tests/Hungary/AllSaintsDayTest.php
@@ -67,6 +67,6 @@ class AllSaintsDayTest extends HungaryBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Hungary/ChristmasTest.php
+++ b/tests/Hungary/ChristmasTest.php
@@ -67,6 +67,6 @@ class ChristmasTest extends HungaryBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Hungary/EasterMondayTest.php
+++ b/tests/Hungary/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends HungaryBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Hungary/EasterTest.php
+++ b/tests/Hungary/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends HungaryBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Hungary/HungaryTest.php
+++ b/tests/Hungary/HungaryTest.php
@@ -25,9 +25,9 @@ class HungaryTest extends HungaryBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Hungary are defined by the provider class
+     * Tests if all official holidays in Hungary are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class HungaryTest extends HungaryBaseTestCase
             'memorialDay1848',
             'memorialDay1956',
             'stateFoundation',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Hungary/InternationalWorkersDayTest.php
+++ b/tests/Hungary/InternationalWorkersDayTest.php
@@ -67,6 +67,6 @@ class InternationalWorkersDayTest extends HungaryBaseTestCase implements YasumiT
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Hungary/MemorialDay1848Test.php
+++ b/tests/Hungary/MemorialDay1848Test.php
@@ -80,7 +80,7 @@ class MemorialDay1848Test extends HungaryBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Hungary/MemorialDay1956Test.php
+++ b/tests/Hungary/MemorialDay1956Test.php
@@ -80,7 +80,7 @@ class MemorialDay1956Test extends HungaryBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Hungary/NewYearsDayTest.php
+++ b/tests/Hungary/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends HungaryBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Hungary/PentecostMondayTest.php
+++ b/tests/Hungary/PentecostMondayTest.php
@@ -59,6 +59,6 @@ class PentecostMondayTest extends HungaryBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Hungary/SecondChristmasDayTest.php
+++ b/tests/Hungary/SecondChristmasDayTest.php
@@ -67,6 +67,6 @@ class SecondChristmasDayTest extends HungaryBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Hungary/StateFoundationDayTest.php
+++ b/tests/Hungary/StateFoundationDayTest.php
@@ -80,7 +80,7 @@ class StateFoundationDayTest extends HungaryBaseTestCase implements YasumiTestCa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Ireland/AugustHolidayTest.php
+++ b/tests/Ireland/AugustHolidayTest.php
@@ -89,6 +89,6 @@ class AugustHolidayTest extends IrelandBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ireland/ChristmasDayTest.php
+++ b/tests/Ireland/ChristmasDayTest.php
@@ -88,6 +88,6 @@ class ChristmasDayTest extends IrelandBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ireland/EasterMondayTest.php
+++ b/tests/Ireland/EasterMondayTest.php
@@ -90,6 +90,6 @@ class EasterMondayTest extends IrelandBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ireland/EasterTest.php
+++ b/tests/Ireland/EasterTest.php
@@ -88,6 +88,6 @@ class EasterTest extends IrelandBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ireland/IrelandTest.php
+++ b/tests/Ireland/IrelandTest.php
@@ -25,33 +25,33 @@ class IrelandTest extends IrelandBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Ireland are defined by the provider class
+     * Tests if all official holidays in Ireland are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = ['easter', 'easterMonday', 'augustHoliday', 'christmasDay', 'stStephensDay'];
+        $officialHolidays = ['easter', 'easterMonday', 'augustHoliday', 'christmasDay', 'stStephensDay'];
         if ($this->year >= 1974) {
-            $nationalHolidays[] = 'newYearsDay';
-            $nationalHolidays[] = 'juneHoliday';
+            $officialHolidays[] = 'newYearsDay';
+            $officialHolidays[] = 'juneHoliday';
         }
 
         if ($this->year >= 1903) {
-            $nationalHolidays[] = 'stPatricksDay';
+            $officialHolidays[] = 'stPatricksDay';
         }
 
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'mayDay';
+            $officialHolidays[] = 'mayDay';
         }
 
         if ($this->year <= 1973) {
-            $nationalHolidays[] = 'pentecostMonday';
+            $officialHolidays[] = 'pentecostMonday';
         }
 
         if ($this->year >= 1977) {
-            $nationalHolidays[] = 'octoberHoliday';
+            $officialHolidays[] = 'octoberHoliday';
         }
 
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Ireland/JuneHolidayTest.php
+++ b/tests/Ireland/JuneHolidayTest.php
@@ -110,7 +110,7 @@ class JuneHolidayTest extends IrelandBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Ireland/MayDayTest.php
+++ b/tests/Ireland/MayDayTest.php
@@ -111,7 +111,7 @@ class MayDayTest extends IrelandBaseTestCase implements YasumiTestCaseInterface
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Ireland/NewYearsDayTest.php
+++ b/tests/Ireland/NewYearsDayTest.php
@@ -110,7 +110,7 @@ class NewYearsDayTest extends IrelandBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Ireland/OctoberHolidayTest.php
+++ b/tests/Ireland/OctoberHolidayTest.php
@@ -111,7 +111,7 @@ class OctoberHolidayTest extends IrelandBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Ireland/StPatricksDayTest.php
+++ b/tests/Ireland/StPatricksDayTest.php
@@ -109,7 +109,7 @@ class StPatricksDayTest extends IrelandBaseTestCase implements YasumiTestCaseInt
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Ireland/StStephensDayTest.php
+++ b/tests/Ireland/StStephensDayTest.php
@@ -88,6 +88,6 @@ class StStephensDayTest extends IrelandBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ireland/pentecostMondayTest.php
+++ b/tests/Ireland/pentecostMondayTest.php
@@ -106,7 +106,7 @@ class pentecostMondayTest extends IrelandBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(1000, self::ABOLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Italy/AllSaintsDayTest.php
+++ b/tests/Italy/AllSaintsDayTest.php
@@ -67,6 +67,6 @@ class AllSaintsDayTest extends ItalyBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Italy/AssumptionOfMaryTest.php
+++ b/tests/Italy/AssumptionOfMaryTest.php
@@ -67,6 +67,6 @@ class AssumptionOfMaryTest extends ItalyBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Italy/ChristmasTest.php
+++ b/tests/Italy/ChristmasTest.php
@@ -67,6 +67,6 @@ class ChristmasTest extends ItalyBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Italy/EasterMondayTest.php
+++ b/tests/Italy/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends ItalyBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Italy/EasterTest.php
+++ b/tests/Italy/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends ItalyBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Italy/EpiphanyTest.php
+++ b/tests/Italy/EpiphanyTest.php
@@ -67,6 +67,6 @@ class EpiphanyTest extends ItalyBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Italy/ImmaculateConceptionTest.php
+++ b/tests/Italy/ImmaculateConceptionTest.php
@@ -67,6 +67,6 @@ class ImmaculateConceptionTest extends ItalyBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Italy/InternationalWorkersDayTest.php
+++ b/tests/Italy/InternationalWorkersDayTest.php
@@ -67,6 +67,6 @@ class InternationalWorkersDayTest extends ItalyBaseTestCase implements YasumiTes
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Italy/ItalyTest.php
+++ b/tests/Italy/ItalyTest.php
@@ -25,9 +25,9 @@ class ItalyTest extends ItalyBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Italy are defined by the provider class
+     * Tests if all official holidays in Italy are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class ItalyTest extends ItalyBaseTestCase
             'stStephensDay',
             'liberationDay',
             'republicDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Italy/LiberationDayTest.php
+++ b/tests/Italy/LiberationDayTest.php
@@ -87,7 +87,7 @@ class LiberationDayTest extends ItalyBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Italy/NewYearsDayTest.php
+++ b/tests/Italy/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends ItalyBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Italy/RepublicDayTest.php
+++ b/tests/Italy/RepublicDayTest.php
@@ -87,7 +87,7 @@ class RepublicDayTest extends ItalyBaseTestCase implements YasumiTestCaseInterfa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Italy/stStephensDayTest.php
+++ b/tests/Italy/stStephensDayTest.php
@@ -67,6 +67,6 @@ class stStephensDayTest extends ItalyBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Japan/AutumnalEquinoxDayTest.php
+++ b/tests/Japan/AutumnalEquinoxDayTest.php
@@ -133,7 +133,7 @@ class AutumnalEquinoxDayTest extends JapanBaseTestCase implements YasumiTestCase
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2150),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/ChildrensDayTest.php
+++ b/tests/Japan/ChildrensDayTest.php
@@ -94,7 +94,7 @@ class ChildrensDayTest extends JapanBaseTestCase implements YasumiTestCaseInterf
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/ComingOfAgeDayTest.php
+++ b/tests/Japan/ComingOfAgeDayTest.php
@@ -98,7 +98,7 @@ class ComingOfAgeDayTest extends JapanBaseTestCase implements YasumiTestCaseInte
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/ConstitutionMemorialDayTest.php
+++ b/tests/Japan/ConstitutionMemorialDayTest.php
@@ -95,7 +95,7 @@ class ConstitutionMemorialDayTest extends JapanBaseTestCase implements YasumiTes
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/CultureDayTest.php
+++ b/tests/Japan/CultureDayTest.php
@@ -94,7 +94,7 @@ class CultureDayTest extends JapanBaseTestCase implements YasumiTestCaseInterfac
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/EmperorsBirthdayTest.php
+++ b/tests/Japan/EmperorsBirthdayTest.php
@@ -99,7 +99,7 @@ class EmperorsBirthdayTest extends JapanBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/GreeneryDayTest.php
+++ b/tests/Japan/GreeneryDayTest.php
@@ -125,7 +125,7 @@ class GreeneryDayTest extends JapanBaseTestCase implements YasumiTestCaseInterfa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/HealthAndSportsDayTest.php
+++ b/tests/Japan/HealthAndSportsDayTest.php
@@ -112,7 +112,7 @@ class HealthAndSportsDayTest extends JapanBaseTestCase implements YasumiTestCase
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/JapanTest.php
+++ b/tests/Japan/JapanTest.php
@@ -25,9 +25,9 @@ class JapanTest extends JapanBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Japan are defined by the provider class
+     * Tests if all official holidays in Japan are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -47,7 +47,7 @@ class JapanTest extends JapanBaseTestCase
             'laborThanksgivingDay',
             'emperorsBirthday',
 
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Japan/LabourThanksgivingDayTest.php
+++ b/tests/Japan/LabourThanksgivingDayTest.php
@@ -97,7 +97,7 @@ class LabourThanksgivingDayTest extends JapanBaseTestCase implements YasumiTestC
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/MarineDayTest.php
+++ b/tests/Japan/MarineDayTest.php
@@ -111,7 +111,7 @@ class MarineDayTest extends JapanBaseTestCase implements YasumiTestCaseInterface
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/MountainDayTest.php
+++ b/tests/Japan/MountainDayTest.php
@@ -94,7 +94,7 @@ class MountainDayTest extends JapanBaseTestCase implements YasumiTestCaseInterfa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/NationalFoundationDayTest.php
+++ b/tests/Japan/NationalFoundationDayTest.php
@@ -95,7 +95,7 @@ class NationalFoundationDayTest extends JapanBaseTestCase implements YasumiTestC
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/NewYearsDayTest.php
+++ b/tests/Japan/NewYearsDayTest.php
@@ -94,7 +94,7 @@ class NewYearsDayTest extends JapanBaseTestCase implements YasumiTestCaseInterfa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/PublicBridgeDayTest.php
+++ b/tests/Japan/PublicBridgeDayTest.php
@@ -58,7 +58,7 @@ class PublicBridgeDayTest extends JapanBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Japan/RespectForTheAgedDayTest.php
+++ b/tests/Japan/RespectForTheAgedDayTest.php
@@ -112,7 +112,7 @@ class RespectForTheAgedDayTest extends JapanBaseTestCase implements YasumiTestCa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/ShowaDayTest.php
+++ b/tests/Japan/ShowaDayTest.php
@@ -94,7 +94,7 @@ class ShowaDayTest extends JapanBaseTestCase implements YasumiTestCaseInterface
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Japan/VernalEquinoxDayTest.php
+++ b/tests/Japan/VernalEquinoxDayTest.php
@@ -134,7 +134,7 @@ class VernalEquinoxDayTest extends JapanBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2150),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Netherlands/AscensionDayTest.php
+++ b/tests/Netherlands/AscensionDayTest.php
@@ -59,6 +59,6 @@ class AscensionDayTest extends NetherlandsBaseTestCase implements YasumiTestCase
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Netherlands/ChristmasDayTest.php
+++ b/tests/Netherlands/ChristmasDayTest.php
@@ -67,6 +67,6 @@ class ChristmasDayTest extends NetherlandsBaseTestCase implements YasumiTestCase
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Netherlands/EasterMondayTest.php
+++ b/tests/Netherlands/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends NetherlandsBaseTestCase implements YasumiTestCase
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Netherlands/EasterTest.php
+++ b/tests/Netherlands/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends NetherlandsBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Netherlands/KingsDayTest.php
+++ b/tests/Netherlands/KingsDayTest.php
@@ -94,7 +94,7 @@ class KingsDayTest extends NetherlandsBaseTestCase implements YasumiTestCaseInte
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Netherlands/NetherlandsTest.php
+++ b/tests/Netherlands/NetherlandsTest.php
@@ -25,9 +25,9 @@ class NetherlandsTest extends NetherlandsBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Netherlands are defined by the provider class
+     * Tests if all official holidays in Netherlands are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -39,7 +39,7 @@ class NetherlandsTest extends NetherlandsBaseTestCase
             'pentecostMonday',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Netherlands/NewYearsDayTest.php
+++ b/tests/Netherlands/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends NetherlandsBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Netherlands/PentecostTest.php
+++ b/tests/Netherlands/PentecostTest.php
@@ -59,6 +59,6 @@ class PentecostTest extends NetherlandsBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Netherlands/QueensDayTest.php
+++ b/tests/Netherlands/QueensDayTest.php
@@ -135,7 +135,7 @@ class QueensDayTest extends NetherlandsBaseTestCase implements YasumiTestCaseInt
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(1891, 2013),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Netherlands/pentecostMondayTest.php
+++ b/tests/Netherlands/pentecostMondayTest.php
@@ -59,6 +59,6 @@ class pentecostMondayTest extends NetherlandsBaseTestCase implements YasumiTestC
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Netherlands/secondChristmasdayTest.php
+++ b/tests/Netherlands/secondChristmasdayTest.php
@@ -67,6 +67,6 @@ class secondChristmasdayTest extends NetherlandsBaseTestCase implements YasumiTe
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/NewZealand/AnzacDayTest.php
+++ b/tests/NewZealand/AnzacDayTest.php
@@ -104,7 +104,7 @@ class AnzacDayTest extends NewZealandBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/NewZealand/BoxingDayTest.php
+++ b/tests/NewZealand/BoxingDayTest.php
@@ -87,6 +87,6 @@ class BoxingDayTest extends NewZealandBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/NewZealand/ChristmasDayTest.php
+++ b/tests/NewZealand/ChristmasDayTest.php
@@ -87,6 +87,6 @@ class ChristmasDayTest extends NewZealandBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/NewZealand/DayAfterNewYearsDayTest.php
+++ b/tests/NewZealand/DayAfterNewYearsDayTest.php
@@ -64,7 +64,7 @@ class DayAfterNewYearsDayTest extends NewZealandBaseTestCase implements YasumiTe
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/NewZealand/EasterMondayTest.php
+++ b/tests/NewZealand/EasterMondayTest.php
@@ -84,6 +84,6 @@ class EasterMondayTest extends NewZealandBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/NewZealand/GoodFridayTest.php
+++ b/tests/NewZealand/GoodFridayTest.php
@@ -83,6 +83,6 @@ class GoodFridayTest extends NewZealandBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/NewZealand/LabourDayTest.php
+++ b/tests/NewZealand/LabourDayTest.php
@@ -102,7 +102,7 @@ class LabourDayTest extends NewZealandBaseTestCase implements YasumiTestCaseInte
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/NewZealand/NewYearsDayTest.php
+++ b/tests/NewZealand/NewYearsDayTest.php
@@ -92,6 +92,6 @@ class NewYearsDayTest extends NewZealandBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/NewZealand/NewZealandTest.php
+++ b/tests/NewZealand/NewZealandTest.php
@@ -25,9 +25,9 @@ class NewZealandTest extends NewZealandBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in New Zealand are defined by the provider class
+     * Tests if all official holidays in New Zealand are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -39,7 +39,7 @@ class NewZealandTest extends NewZealandBaseTestCase
             'anzacDay',
             'queensBirthday',
             'labourDay',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/NewZealand/QueensBirthdayTest.php
+++ b/tests/NewZealand/QueensBirthdayTest.php
@@ -93,7 +93,7 @@ class QueensBirthdayTest extends NewZealandBaseTestCase implements YasumiTestCas
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/NewZealand/WaitangiDayTest.php
+++ b/tests/NewZealand/WaitangiDayTest.php
@@ -80,7 +80,7 @@ class WaitangiDayTest extends NewZealandBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 

--- a/tests/Norway/AscensionDayTest.php
+++ b/tests/Norway/AscensionDayTest.php
@@ -59,6 +59,6 @@ class AscensionDayTest extends NorwayBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Norway/ChristmasDayTest.php
+++ b/tests/Norway/ChristmasDayTest.php
@@ -67,6 +67,6 @@ class ChristmasDayTest extends NorwayBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Norway/ConstitutionDayTest.php
+++ b/tests/Norway/ConstitutionDayTest.php
@@ -80,7 +80,7 @@ class ConstitutionDayTest extends NorwayBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Norway/EasterMondayTest.php
+++ b/tests/Norway/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends NorwayBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Norway/EasterTest.php
+++ b/tests/Norway/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends NorwayBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Norway/GoodFridayTest.php
+++ b/tests/Norway/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends NorwayBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Norway/InternationalWorkersDayTest.php
+++ b/tests/Norway/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends NorwayBaseTestCase implements YasumiTe
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Norway/MaundyThursdayTest.php
+++ b/tests/Norway/MaundyThursdayTest.php
@@ -59,6 +59,6 @@ class MaundyThursdayTest extends NorwayBaseTestCase implements YasumiTestCaseInt
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Norway/NewYearsDayTest.php
+++ b/tests/Norway/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends NorwayBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Norway/NorwayTest.php
+++ b/tests/Norway/NorwayTest.php
@@ -25,9 +25,9 @@ class NorwayTest extends NorwayBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Norway are defined by the provider class
+     * Tests if all official holidays in Norway are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class NorwayTest extends NorwayBaseTestCase
             'constitutionDay',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Norway/PentecostMondayTest.php
+++ b/tests/Norway/PentecostMondayTest.php
@@ -59,6 +59,6 @@ class PentecostMondayTest extends NorwayBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Norway/PentecostTest.php
+++ b/tests/Norway/PentecostTest.php
@@ -59,6 +59,6 @@ class PentecostTest extends NorwayBaseTestCase implements YasumiTestCaseInterfac
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Norway/SecondChristmasDayTest.php
+++ b/tests/Norway/SecondChristmasDayTest.php
@@ -67,6 +67,6 @@ class SecondChristmasDayTest extends NorwayBaseTestCase implements YasumiTestCas
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Poland/AllSaintsDayTest.php
+++ b/tests/Poland/AllSaintsDayTest.php
@@ -67,6 +67,6 @@ class AllSaintsDayTest extends PolandBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Poland/AssumptionOfMaryTest.php
+++ b/tests/Poland/AssumptionOfMaryTest.php
@@ -67,6 +67,6 @@ class AssumptionOfMaryTest extends PolandBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Poland/ChristmasTest.php
+++ b/tests/Poland/ChristmasTest.php
@@ -67,6 +67,6 @@ class ChristmasTest extends PolandBaseTestCase implements YasumiTestCaseInterfac
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Poland/ConstitutionDayTest.php
+++ b/tests/Poland/ConstitutionDayTest.php
@@ -80,7 +80,7 @@ class ConstitutionDayTest extends PolandBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Poland/EasterMondayTest.php
+++ b/tests/Poland/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends PolandBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Poland/EasterTest.php
+++ b/tests/Poland/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends PolandBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Poland/EpiphanyTest.php
+++ b/tests/Poland/EpiphanyTest.php
@@ -67,6 +67,6 @@ class EpiphanyTest extends PolandBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Poland/IndependenceDayTest.php
+++ b/tests/Poland/IndependenceDayTest.php
@@ -80,7 +80,7 @@ class IndependenceDayTest extends PolandBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Poland/InternationalWorkersDayTest.php
+++ b/tests/Poland/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends PolandBaseTestCase implements YasumiTe
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Poland/NewYearsDayTest.php
+++ b/tests/Poland/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends PolandBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Poland/PentecostTest.php
+++ b/tests/Poland/PentecostTest.php
@@ -59,6 +59,6 @@ class PentecostTest extends PolandBaseTestCase implements YasumiTestCaseInterfac
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Poland/PolandTest.php
+++ b/tests/Poland/PolandTest.php
@@ -25,9 +25,9 @@ class PolandTest extends PolandBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Poland are defined by the provider class
+     * Tests if all official holidays in Poland are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class PolandTest extends PolandBaseTestCase
             'secondChristmasDay',
             'constitutionDay',
             'independenceDay',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Poland/SecondChristmasDayTest.php
+++ b/tests/Poland/SecondChristmasDayTest.php
@@ -67,6 +67,6 @@ class SecondChristmasDayTest extends PolandBaseTestCase implements YasumiTestCas
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/AllSaintsDayTest.php
+++ b/tests/Portugal/AllSaintsDayTest.php
@@ -81,10 +81,10 @@ class AllSaintsDayTest extends PortugalBaseTestCase implements YasumiTestCaseInt
     {
         // After restoration
         $year = $this->generateRandomYear(self::HOLIDAY_YEAR_RESTORED);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
 
         // Before abolishment
         $year = $this->generateRandomYear(1000, self::HOLIDAY_YEAR_ABOLISHED - 1);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/AssumptionOfMaryTest.php
+++ b/tests/Portugal/AssumptionOfMaryTest.php
@@ -67,6 +67,6 @@ class AssumptionOfMaryTest extends PortugalBaseTestCase implements YasumiTestCas
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/CarnationRevolutionDayTest.php
+++ b/tests/Portugal/CarnationRevolutionDayTest.php
@@ -66,6 +66,6 @@ class CarnationRevolutionDayTest extends PortugalBaseTestCase implements YasumiT
     public function testHolidayType()
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/ChristmasTest.php
+++ b/tests/Portugal/ChristmasTest.php
@@ -67,6 +67,6 @@ class ChristmasTest extends PortugalBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/EasterTest.php
+++ b/tests/Portugal/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends PortugalBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/GoodFridayTest.php
+++ b/tests/Portugal/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends PortugalBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/ImmaculateConceptionTest.php
+++ b/tests/Portugal/ImmaculateConceptionTest.php
@@ -67,6 +67,6 @@ class ImmaculateConceptionTest extends PortugalBaseTestCase implements YasumiTes
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/InternationalWorkersDayTest.php
+++ b/tests/Portugal/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends PortugalBaseTestCase implements Yasumi
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Portugal/NewYearsDayTest.php
+++ b/tests/Portugal/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends PortugalBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/PortugalDayTest.php
+++ b/tests/Portugal/PortugalDayTest.php
@@ -91,9 +91,9 @@ class PortugalDayTest extends PortugalBaseTestCase implements YasumiTestCaseInte
     public function testHolidayType()
     {
         $year = $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR_BEFORE);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
 
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR_AFTER);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/PortugalTest.php
+++ b/tests/Portugal/PortugalTest.php
@@ -25,9 +25,9 @@ class PortugalTest extends PortugalBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Portugal are defined by the provider class
+     * Tests if all official holidays in Portugal are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class PortugalTest extends PortugalBaseTestCase
             'portugueseRepublic',
             'restorationOfIndependence',
             'portugalDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Portugal/PortugueseRepublicDayTest.php
+++ b/tests/Portugal/PortugueseRepublicDayTest.php
@@ -81,7 +81,7 @@ class PortugueseRepublicDayTest extends PortugalBaseTestCase implements YasumiTe
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Portugal/RestorationOfIndependenceTest.php
+++ b/tests/Portugal/RestorationOfIndependenceTest.php
@@ -115,10 +115,10 @@ class RestorationOfIndependenceTest extends PortugalBaseTestCase implements Yasu
     {
         // After establishment and before abolishment
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::HOLIDAY_YEAR_ABOLISHED - 1);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
 
         // After restoration
         $this->generateRandomYear(self::HOLIDAY_YEAR_RESTORED);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Romania/AssumptionOfMaryTest.php
+++ b/tests/Romania/AssumptionOfMaryTest.php
@@ -80,7 +80,7 @@ class AssumptionOfMaryTest extends RomaniaBaseTestCase implements YasumiTestCase
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Romania/ChildrensDayTest.php
+++ b/tests/Romania/ChildrensDayTest.php
@@ -82,6 +82,6 @@ class ChildrensDayTest extends RomaniaBaseTestCase implements YasumiTestCaseInte
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2016),
             Holiday::TYPE_OBSERVANCE
         );
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(2017), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(2017), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Romania/ChristmasDayTest.php
+++ b/tests/Romania/ChristmasDayTest.php
@@ -67,6 +67,6 @@ class ChristmasDayTest extends RomaniaBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Romania/DayAfterNewYearsDayTest.php
+++ b/tests/Romania/DayAfterNewYearsDayTest.php
@@ -67,6 +67,6 @@ class DayAfterNewYearsDayTest extends RomaniaBaseTestCase implements YasumiTestC
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Romania/EasterMondayTest.php
+++ b/tests/Romania/EasterMondayTest.php
@@ -60,6 +60,6 @@ class EasterMondayTest extends RomaniaBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Romania/EasterTest.php
+++ b/tests/Romania/EasterTest.php
@@ -60,6 +60,6 @@ class EasterTest extends RomaniaBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Romania/InternationalWorkersDayTest.php
+++ b/tests/Romania/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends RomaniaBaseTestCase implements YasumiT
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Romania/NationalDayTest.php
+++ b/tests/Romania/NationalDayTest.php
@@ -108,7 +108,7 @@ class NationalDayTest extends RomaniaBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Romania/NewYearsDayTest.php
+++ b/tests/Romania/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends RomaniaBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Romania/PentecostMondayTest.php
+++ b/tests/Romania/PentecostMondayTest.php
@@ -81,7 +81,7 @@ class PentecostMondayTest extends RomaniaBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Romania/PentecostTest.php
+++ b/tests/Romania/PentecostTest.php
@@ -81,7 +81,7 @@ class PentecostTest extends RomaniaBaseTestCase implements YasumiTestCaseInterfa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Romania/RomaniaTest.php
+++ b/tests/Romania/RomaniaTest.php
@@ -26,9 +26,9 @@ class RomaniaTest extends RomaniaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Romania are defined by the provider class
+     * Tests if all official holidays in Romania are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $national_holidays = [
             'newYearsDay',
@@ -50,7 +50,7 @@ class RomaniaTest extends RomaniaBaseTestCase
             $national_holidays[] = 'childrensDay';
         }
 
-        $this->assertDefinedHolidays($national_holidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($national_holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Romania/SecondChristmasDayTest.php
+++ b/tests/Romania/SecondChristmasDayTest.php
@@ -67,6 +67,6 @@ class SecondChristmasDayTest extends RomaniaBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Romania/StAndrewDayTest.php
+++ b/tests/Romania/StAndrewDayTest.php
@@ -80,7 +80,7 @@ class StAndrewDayTest extends RomaniaBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Romania/UnitedPrincipalitiesDayTest.php
+++ b/tests/Romania/UnitedPrincipalitiesDayTest.php
@@ -80,7 +80,7 @@ class UnitedPrincipalitiesDayTest extends RomaniaBaseTestCase implements YasumiT
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Slovakia/NewYearsDayTest.php
+++ b/tests/Slovakia/NewYearsDayTest.php
@@ -77,6 +77,6 @@ class NewYearsDayTest extends SlovakiaBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Slovakia/SaintsCyrilAndMethodiusDayTest.php
+++ b/tests/Slovakia/SaintsCyrilAndMethodiusDayTest.php
@@ -19,7 +19,7 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing a national holiday in Slovakia.
+ * Class for testing a official holiday in Slovakia.
  *
  *
  * @package Yasumi\tests\Slovakia
@@ -77,6 +77,6 @@ class SaintsCyrilAndMethodiusDayTest extends SlovakiaBaseTestCase implements Yas
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Slovakia/SlovakConstitutionDayTest.php
+++ b/tests/Slovakia/SlovakConstitutionDayTest.php
@@ -19,7 +19,7 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing a national holiday in Slovakia.
+ * Class for testing an official holiday in Slovakia.
  *
  *
  * @package Yasumi\tests\Slovakia
@@ -31,7 +31,6 @@ class SlovakConstitutionDayTest extends SlovakiaBaseTestCase implements YasumiTe
      * The name of the holiday to be tested
      */
     const HOLIDAY = 'slovakConstitutionDay';
-
 
     /**
      * Tests the holiday defined in this test.
@@ -77,6 +76,6 @@ class SlovakConstitutionDayTest extends SlovakiaBaseTestCase implements YasumiTe
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Slovakia/SlovakNationalUprisingDayTest.php
+++ b/tests/Slovakia/SlovakNationalUprisingDayTest.php
@@ -19,7 +19,7 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing a national holiday in Slovakia.
+ * Class for testing an official holiday in Slovakia.
  *
  *
  * @package Yasumi\tests\Slovakia
@@ -77,6 +77,6 @@ class SlovakNationalUprisingDayTest extends SlovakiaBaseTestCase implements Yasu
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Slovakia/SlovakiaTest.php
+++ b/tests/Slovakia/SlovakiaTest.php
@@ -32,9 +32,9 @@ class SlovakiaTest extends SlovakiaBaseTestCase
 
 
     /**
-     * Tests if all national holidays in Slovakia are defined by the provider class
+     * Tests if all official holidays in Slovakia are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class SlovakiaTest extends SlovakiaBaseTestCase
             'slovakNationalUprisingDay',
             'saintsCyrilAndMethodiusDay',
             'struggleForFreedomAndDemocracyDay',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
 

--- a/tests/Slovakia/StruggleForFreedomAndDemocracyDayTest.php
+++ b/tests/Slovakia/StruggleForFreedomAndDemocracyDayTest.php
@@ -19,7 +19,7 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing a national holiday in Slovakia.
+ * Class for testing an official holiday in Slovakia.
  *
  *
  * @package Yasumi\tests\Slovakia
@@ -77,6 +77,6 @@ class StruggleForFreedomAndDemocracyDayTest extends SlovakiaBaseTestCase impleme
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/SouthAfrica/ChristmasDayTest.php
+++ b/tests/SouthAfrica/ChristmasDayTest.php
@@ -109,7 +109,7 @@ class ChristmasDayTest extends SouthAfricaBaseTestCase implements YasumiTestCase
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/FamilyDayTest.php
+++ b/tests/SouthAfrica/FamilyDayTest.php
@@ -108,7 +108,7 @@ class FamilyDayTest extends SouthAfricaBaseTestCase implements YasumiTestCaseInt
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/FreedomDayTest.php
+++ b/tests/SouthAfrica/FreedomDayTest.php
@@ -109,7 +109,7 @@ class FreedomDayTest extends SouthAfricaBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/GoodFridayTest.php
+++ b/tests/SouthAfrica/GoodFridayTest.php
@@ -108,7 +108,7 @@ class GoodFridayTest extends SouthAfricaBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/HeritageDayTest.php
+++ b/tests/SouthAfrica/HeritageDayTest.php
@@ -109,7 +109,7 @@ class HeritageDayTest extends SouthAfricaBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/HumanRightsDayTest.php
+++ b/tests/SouthAfrica/HumanRightsDayTest.php
@@ -109,7 +109,7 @@ class HumanRightsDayTest extends SouthAfricaBaseTestCase implements YasumiTestCa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/MunicipalElections2016DayTest.php
+++ b/tests/SouthAfrica/MunicipalElections2016DayTest.php
@@ -91,7 +91,7 @@ class MunicipalElections2016DayTest extends SouthAfricaBaseTestCase implements Y
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/NationalWomensDayTest.php
+++ b/tests/SouthAfrica/NationalWomensDayTest.php
@@ -109,7 +109,7 @@ class NationalWomensDayTest extends SouthAfricaBaseTestCase implements YasumiTes
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/NewYearsDayTest.php
+++ b/tests/SouthAfrica/NewYearsDayTest.php
@@ -109,7 +109,7 @@ class NewYearsDayTest extends SouthAfricaBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/ReconciliationDayTest.php
+++ b/tests/SouthAfrica/ReconciliationDayTest.php
@@ -109,7 +109,7 @@ class ReconciliationDayTest extends SouthAfricaBaseTestCase implements YasumiTes
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/SecondChristmasDayTest.php
+++ b/tests/SouthAfrica/SecondChristmasDayTest.php
@@ -109,7 +109,7 @@ class SecondChristmasDayTest extends SouthAfricaBaseTestCase implements YasumiTe
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/SouthAfricaTest.php
+++ b/tests/SouthAfrica/SouthAfricaTest.php
@@ -29,11 +29,11 @@ class SouthAfricaTest extends SouthAfricaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in SouthAfrica are defined by the provider class
+     * Tests if all official holidays in SouthAfrica are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [
+        $officialHolidays = [
             'newYearsDay',
             'humanRightsDay',
             'goodFriday',
@@ -49,11 +49,11 @@ class SouthAfricaTest extends SouthAfricaBaseTestCase
         ];
 
         if ($this->year === 2016) {
-            $nationalHolidays[] = '2016MunicipalElectionsDay';
-            $nationalHolidays[] = 'substituteDayOfGoodwill';
+            $officialHolidays[] = '2016MunicipalElectionsDay';
+            $officialHolidays[] = 'substituteDayOfGoodwill';
         }
 
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/SouthAfrica/SubstituteDayOfGoodwillTest.php
+++ b/tests/SouthAfrica/SubstituteDayOfGoodwillTest.php
@@ -91,7 +91,7 @@ class SubstituteDayOfGoodwillTest extends SouthAfricaBaseTestCase implements Yas
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/WorkersDayTest.php
+++ b/tests/SouthAfrica/WorkersDayTest.php
@@ -109,7 +109,7 @@ class WorkersDayTest extends SouthAfricaBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/SouthAfrica/YouthDayTest.php
+++ b/tests/SouthAfrica/YouthDayTest.php
@@ -109,7 +109,7 @@ class YouthDayTest extends SouthAfricaBaseTestCase implements YasumiTestCaseInte
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/AllSaintsDayTest.php
+++ b/tests/Spain/AllSaintsDayTest.php
@@ -67,6 +67,6 @@ class AllSaintsDayTest extends SpainBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Spain/Andalusia/AndalusiaDayTest.php
+++ b/tests/Spain/Andalusia/AndalusiaDayTest.php
@@ -80,7 +80,7 @@ class AndalusiaDayTest extends AndalusiaBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/Andalusia/AndalusiaTest.php
+++ b/tests/Spain/Andalusia/AndalusiaTest.php
@@ -25,9 +25,9 @@ class AndalusiaTest extends AndalusiaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Andalusia are defined by the provider class
+     * Tests if all official holidays in Andalusia (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class AndalusiaTest extends AndalusiaBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/Aragon/AragonTest.php
+++ b/tests/Spain/Aragon/AragonTest.php
@@ -25,9 +25,9 @@ class AragonTest extends AragonBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Aragon are defined by the provider class
+     * Tests if all official holidays in Aragon (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class AragonTest extends AragonBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/AssumptionOfMaryTest.php
+++ b/tests/Spain/AssumptionOfMaryTest.php
@@ -67,6 +67,6 @@ class AssumptionOfMaryTest extends SpainBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Spain/Asturias/AsturiasDayTest.php
+++ b/tests/Spain/Asturias/AsturiasDayTest.php
@@ -80,7 +80,7 @@ class AsturiasDayTest extends AsturiasBaseTestCase implements YasumiTestCaseInte
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/Asturias/AsturiasTest.php
+++ b/tests/Spain/Asturias/AsturiasTest.php
@@ -25,9 +25,9 @@ class AsturiasTest extends AsturiasBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Asturias are defined by the provider class
+     * Tests if all official holidays in Asturias (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class AsturiasTest extends AsturiasBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/BalearicIslands/BalearicIslandsDayTest.php
+++ b/tests/Spain/BalearicIslands/BalearicIslandsDayTest.php
@@ -80,7 +80,7 @@ class BalearicIslandsDayTest extends BalearicIslandsBaseTestCase implements Yasu
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/BalearicIslands/BalearicIslandsTest.php
+++ b/tests/Spain/BalearicIslands/BalearicIslandsTest.php
@@ -25,9 +25,9 @@ class BalearicIslandsTest extends BalearicIslandsBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in the Balearic Islands are defined by the provider class
+     * Tests if all official holidays in the Balearic Islands (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class BalearicIslandsTest extends BalearicIslandsBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/BasqueCountry/BasqueCountryDayTest.php
+++ b/tests/Spain/BasqueCountry/BasqueCountryDayTest.php
@@ -93,7 +93,7 @@ class BasqueCountryDayTest extends BasqueCountryBaseTestCase implements YasumiTe
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ABOLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/BasqueCountry/BasqueCountryTest.php
+++ b/tests/Spain/BasqueCountry/BasqueCountryTest.php
@@ -25,9 +25,9 @@ class BasqueCountryTest extends BasqueCountryBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Basque Country are defined by the provider class
+     * Tests if all official holidays in Basque Country (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class BasqueCountryTest extends BasqueCountryBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/CanaryIslands/CanaryIslandsDayTest.php
+++ b/tests/Spain/CanaryIslands/CanaryIslandsDayTest.php
@@ -80,7 +80,7 @@ class CanaryIslandsDayTest extends CanaryIslandsBaseTestCase implements YasumiTe
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/CanaryIslands/CanaryIslandsTest.php
+++ b/tests/Spain/CanaryIslands/CanaryIslandsTest.php
@@ -25,9 +25,9 @@ class CanaryIslandsTest extends CanaryIslandsBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in the Canary Islands are defined by the provider class
+     * Tests if all official holidays in the Canary Islands (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class CanaryIslandsTest extends CanaryIslandsBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/Cantabria/CantabriaDayTest.php
+++ b/tests/Spain/Cantabria/CantabriaDayTest.php
@@ -80,7 +80,7 @@ class CantabriaDayTest extends CantabriaBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/Cantabria/CantabriaTest.php
+++ b/tests/Spain/Cantabria/CantabriaTest.php
@@ -25,9 +25,9 @@ class CantabriaTest extends CantabriaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Cantabria are defined by the provider class
+     * Tests if all official holidays in Cantabria (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class CantabriaTest extends CantabriaBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/CastileAndLeon/CastileAndLeonDayTest.php
+++ b/tests/Spain/CastileAndLeon/CastileAndLeonDayTest.php
@@ -80,7 +80,7 @@ class CastileAndLeonDayTest extends CastileAndLeonBaseTestCase implements Yasumi
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/CastileAndLeon/CastileAndLeonTest.php
+++ b/tests/Spain/CastileAndLeon/CastileAndLeonTest.php
@@ -25,9 +25,9 @@ class CastileAndLeonTest extends CastileAndLeonBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Castile And Leon are defined by the provider class
+     * Tests if all official holidays in Castile And Leon (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class CastileAndLeonTest extends CastileAndLeonBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/CastillaLaMancha/CastillaLaManchaDayTest.php
+++ b/tests/Spain/CastillaLaMancha/CastillaLaManchaDayTest.php
@@ -80,7 +80,7 @@ class CastillaLaManchaDayTest extends CastillaLaManchaBaseTestCase implements Ya
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/CastillaLaMancha/CastillaLaManchaTest.php
+++ b/tests/Spain/CastillaLaMancha/CastillaLaManchaTest.php
@@ -25,9 +25,9 @@ class CastillaLaManchaTest extends CastillaLaManchaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Castilla-La Mancha are defined by the provider class
+     * Tests if all official holidays in Castilla-La Mancha (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class CastillaLaManchaTest extends CastillaLaManchaBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/Catalonia/CataloniaTest.php
+++ b/tests/Spain/Catalonia/CataloniaTest.php
@@ -25,9 +25,9 @@ class CataloniaTest extends CataloniaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Catalonia are defined by the provider class
+     * Tests if all official holidays in Catalonia (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class CataloniaTest extends CataloniaBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/Catalonia/nationalCataloniaDayTest.php
+++ b/tests/Spain/Catalonia/nationalCataloniaDayTest.php
@@ -80,7 +80,7 @@ class nationalCataloniaDayTest extends CataloniaBaseTestCase implements YasumiTe
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/Ceuta/CeutaTest.php
+++ b/tests/Spain/Ceuta/CeutaTest.php
@@ -25,9 +25,9 @@ class CeutaTest extends CeutaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Ceuta are defined by the provider class
+     * Tests if all official holidays in Ceuta (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class CeutaTest extends CeutaBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/Ceuta/ceutaDayTest.php
+++ b/tests/Spain/Ceuta/ceutaDayTest.php
@@ -80,7 +80,7 @@ class ceutaDayTest extends CeutaBaseTestCase implements YasumiTestCaseInterface
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/ChristmasTest.php
+++ b/tests/Spain/ChristmasTest.php
@@ -67,6 +67,6 @@ class ChristmasTest extends SpainBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Spain/CommunityOfMadrid/CommunityOfMadridTest.php
+++ b/tests/Spain/CommunityOfMadrid/CommunityOfMadridTest.php
@@ -25,9 +25,9 @@ class CommunityOfMadridTest extends CommunityOfMadridBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in the Community of Madrid are defined by the provider class
+     * Tests if all official holidays in the Community of Madrid (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class CommunityOfMadridTest extends CommunityOfMadridBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/CommunityOfMadrid/DosdeMayoUprisingDayTest.php
+++ b/tests/Spain/CommunityOfMadrid/DosdeMayoUprisingDayTest.php
@@ -59,6 +59,6 @@ class DosdeMayoUprisingDayTest extends CommunityOfMadridBaseTestCase implements 
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Spain/ConstitutionDayTest.php
+++ b/tests/Spain/ConstitutionDayTest.php
@@ -80,7 +80,7 @@ class ConstitutionDayTest extends SpainBaseTestCase implements YasumiTestCaseInt
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/EpiphanyTest.php
+++ b/tests/Spain/EpiphanyTest.php
@@ -67,6 +67,6 @@ class EpiphanyTest extends SpainBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Spain/Extremadura/ExtremaduraDayTest.php
+++ b/tests/Spain/Extremadura/ExtremaduraDayTest.php
@@ -80,7 +80,7 @@ class ExtremaduraDayTest extends ExtremaduraBaseTestCase implements YasumiTestCa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/Extremadura/ExtremaduraTest.php
+++ b/tests/Spain/Extremadura/ExtremaduraTest.php
@@ -25,9 +25,9 @@ class ExtremaduraTest extends ExtremaduraBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Extremadura are defined by the provider class
+     * Tests if all official holidays in Extremadura (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class ExtremaduraTest extends ExtremaduraBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/Galicia/GaliciaTest.php
+++ b/tests/Spain/Galicia/GaliciaTest.php
@@ -25,9 +25,9 @@ class GaliciaTest extends GaliciaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Galicia are defined by the provider class
+     * Tests if all official holidays in Galicia (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -43,7 +43,7 @@ class GaliciaTest extends GaliciaBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/Galicia/GalicianLiteratureDayTest.php
+++ b/tests/Spain/Galicia/GalicianLiteratureDayTest.php
@@ -80,7 +80,7 @@ class GalicianLiteratureDayTest extends GaliciaBaseTestCase implements YasumiTes
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/Galicia/stJamesDayTest.php
+++ b/tests/Spain/Galicia/stJamesDayTest.php
@@ -80,7 +80,7 @@ class stJamesDayTest extends GaliciaBaseTestCase implements YasumiTestCaseInterf
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/GoodFridayTest.php
+++ b/tests/Spain/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends SpainBaseTestCase implements YasumiTestCaseInterfac
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Spain/ImmaculateConceptionTest.php
+++ b/tests/Spain/ImmaculateConceptionTest.php
@@ -67,6 +67,6 @@ class ImmaculateConceptionTest extends SpainBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Spain/InternationalWorkersDayTest.php
+++ b/tests/Spain/InternationalWorkersDayTest.php
@@ -67,6 +67,6 @@ class InternationalWorkersDayTest extends SpainBaseTestCase implements YasumiTes
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Spain/LaRioja/LaRiojaDayTest.php
+++ b/tests/Spain/LaRioja/LaRiojaDayTest.php
@@ -80,7 +80,7 @@ class LaRiojaDayTest extends LaRiojaBaseTestCase implements YasumiTestCaseInterf
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/LaRioja/LaRiojaTest.php
+++ b/tests/Spain/LaRioja/LaRiojaTest.php
@@ -25,9 +25,9 @@ class LaRiojaTest extends LaRiojaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in La Rioja are defined by the provider class
+     * Tests if all official holidays in La Rioja (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class LaRiojaTest extends LaRiojaBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/Melilla/MelillaTest.php
+++ b/tests/Spain/Melilla/MelillaTest.php
@@ -25,9 +25,9 @@ class MelillaTest extends MelillaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Melilla are defined by the provider class
+     * Tests if all official holidays in Melilla (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class MelillaTest extends MelillaBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/NationalDayTest.php
+++ b/tests/Spain/NationalDayTest.php
@@ -80,7 +80,7 @@ class NationalDayTest extends SpainBaseTestCase implements YasumiTestCaseInterfa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/Navarre/NavarreTest.php
+++ b/tests/Spain/Navarre/NavarreTest.php
@@ -25,9 +25,9 @@ class NavarreTest extends NavarreBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Navarre are defined by the provider class
+     * Tests if all official holidays in Navarre (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -41,7 +41,7 @@ class NavarreTest extends NavarreBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/NewYearsDayTest.php
+++ b/tests/Spain/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends SpainBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Spain/RegionOfMurcia/RegionOfMurciaDayTest.php
+++ b/tests/Spain/RegionOfMurcia/RegionOfMurciaDayTest.php
@@ -80,7 +80,7 @@ class RegionOfMurciaDayTest extends RegionOfMurciaBaseTestCase implements Yasumi
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/RegionOfMurcia/RegionOfMurciaTest.php
+++ b/tests/Spain/RegionOfMurcia/RegionOfMurciaTest.php
@@ -25,9 +25,9 @@ class RegionOfMurciaTest extends RegionOfMurciaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in the Region of Murcia are defined by the provider class
+     * Tests if all official holidays in the Region of Murcia (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class RegionOfMurciaTest extends RegionOfMurciaBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/SpainTest.php
+++ b/tests/Spain/SpainTest.php
@@ -25,9 +25,9 @@ class SpainTest extends SpainBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Spain are defined by the provider class
+     * Tests if all official holidays in Spain are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -40,7 +40,7 @@ class SpainTest extends SpainBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Spain/ValencianCommunity/ValencianCommunityDayTest.php
+++ b/tests/Spain/ValencianCommunity/ValencianCommunityDayTest.php
@@ -80,7 +80,7 @@ class ValencianCommunityDayTest extends ValencianCommunityBaseTestCase implement
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Spain/ValencianCommunity/ValencianCommunityTest.php
+++ b/tests/Spain/ValencianCommunity/ValencianCommunityTest.php
@@ -25,9 +25,9 @@ class ValencianCommunityTest extends ValencianCommunityBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in the Valencian Community are defined by the provider class
+     * Tests if all official holidays in the Valencian Community (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class ValencianCommunityTest extends ValencianCommunityBaseTestCase
             'constitutionDay',
             'immaculateConception',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Sweden/AllSaintsDayTest.php
+++ b/tests/Sweden/AllSaintsDayTest.php
@@ -85,6 +85,6 @@ class AllSaintsDayTest extends SwedenBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/AscensionDayTest.php
+++ b/tests/Sweden/AscensionDayTest.php
@@ -59,6 +59,6 @@ class AscensionDayTest extends SwedenBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/ChristmasDayTest.php
+++ b/tests/Sweden/ChristmasDayTest.php
@@ -67,6 +67,6 @@ class ChristmasDayTest extends SwedenBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/ChristmasEveTest.php
+++ b/tests/Sweden/ChristmasEveTest.php
@@ -67,6 +67,6 @@ class ChristmasEveTest extends SwedenBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/EasterMondayTest.php
+++ b/tests/Sweden/EasterMondayTest.php
@@ -59,6 +59,6 @@ class EasterMondayTest extends SwedenBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/EasterTest.php
+++ b/tests/Sweden/EasterTest.php
@@ -59,6 +59,6 @@ class EasterTest extends SwedenBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/EpiphanyTest.php
+++ b/tests/Sweden/EpiphanyTest.php
@@ -67,6 +67,6 @@ class EpiphanyTest extends SwedenBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/GoodFridayTest.php
+++ b/tests/Sweden/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends SwedenBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/InternationalWorkersDayTest.php
+++ b/tests/Sweden/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends SwedenBaseTestCase implements YasumiTe
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Sweden/NationalDayTest.php
+++ b/tests/Sweden/NationalDayTest.php
@@ -80,7 +80,7 @@ class NationalDayTest extends SwedenBaseTestCase implements YasumiTestCaseInterf
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 

--- a/tests/Sweden/NewYearsDayTest.php
+++ b/tests/Sweden/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends SwedenBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/PentecostTest.php
+++ b/tests/Sweden/PentecostTest.php
@@ -59,6 +59,6 @@ class PentecostTest extends SwedenBaseTestCase implements YasumiTestCaseInterfac
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/SecondChristmasDayTest.php
+++ b/tests/Sweden/SecondChristmasDayTest.php
@@ -67,6 +67,6 @@ class SecondChristmasDayTest extends SwedenBaseTestCase implements YasumiTestCas
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Sweden/SwedenTest.php
+++ b/tests/Sweden/SwedenTest.php
@@ -25,9 +25,9 @@ class SwedenTest extends SwedenBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Sweden are defined by the provider class
+     * Tests if all official holidays in Sweden (Spain) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -44,7 +44,7 @@ class SwedenTest extends SwedenBaseTestCase
             'christmasEve',
             'christmasDay',
             'secondChristmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Sweden/stJohnsDayTest.php
+++ b/tests/Sweden/stJohnsDayTest.php
@@ -67,6 +67,6 @@ class stJohnsDayTest extends SwedenBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Switzerland/Aargau/AargauTest.php
+++ b/tests/Switzerland/Aargau/AargauTest.php
@@ -25,19 +25,19 @@ class AargauTest extends AargauBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Aargau are defined by the provider class
+     * Tests if all official holidays in Aargau (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Aargau are defined by the provider class
+     * Tests if all official holidays in Aargau (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/AppenzellAusserrhoden/AppenzellAusserrhodenTest.php
+++ b/tests/Switzerland/AppenzellAusserrhoden/AppenzellAusserrhodenTest.php
@@ -25,19 +25,19 @@ class AppenzellAusserrhodenTest extends AppenzellAusserrhodenBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Appenzell Ausserrhoden are defined by the provider class
+     * Tests if all official holidays in Appenzell Ausserrhoden (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Appenzell Ausserrhoden are defined by the provider class
+     * Tests if all regional holidays in Appenzell Ausserrhoden (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/AppenzellInnerrhoden/AppenzellInnerrhodenTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/AppenzellInnerrhodenTest.php
@@ -25,19 +25,19 @@ class AppenzellInnerrhodenTest extends AppenzellInnerrhodenBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Appenzell Innerrhoden are defined by the provider class
+     * Tests if all official holidays in Appenzell Innerrhoden (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Appenzell Innerrhoden are defined by the provider class
+     * Tests if all regional holidays in Appenzell Innerrhoden (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/BaselLandschaft/BaselLandschaftTest.php
+++ b/tests/Switzerland/BaselLandschaft/BaselLandschaftTest.php
@@ -25,19 +25,19 @@ class BaselLandschaftTest extends BaselLandschaftBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in BaselLandschaft are defined by the provider class
+     * Tests if all official holidays in BaselLandschaft (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in BaselLandschaft are defined by the provider class
+     * Tests if all regional holidays in BaselLandschaft (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/BaselStadt/BaselStadtTest.php
+++ b/tests/Switzerland/BaselStadt/BaselStadtTest.php
@@ -25,19 +25,19 @@ class BaselStadtTest extends BaselStadtBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Basel Stadt are defined by the provider class
+     * Tests if all official holidays in Basel Stadt (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Basel Stadt are defined by the provider class
+     * Tests if all regional holidays in Basel Stadt (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Bern/BernTest.php
+++ b/tests/Switzerland/Bern/BernTest.php
@@ -25,19 +25,19 @@ class BernTest extends BernBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Bern are defined by the provider class
+     * Tests if all official holidays in Bern (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Bern are defined by the provider class
+     * Tests if all regional holidays in Bern (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Fribourg/FribourgTest.php
+++ b/tests/Switzerland/Fribourg/FribourgTest.php
@@ -25,19 +25,19 @@ class FribourgTest extends FribourgBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Fribourg are defined by the provider class
+     * Tests if all official holidays in Fribourg (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Fribourg are defined by the provider class
+     * Tests if all regional holidays in Fribourg (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Geneva/GenevaTest.php
+++ b/tests/Switzerland/Geneva/GenevaTest.php
@@ -25,19 +25,19 @@ class GenevaTest extends GenevaBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Geneva are defined by the provider class
+     * Tests if all official holidays in Geneva (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Geneva are defined by the provider class
+     * Tests if all regional holidays in Geneva (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Glarus/GlarusTest.php
+++ b/tests/Switzerland/Glarus/GlarusTest.php
@@ -25,19 +25,19 @@ class GlarusTest extends GlarusBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Glarus are defined by the provider class
+     * Tests if all official holidays in Glarus (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Glarus are defined by the provider class
+     * Tests if all regional holidays in Glarus (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Grisons/GrisonsTest.php
+++ b/tests/Switzerland/Grisons/GrisonsTest.php
@@ -25,19 +25,19 @@ class GrisonsTest extends GrisonsBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Grisons are defined by the provider class
+     * Tests if all official holidays in Grisons (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Grisons are defined by the provider class
+     * Tests if all regional holidays in Grisons (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Jura/JuraTest.php
+++ b/tests/Switzerland/Jura/JuraTest.php
@@ -25,19 +25,19 @@ class JuraTest extends JuraBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Jura are defined by the provider class
+     * Tests if all official holidays in Jura (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Jura are defined by the provider class
+     * Tests if all regional holidays in Jura (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Lucerne/LucerneTest.php
+++ b/tests/Switzerland/Lucerne/LucerneTest.php
@@ -25,19 +25,19 @@ class LucerneTest extends LucerneBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Lucerne are defined by the provider class
+     * Tests if all official holidays in Lucerne (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Lucerne are defined by the provider class
+     * Tests if all regional holidays in Lucerne (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Neuchatel/NeuchatelTest.php
+++ b/tests/Switzerland/Neuchatel/NeuchatelTest.php
@@ -25,19 +25,19 @@ class NeuchatelTest extends NeuchatelBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Neuchatel are defined by the provider class
+     * Tests if all official holidays in Neuchatel (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Neuchatel are defined by the provider class
+     * Tests if all regional holidays in Neuchatel (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Nidwalden/NidwaldenTest.php
+++ b/tests/Switzerland/Nidwalden/NidwaldenTest.php
@@ -25,19 +25,19 @@ class NidwaldenTest extends NidwaldenBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Nidwalden are defined by the provider class
+     * Tests if all official holidays in Nidwalden (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Nidwalden are defined by the provider class
+     * Tests if all regional holidays in Nidwalden (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Obwalden/ObwaldenTest.php
+++ b/tests/Switzerland/Obwalden/ObwaldenTest.php
@@ -25,19 +25,19 @@ class ObwaldenTest extends ObwaldenBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Obwalden are defined by the provider class
+     * Tests if all official holidays in Obwalden (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Obwalden are defined by the provider class
+     * Tests if all regional holidays in Obwalden (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Schaffhausen/SchaffhausenTest.php
+++ b/tests/Switzerland/Schaffhausen/SchaffhausenTest.php
@@ -25,19 +25,19 @@ class SchaffhausenTest extends SchaffhausenBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Schaffhausen are defined by the provider class
+     * Tests if all official holidays in Schaffhausen (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Schaffhausen are defined by the provider class
+     * Tests if all regional holidays in Schaffhausen (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Schwyz/SchwyzTest.php
+++ b/tests/Switzerland/Schwyz/SchwyzTest.php
@@ -25,19 +25,19 @@ class SchwyzTest extends SchwyzBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Schwyz are defined by the provider class
+     * Tests if all official holidays in Schwyz (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Schwyz are defined by the provider class
+     * Tests if all regional holidays in Schwyz (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Solothurn/SolothurnTest.php
+++ b/tests/Switzerland/Solothurn/SolothurnTest.php
@@ -25,20 +25,20 @@ class SolothurnTest extends SolothurnBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Solothurn are defined by the provider class
+     * Tests if all official holidays in Solothurn (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
 
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Solothurn are defined by the provider class
+     * Tests if all regional holidays in Solothurn (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/StGallen/StGallenTest.php
+++ b/tests/Switzerland/StGallen/StGallenTest.php
@@ -25,19 +25,19 @@ class StGallenTest extends StGallenBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in St. Gallen are defined by the provider class
+     * Tests if all official holidays in St. Gallen (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in St. Gallen are defined by the provider class
+     * Tests if all regional holidays in St. Gallen (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/SwissNationalDayTest.php
+++ b/tests/Switzerland/SwissNationalDayTest.php
@@ -129,7 +129,7 @@ class SwissNationalDayTest extends SwitzerlandBaseTestCase implements YasumiTest
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::NATIONAL_ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Switzerland/SwitzerlandTest.php
+++ b/tests/Switzerland/SwitzerlandTest.php
@@ -25,15 +25,15 @@ class SwitzerlandTest extends SwitzerlandBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Switzerland are defined by the provider class
+     * Tests if all official holidays in Switzerland are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Switzerland/Thurgau/ThurgauTest.php
+++ b/tests/Switzerland/Thurgau/ThurgauTest.php
@@ -25,19 +25,19 @@ class ThurgauTest extends ThurgauBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Thurgau are defined by the provider class
+     * Tests if all official holidays in Thurgau (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Thurgau are defined by the provider class
+     * Tests if all regional holidays in Thurgau (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Ticino/TicinoTest.php
+++ b/tests/Switzerland/Ticino/TicinoTest.php
@@ -25,19 +25,19 @@ class TicinoTest extends TicinoBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Ticino are defined by the provider class
+     * Tests if all official holidays in Ticino (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Ticino are defined by the provider class
+     * Tests if all regional holidays in Ticino (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Uri/UriTest.php
+++ b/tests/Switzerland/Uri/UriTest.php
@@ -25,19 +25,19 @@ class UriTest extends UriBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Uri are defined by the provider class
+     * Tests if all official holidays in Uri (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Uri are defined by the provider class
+     * Tests if all regional holidays in Uri (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Valais/ValaisTest.php
+++ b/tests/Switzerland/Valais/ValaisTest.php
@@ -25,19 +25,19 @@ class ValaisTest extends ValaisBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Valais are defined by the provider class
+     * Tests if all official holidays in Valais (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Valais are defined by the provider class
+     * Tests if all regional holidays in Valais (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Vaud/VaudTest.php
+++ b/tests/Switzerland/Vaud/VaudTest.php
@@ -25,19 +25,19 @@ class VaudTest extends VaudBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Vaud are defined by the provider class
+     * Tests if all official holidays in Vaud (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Vaud are defined by the provider class
+     * Tests if all regional holidays in Vaud (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Zug/ZugTest.php
+++ b/tests/Switzerland/Zug/ZugTest.php
@@ -25,19 +25,19 @@ class ZugTest extends ZugBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Zug are defined by the provider class
+     * Tests if all official holidays in Zug (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Zug are defined by the provider class
+     * Tests if all regional holidays in Zug (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/Switzerland/Zurich/ZurichTest.php
+++ b/tests/Switzerland/Zurich/ZurichTest.php
@@ -25,19 +25,19 @@ class ZurichTest extends ZurichBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Zurich are defined by the provider class
+     * Tests if all official holidays in Zurich (Switzerland) are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
-        $nationalHolidays = [];
+        $officialHolidays = [];
         if ($this->year >= 1994) {
-            $nationalHolidays[] = 'swissNationalDay';
+            $officialHolidays[] = 'swissNationalDay';
         }
-        $this->assertDefinedHolidays($nationalHolidays, self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**
-     * Tests if all national holidays in Zurich are defined by the provider class
+     * Tests if all regional holidays in Zurich (Switzerland) are defined by the provider class
      */
     public function testRegionalHolidays()
     {

--- a/tests/USA/ChristmasDayTest.php
+++ b/tests/USA/ChristmasDayTest.php
@@ -89,6 +89,6 @@ class ChristmasDayTest extends USABaseTestCase implements YasumiTestCaseInterfac
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/USA/ColumbusDayTest.php
+++ b/tests/USA/ColumbusDayTest.php
@@ -97,7 +97,7 @@ class ColumbusDayTest extends USABaseTestCase implements YasumiTestCaseInterface
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/USA/IndependenceDayTest.php
+++ b/tests/USA/IndependenceDayTest.php
@@ -108,7 +108,7 @@ class IndependenceDayTest extends USABaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/USA/LabourDayTest.php
+++ b/tests/USA/LabourDayTest.php
@@ -80,7 +80,7 @@ class LabourDayTest extends USABaseTestCase implements YasumiTestCaseInterface
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/USA/MartinLutherKingDayTest.php
+++ b/tests/USA/MartinLutherKingDayTest.php
@@ -82,7 +82,7 @@ class MartinLutherKingDayTest extends USABaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/USA/MemorialDayTest.php
+++ b/tests/USA/MemorialDayTest.php
@@ -97,7 +97,7 @@ class MemorialDayTest extends USABaseTestCase implements YasumiTestCaseInterface
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/USA/NewYearsDayTest.php
+++ b/tests/USA/NewYearsDayTest.php
@@ -88,6 +88,6 @@ class NewYearsDayTest extends USABaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/USA/ThanksgivingDayTest.php
+++ b/tests/USA/ThanksgivingDayTest.php
@@ -82,7 +82,7 @@ class ThanksgivingDayTest extends USABaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/USA/USATest.php
+++ b/tests/USA/USATest.php
@@ -25,9 +25,9 @@ class USATest extends USABaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in the USA are defined by the provider class
+     * Tests if all official holidays in the USA are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -40,7 +40,7 @@ class USATest extends USABaseTestCase
             'veteransDay',
             'thanksgivingDay',
             'christmasDay'
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/USA/VeteransDayTest.php
+++ b/tests/USA/VeteransDayTest.php
@@ -105,7 +105,7 @@ class VeteransDayTest extends USABaseTestCase implements YasumiTestCaseInterface
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/USA/WashingtonsBirthdayTest.php
+++ b/tests/USA/WashingtonsBirthdayTest.php
@@ -97,7 +97,7 @@ class WashingtonsBirthdayTest extends USABaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_NATIONAL
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Ukraine/ChristmasDayTest.php
+++ b/tests/Ukraine/ChristmasDayTest.php
@@ -67,6 +67,6 @@ class ChristmasDayTest extends UkraineBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ukraine/ConstitutionDayTest.php
+++ b/tests/Ukraine/ConstitutionDayTest.php
@@ -50,6 +50,6 @@ class ConstitutionDayTest extends UkraineBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, 2020, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, 2020, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ukraine/DefenderOfUkraineDayTest.php
+++ b/tests/Ukraine/DefenderOfUkraineDayTest.php
@@ -55,6 +55,6 @@ class DefenderOfUkraineDayTest extends UkraineBaseTestCase implements YasumiTest
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, 2020, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, 2020, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ukraine/EasterTest.php
+++ b/tests/Ukraine/EasterTest.php
@@ -60,6 +60,6 @@ class EasterTest extends UkraineBaseTestCase implements YasumiTestCaseInterface
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ukraine/IndependenceDayTest.php
+++ b/tests/Ukraine/IndependenceDayTest.php
@@ -50,6 +50,6 @@ class IndependenceDayTest extends UkraineBaseTestCase implements YasumiTestCaseI
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, 2020, Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, 2020, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ukraine/InternationalWomensDayTest.php
+++ b/tests/Ukraine/InternationalWomensDayTest.php
@@ -65,6 +65,6 @@ class InternationalWomensDayTest extends UkraineBaseTestCase implements YasumiTe
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ukraine/InternationalWorkersDayTest.php
+++ b/tests/Ukraine/InternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class InternationalWorkersDayTest extends UkraineBaseTestCase implements YasumiT
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Ukraine/NewYearsDayTest.php
+++ b/tests/Ukraine/NewYearsDayTest.php
@@ -67,6 +67,6 @@ class NewYearsDayTest extends UkraineBaseTestCase implements YasumiTestCaseInter
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ukraine/PentecostTest.php
+++ b/tests/Ukraine/PentecostTest.php
@@ -60,6 +60,6 @@ class PentecostTest extends UkraineBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Ukraine/SecondInternationalWorkersDayTest.php
+++ b/tests/Ukraine/SecondInternationalWorkersDayTest.php
@@ -57,7 +57,7 @@ class SecondInternationalWorkersDayTest extends UkraineBaseTestCase implements Y
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Ukraine/UkraineTest.php
+++ b/tests/Ukraine/UkraineTest.php
@@ -26,9 +26,9 @@ class UkraineTest extends UkraineBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in Ukraine are defined by the provider class
+     * Tests if all official holidays in Ukraine are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
@@ -42,7 +42,7 @@ class UkraineTest extends UkraineBaseTestCase
             'constitutionDay',
             'independenceDay',
             'defenderOfUkraineDay',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Ukraine/VictoryDayTest.php
+++ b/tests/Ukraine/VictoryDayTest.php
@@ -65,6 +65,6 @@ class VictoryDayTest extends UkraineBaseTestCase implements YasumiTestCaseInterf
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/UnitedKingdom/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/ChristmasDayTest.php
@@ -85,6 +85,6 @@ class ChristmasDayTest extends UnitedKingdomBaseTestCase implements YasumiTestCa
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/UnitedKingdom/GoodFridayTest.php
+++ b/tests/UnitedKingdom/GoodFridayTest.php
@@ -59,6 +59,6 @@ class GoodFridayTest extends UnitedKingdomBaseTestCase implements YasumiTestCase
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_NATIONAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/UnitedKingdom/UnitedKingdomTest.php
+++ b/tests/UnitedKingdom/UnitedKingdomTest.php
@@ -25,14 +25,14 @@ class UnitedKingdomTest extends UnitedKingdomBaseTestCase
     protected $year;
 
     /**
-     * Tests if all national holidays in the United Kingdom are defined by the provider class
+     * Tests if all official holidays in the United Kingdom are defined by the provider class
      */
-    public function testNationalHolidays()
+    public function testOfficialHolidays()
     {
         $this->assertDefinedHolidays([
             'goodFriday',
             'christmasDay',
-        ], self::REGION, $this->year, Holiday::TYPE_NATIONAL);
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/YasumiBase.php
+++ b/tests/YasumiBase.php
@@ -38,7 +38,7 @@ trait YasumiBase
      * @param string $provider               the holiday provider (i.e. country/state) for which the holidays need to be
      *                                       tested
      * @param int    $year                   holiday calendar year
-     * @param string $type                   The type of holiday. Use the following constants: TYPE_NATIONAL,
+     * @param string $type                   The type of holiday. Use the following constants: TYPE_OFFICIAL,
      *                                       TYPE_OBSERVANCE, TYPE_SEASON, TYPE_BANK or TYPE_OTHER.
      *
      * @throws \InvalidArgumentException
@@ -50,7 +50,7 @@ trait YasumiBase
         $holidays = Yasumi::create($provider, $year);
 
         switch ($type) {
-            case Holiday::TYPE_NATIONAL:
+            case Holiday::TYPE_OFFICIAL:
                 $holidays = new OfficialHolidaysFilter($holidays->getIterator());
                 break;
             case Holiday::TYPE_OBSERVANCE:


### PR DESCRIPTION
Renamed the holiday type NATIONAL to OFFICIAL. Subregions may have official holidays and the name NATIONAL doesn't suit these situations.