### PR TITLE
Get summer/winter time from PHP timezone library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 ### Changed
+- Summer/winter time is now fetched from PHP's tz database. [\#103](https://github.com/azuyalabs/yasumi/pull/103)
 
 ### Fixed
 - Fixed spelling issue in the Swedish translation. [\#97](https://github.com/azuyalabs/yasumi/pull/97)

--- a/src/Yasumi/Provider/CommonHolidays.php
+++ b/src/Yasumi/Provider/CommonHolidays.php
@@ -355,4 +355,98 @@ trait CommonHolidays
             $type
         );
     }
+
+    /**
+     * Calculates daylight saving time transitions.
+     *
+     * Daylight saving time is the practice of advancing clocks by one hour during summer months so evening daylight lasts even longer, while sacrificing normal sunrise times.
+     *
+     * The date of transition between standard time and daylight saving time differs from country to country and sometimes from year to year. Most countries outside Europe and North America do not observe daylight saving time.
+     *
+     * On the northern hemisphere, summer time starts around March/April. On the southern hemisphere it happens 6 months later.
+     *
+     * @param int    $year     the year for which Easter needs to be calculated
+     * @param string $timezone the timezone in which Easter is celebrated
+     * @param bool   $summer   whether to calculate the start of summer or winter time
+     */
+    protected function calculateSummerWinterTime($year, $timezone, $summer)
+    {
+        $zone = new DateTimeZone($timezone);
+
+        $transitions = $zone->getTransitions(mktime(0, 0, 0, 1, 1, $year), mktime(23, 59, 59, 12, 31, $year));
+
+        $transition = array_shift($transitions);
+        $dst = $transition['isdst'];
+
+        foreach ($transitions as $transition) {
+            if ($transition['isdst'] !== $dst && $transition['isdst'] === $summer) {
+                return new DateTime(substr($transition['time'], 0, 10), $zone);
+            }
+            $dst = $transition['isdst'];
+        }
+
+        return null;
+    }
+
+    /**
+     * The beginning of summer time.
+     *
+     * Summer time is also known as daylight save time.
+     *
+     * @param int    $year     the year for which summer time need to be created
+     * @param string $timezone the timezone in which summer time transition occurs
+     * @param string $locale   the locale for which summer time need to be displayed in.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @return \Yasumi\Holiday
+     *
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \InvalidArgumentException
+     */
+    public function summerTime($year, $timezone, $locale, $type = Holiday::TYPE_SEASON)
+    {
+        $date = $this->calculateSummerWinterTime($year, $timezone, true);
+
+        if ($date) {
+            return new Holiday(
+                'summerTime',
+                [],
+                $date,
+                $locale,
+                $type
+            );
+        }
+    }
+
+    /**
+     * The beginning of winter time.
+     *
+     * Winter time is also known as standard time.
+     *
+     * @param int    $year     the year for which summer time need to be created
+     * @param string $timezone the timezone in which summer time transition occurs
+     * @param string $locale   the locale for which summer time need to be displayed in.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @return \Yasumi\Holiday
+     *
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \InvalidArgumentException
+     */
+    public function winterTime($year, $timezone, $locale, $type = Holiday::TYPE_SEASON)
+    {
+        $date = $this->calculateSummerWinterTime($year, $timezone, false);
+
+        if ($date) {
+            return new Holiday(
+                'winterTime',
+                [],
+                $date,
+                $locale,
+                $type
+            );
+        }
+    }
 }

--- a/src/Yasumi/Provider/CommonHolidays.php
+++ b/src/Yasumi/Provider/CommonHolidays.php
@@ -373,14 +373,14 @@ trait CommonHolidays
     {
         $zone = new DateTimeZone($timezone);
 
-        $transitions = $zone->getTransitions(mktime(0, 0, 0, 1, 1, $year), mktime(23, 59, 59, 12, 31, $year));
+        $transitions = $zone->getTransitions(\mktime(0, 0, 0, 1, 1, $year), \mktime(23, 59, 59, 12, 31, $year));
 
-        $transition = array_shift($transitions);
+        $transition = \array_shift($transitions);
         $dst = $transition['isdst'];
 
         foreach ($transitions as $transition) {
             if ($transition['isdst'] !== $dst && $transition['isdst'] === $summer) {
-                return new DateTime(substr($transition['time'], 0, 10), $zone);
+                return new DateTime(\substr($transition['time'], 0, 10), $zone);
             }
             $dst = $transition['isdst'];
         }

--- a/src/Yasumi/Provider/Netherlands.php
+++ b/src/Yasumi/Provider/Netherlands.php
@@ -176,33 +176,14 @@ class Netherlands extends AbstractProvider
             Holiday::TYPE_OBSERVANCE
         ));
 
