### PR TITLE
Skip AbstractProvider when generating provider list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixed spelling issues in the Danish translation. [\#96](https://github.com/azuyalabs/yasumi/pull/96)
 - Fixed German Easter Sunday and Pentecost Sunday holidays (not nationwide, only in Brandenburg). [\#100](https://github.com/azuyalabs/yasumi/pull/100)
 - Fixed BetweenFilter to ignore time part and timezone. [\#101](https://github.com/azuyalabs/yasumi/pull/101)
+- Fixed bug in provider list generation related to variable order of files returned by the filesystem [\#107](https://github.com/azuyalabs/yasumi/pull/107)
 
 ### Removed
 

--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -243,7 +243,7 @@ class Yasumi
             $class = new ReflectionClass(\sprintf('Yasumi\Provider\%s', \str_replace('/', '\\', $provider)));
 
             $key = 'ID';
-            if ($class->hasConstant($key)) {
+            if ($class->isSubclassOf('Yasumi\Provider\AbstractProvider') && $class->hasConstant($key)) {
                 $providers[\strtoupper($class->getConstant($key))] = $provider;
             }
         }

--- a/tests/Base/YasumiTest.php
+++ b/tests/Base/YasumiTest.php
@@ -302,6 +302,8 @@ class YasumiTest extends PHPUnit_Framework_TestCase
         $this->assertNotEmpty($providers);
         $this->assertInternalType('array', $providers);
         $this->assertContains('Netherlands', $providers);
+        $this->assertEquals('USA', $providers['US']);
+        $this->assertNotContains('AbstractProvider', $providers);
     }
 
     /**


### PR DESCRIPTION
In some cases, when filesystem iterator returned `AbstractProvider.php` after `USA.php`, provider list generator returned `AbstractProvider` as the provider for USA, as abstract provider has the `ID` constant set to `US` (I'm unsure why it has this constant at all). The mechanism is simple: loop checks `USA.php`, adds `'US' => 'USA'` to the array, then checks AbstractProvider, and overwrites the USA provider by adding `'US' => 'AbstractProvider'` to the output.

To overcome this issue, I've expanded the condition checking if the class is a proper provider by checking if it's a subclass of `AbstractProvider`. That's why AbstractProvider won't be taken into consideration at all.