### PR TITLE
Fix Saxony (Germany) test for other holidays

### DIFF
--- a/tests/Germany/Saxony/SaxonyTest.php
+++ b/tests/Germany/Saxony/SaxonyTest.php
@@ -82,7 +82,13 @@ class SaxonyTest extends SaxonyBaseTestCase
      */
     public function testOtherHolidays()
     {
-        $this->assertDefinedHolidays(['repentanceAndPrayerDay'], self::REGION, $this->year, Holiday::TYPE_OTHER);
+        $holidays = [];
+
+        if ($this->year >= 1995) {
+            $holidays[] = 'repentanceAndPrayerDay';
+        }
+
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OTHER);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Generated random year (initial 1990) can sometimes be lower than
established holiday (Repentance and Prayer Day) date 1995 which causes
test to fail.