-        /**
-         * Summertime.
-         *
-         * Start of Summertime takes place on the last sunday of march. (Summertime is the common name for Daylight Saving
-         * Time).
-         */
-        $this->addHoliday(new Holiday(
-            'summerTime',
-            ['en_US' => 'Summertime', 'nl_NL' => 'Zomertijd'],
-            new DateTime("last sunday of march $this->year", new DateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_SEASON
-        ));
-
-        /**
-         * Wintertime.
-         *
-         * Start of Wintertime takes place on the last sunday of october. (Wintertime is actually the end of Summertime.
-         * Summertime is the common name for Daylight Saving Time).
-         */
-        $this->addHoliday(new Holiday(
-            'winterTime',
-            ['en_US' => 'Wintertime', 'nl_NL' => 'Wintertijd'],
-            new DateTime("last sunday of october $this->year", new DateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_SEASON
-        ));
+        $summerTime = $this->summerTime($this->year, $this->timezone, $this->locale);
+        if ($summerTime) {
+            $this->addHoliday($summerTime);
+        }
+        $winterTime = $this->winterTime($this->year, $this->timezone, $this->locale);
+        if ($winterTime) {
+            $this->addHoliday($winterTime);
+        }
 
         /**
          * Carnival.

--- a/src/Yasumi/data/translations/summerTime.php
+++ b/src/Yasumi/data/translations/summerTime.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+// Translations for daylight saving time start.
+return [
+    'en_US' => 'Summertime',
+    'nl_NL' => 'Zomertijd',
+];

--- a/src/Yasumi/data/translations/winterTime.php
+++ b/src/Yasumi/data/translations/winterTime.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+// Translations for daylight saving time end.
+return [
+    'en_US' => 'Wintertime',
+    'nl_NL' => 'Wintertijd',
+];

--- a/tests/Netherlands/NetherlandsTest.php
+++ b/tests/Netherlands/NetherlandsTest.php
@@ -66,7 +66,8 @@ class NetherlandsTest extends NetherlandsBaseTestCase
      */
     public function testSeasonalHolidays()
     {
-        $this->assertDefinedHolidays(['summerTime', 'winterTime'], self::REGION, $this->year, Holiday::TYPE_SEASON);
+        $year = $this->generateRandomYear(1978, 2037);
+        $this->assertDefinedHolidays(['summerTime', 'winterTime'], self::REGION, $year, Holiday::TYPE_SEASON);
     }
 
     /**

--- a/tests/Netherlands/SummertimeTest.php
+++ b/tests/Netherlands/SummertimeTest.php
@@ -32,7 +32,17 @@ class SummertimeTest extends NetherlandsBaseTestCase implements YasumiTestCaseIn
      */
     public function testSummertime()
     {
-        $year = $this->generateRandomYear();
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $this->generateRandomYear(1946, 1976));
+
+        $year = $this->generateRandomYear(1977, 1980);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("first sunday of april $year", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $year = $this->generateRandomYear(1981, 2036);
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
@@ -49,7 +59,7 @@ class SummertimeTest extends NetherlandsBaseTestCase implements YasumiTestCaseIn
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(),
+            $this->generateRandomYear(1978, 2037),
             [self::LOCALE => 'Zomertijd']
         );
     }
@@ -59,6 +69,6 @@ class SummertimeTest extends NetherlandsBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_SEASON);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(1978, 2037), Holiday::TYPE_SEASON);
     }
 }

--- a/tests/Netherlands/WintertimeTest.php
+++ b/tests/Netherlands/WintertimeTest.php
@@ -32,7 +32,17 @@ class WintertimeTest extends NetherlandsBaseTestCase implements YasumiTestCaseIn
      */
     public function testWintertime()
     {
-        $year = $this->generateRandomYear();
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $this->generateRandomYear(1946, 1976));
+
+        $year = $this->generateRandomYear(1979, 1995);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("last sunday of september $year", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $year = $this->generateRandomYear(1996, 2037);
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
@@ -49,7 +59,7 @@ class WintertimeTest extends NetherlandsBaseTestCase implements YasumiTestCaseIn
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(),
+            $this->generateRandomYear(1978, 2037),
             [self::LOCALE => 'Wintertijd']
         );
     }
@@ -59,6 +69,6 @@ class WintertimeTest extends NetherlandsBaseTestCase implements YasumiTestCaseIn
      */
     public function testHolidayType()
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_SEASON);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(1978, 2037), Holiday::TYPE_SEASON);
     }
 }


### PR DESCRIPTION
The date of transition to/from daylight saving time, and whether daylight saving time has been used at all, has changed over the years. This information is available in the tz (Olson) database that is included in PHP.

This PR makes Yasumi use the tz database for calculating the transitions. This works for any timezone that observes daylight saving time.

It seems that PHP currently only supports years until 2037 (when Unix timestamps exceed 31 bits), but this will likely be fixed in due time, if daylight saving time exists at all at that time.