### PR TITLE
Spelling fix for sv_SE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 
 ### Fixed
+- Fixed spelling issue in the Swedish translation. [\#97](https://github.com/azuyalabs/yasumi/pull/97)
 
 ### Removed
 

--- a/src/Yasumi/data/translations/ascensionDay.php
+++ b/src/Yasumi/data/translations/ascensionDay.php
@@ -26,5 +26,5 @@ return [
     'nb_NO' => 'Kristi himmelfartsdag',
     'nl_BE' => 'Hemelvaart',
     'nl_NL' => 'Hemelvaart',
-    'sv_SE' => 'Kristi himmelsfärds dag',
+    'sv_SE' => 'Kristi himmelsfärdsdag',
 ];

--- a/tests/Sweden/AscensionDayTest.php
+++ b/tests/Sweden/AscensionDayTest.php
@@ -50,7 +50,7 @@ class AscensionDayTest extends SwedenBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(),
-            [self::LOCALE => 'Kristi himmelsfärds dag']
+            [self::LOCALE => 'Kristi himmelsfärdsdag']
         );
     }
 


### PR DESCRIPTION
The recommended spelling for Ascension Day in Swedish is _Kristi himmelsfärdsdag_.

Sources:
- [himmelsfärdsdag](https://svenska.se/saol/?id=1113054&pz=7) entry  in [Svenska Akademiens ordlista](https://en.wikipedia.org/wiki/Svenska_Akademiens_ordlista).
- [_Kristi Himmelsfärds Dag, Kristi himmelsfärds dag eller Kristi himmelsfärdsdag?_](http://www.sprakochfolkminnen.se/sprak/sprakradgivning/aktuellt-sprakrad/tidsbundna-granskade-rad/2016-04-27-kristi-himmelsfards-dag-kristi-himmelsfards-dag-eller-kristi-himmelsfardsdag.html) published by [Swedish Institute for Language and Folklore](https://en.wikipedia.org/wiki/Swedish_Institute_for_Language_and_Folklore).
