### PR TITLE
easter sunday and pentecost sunday are not nationwide german holidays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 - Fixed spelling issue in the Swedish translation. [\#97](https://github.com/azuyalabs/yasumi/pull/97)
+- Fixed German Easter Sunday and Pentecost Sunday holidays (not nationwide, only in Brandenburg). [\#100](https://github.com/azuyalabs/yasumi/pull/100)
 
 ### Removed
 

--- a/src/Yasumi/Provider/Germany.php
+++ b/src/Yasumi/Provider/Germany.php
@@ -47,12 +47,10 @@ class Germany extends AbstractProvider
         // Add common Christian holidays (common in Germany)
         $this->addHoliday($this->ascensionDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
 

--- a/src/Yasumi/Provider/Germany/Brandenburg.php
+++ b/src/Yasumi/Provider/Germany/Brandenburg.php
@@ -43,6 +43,10 @@ class Brandenburg extends Germany
     {
         parent::initialize();
 
+        // Add specific Christian holidays
+        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
+
         // Add custom Christian holidays
         $this->calculateReformationDay();
     }

--- a/tests/Germany/BadenWurttemberg/BadenWurttembergTest.php
+++ b/tests/Germany/BadenWurttemberg/BadenWurttembergTest.php
@@ -32,11 +32,9 @@ class BadenWurttembergTest extends BadenWurttembergBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/Bavaria/BavariaTest.php
+++ b/tests/Germany/Bavaria/BavariaTest.php
@@ -32,11 +32,9 @@ class BavariaTest extends BavariaBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/Berlin/BerlinTest.php
+++ b/tests/Germany/Berlin/BerlinTest.php
@@ -32,11 +32,9 @@ class BerlinTest extends BerlinBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/Bremen/BremenTest.php
+++ b/tests/Germany/Bremen/BremenTest.php
@@ -32,11 +32,9 @@ class BremenTest extends BremenBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/Hamburg/HamburgTest.php
+++ b/tests/Germany/Hamburg/HamburgTest.php
@@ -32,11 +32,9 @@ class HamburgTest extends HamburgBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/Hesse/HesseTest.php
+++ b/tests/Germany/Hesse/HesseTest.php
@@ -32,11 +32,9 @@ class HesseTest extends HesseBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/LowerSaxony/LowerSaxonyTest.php
+++ b/tests/Germany/LowerSaxony/LowerSaxonyTest.php
@@ -32,11 +32,9 @@ class LowerSaxonyTest extends LowerSaxonyBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/MecklenburgWesternPomerania/MecklenburgWesternPomeraniaTest.php
+++ b/tests/Germany/MecklenburgWesternPomerania/MecklenburgWesternPomeraniaTest.php
@@ -32,11 +32,9 @@ class MecklenburgWesternPomeraniaTest extends MecklenburgWesternPomeraniaBaseTes
         $holidays = [
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'christmasDay',
             'secondChristmasDay'

--- a/tests/Germany/NorthRhineWestphalia/NorthRhineWestphaliaTest.php
+++ b/tests/Germany/NorthRhineWestphalia/NorthRhineWestphaliaTest.php
@@ -32,11 +32,9 @@ class NorthRhineWestphaliaTest extends NorthRhineWestphaliaBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/RhinelandPalatinate/RhinelandPalatinateTest.php
+++ b/tests/Germany/RhinelandPalatinate/RhinelandPalatinateTest.php
@@ -32,11 +32,9 @@ class RhinelandPalatinateTest extends RhinelandPalatinateBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/Saarland/SaarlandTest.php
+++ b/tests/Germany/Saarland/SaarlandTest.php
@@ -32,11 +32,9 @@ class SaarlandTest extends SaarlandBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/Saxony/SaxonyTest.php
+++ b/tests/Germany/Saxony/SaxonyTest.php
@@ -32,11 +32,9 @@ class SaxonyTest extends SaxonyBaseTestCase
         $holidays = [
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'christmasDay',
             'secondChristmasDay'

--- a/tests/Germany/SaxonyAnhalt/SaxonyAnhaltTest.php
+++ b/tests/Germany/SaxonyAnhalt/SaxonyAnhaltTest.php
@@ -32,11 +32,9 @@ class SaxonyAnhaltTest extends SaxonyAnhaltBaseTestCase
         $holidays = [
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'christmasDay',
             'secondChristmasDay'

--- a/tests/Germany/SchleswigHolstein/SchleswigHolsteinTest.php
+++ b/tests/Germany/SchleswigHolstein/SchleswigHolsteinTest.php
@@ -32,11 +32,9 @@ class SchleswigHolsteinTest extends SchleswigHolsteinBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',

--- a/tests/Germany/Thuringia/ThuringiaTest.php
+++ b/tests/Germany/Thuringia/ThuringiaTest.php
@@ -32,11 +32,9 @@ class ThuringiaTest extends ThuringiaBaseTestCase
         $holidays = [
             'newYearsDay',
             'goodFriday',
-            'easter',
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
-            'pentecost',
             'pentecostMonday',
             'christmasDay',
             'secondChristmasDay'


### PR DESCRIPTION
They are holidays only in Brandenburg, see https://de.wikipedia.org/wiki/Gesetzliche_Feiertage_in_Deutschland#%C3%9Cbersicht_aller_gesetzlichen_Feiertage