### PR TITLE
fix Japanese holiday name according to Japanese law.

### DIFF
--- a/src/Yasumi/Provider/Japan.php
+++ b/src/Yasumi/Provider/Japan.php
@@ -131,7 +131,7 @@ class Japan extends AbstractProvider
         if ($this->year >= 1948) {
             $this->addHoliday(new Holiday(
                 'childrensDay',
-                ['en_US' => 'Children\'s Day', 'ja_JP' => '子供の日'],
+                ['en_US' => 'Children\'s Day', 'ja_JP' => 'こどもの日'],
                 new DateTime("$this->year-5-5", new DateTimeZone($this->timezone)),
                 $this->locale
             ));
@@ -280,7 +280,7 @@ class Japan extends AbstractProvider
         if (null !== $date) {
             $this->addHoliday(new Holiday(
                 'greeneryDay',
-                ['en_US' => 'Greenery Day', 'ja_JP' => '緑の日'],
+                ['en_US' => 'Greenery Day', 'ja_JP' => 'みどりの日'],
                 $date,
                 $this->locale
             ));

--- a/tests/Japan/ChildrensDayTest.php
+++ b/tests/Japan/ChildrensDayTest.php
@@ -81,7 +81,7 @@ class ChildrensDayTest extends JapanBaseTestCase implements YasumiTestCaseInterf
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            [self::LOCALE => '子供の日']
+            [self::LOCALE => 'こどもの日']
         );
     }
 

--- a/tests/Japan/GreeneryDayTest.php
+++ b/tests/Japan/GreeneryDayTest.php
@@ -112,7 +112,7 @@ class GreeneryDayTest extends JapanBaseTestCase implements YasumiTestCaseInterfa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            [self::LOCALE => '緑の日']
+            [self::LOCALE => 'みどりの日']
         );
     }
 


### PR DESCRIPTION
Japanese "Green Day" and "Children's Day" use "Hiragana".
Because It is stipulated by Japanese law.
http://www8.cao.go.jp/chosei/shukujitsu/gaiyou.html