### PR TITLE
assertNotHoliday() skips rest of test

### DIFF
--- a/tests/YasumiBase.php
+++ b/tests/YasumiBase.php
@@ -123,14 +123,11 @@ trait YasumiBase
      */
     public function assertNotHoliday($provider, $shortName, $year)
     {
-        $this->expectException(\TypeError::class);
-
         $holidays = Yasumi::create($provider, $year);
         $holiday  = $holidays->getHoliday($shortName);
 
         $this->assertInstanceOf('Yasumi\Provider\\' . \str_replace('/', '\\', $provider), $holidays);
         $this->assertNull($holiday);
-        $this->assertFalse($holidays->isHoliday($holiday));
 
         unset($holiday, $holidays);
     }


### PR DESCRIPTION
If you add `assertNotHoliday()` to a test function, the rest of the test is skipped, because it intentionally throws an exception. This is rather surprising/confusing.