### PR TITLE
Add Day of Reformation as new holiday for Hamburg (DE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 - Added Reformation Day as offical holiday since 2018 in Schleswig-Holstein (Germany). [#106](https://github.com/azuyalabs/yasumi/pull/106)
+- Added Day of Reformation as offical holiday since 2018 in Hamburg (Germany). [#108](https://github.com/azuyalabs/yasumi/pull/108)
 
 ### Changed
 - Summer/winter time is now fetched from PHP's tz database. [\#103](https://github.com/azuyalabs/yasumi/pull/103)

--- a/src/Yasumi/Provider/Germany/Hamburg.php
+++ b/src/Yasumi/Provider/Germany/Hamburg.php
@@ -12,6 +12,7 @@
 
 namespace Yasumi\Provider\Germany;
 
+use Yasumi\Holiday;
 use Yasumi\Provider\Germany;
 
 /**
@@ -31,4 +32,44 @@ class Hamburg extends Germany
      * country or sub-region.
      */
     const ID = 'DE-HH';
+
+    /**
+     * Initialize holidays for Schleswig-Holstein (Germany).
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateDayOfReformation();
+    }
+
+    /**
+     * Since 2018 Hamburg celebrates the "Day of Reformation".
+     * It is not called "Reformation Day" like other states to prevent church-based associations
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     */
+    private function calculateDayOfReformation()
+    {
+        if ($this->year < 2018) {
+            return;
+        }
+
+        $this->addHoliday(
+            new Holiday(
+                'dayOfReformation',
+                [],
+                new \DateTime("{$this->year}-10-31", new \DateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_OFFICIAL
+            )
+        );
+    }
 }

--- a/src/Yasumi/data/translations/dayOfReformation.php
+++ b/src/Yasumi/data/translations/dayOfReformation.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+// Translations for Day of Reformation
+return [
+    'de_DE' => 'Tag der Reformation',
+    'en_US' => 'Day of Reformation',
+];

--- a/tests/Germany/Hamburg/DayOfReformationTest.php
+++ b/tests/Germany/Hamburg/DayOfReformationTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Germany\SchleswigHolstein;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\Germany\Hamburg\HamburgBaseTestCase;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Reformation Day in Schleswig-Holstein (Germany).
+ */
+class DayOfReformationTest extends HamburgBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = 'dayOfReformation';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 2018;
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int      $year     the year for which the holiday defined in this test needs to be tested
+     * @param DateTime $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year   = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+            $data[] = [$year, new DateTime("$year-10-31", new DateTimeZone(self::TIMEZONE))];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Tag der Reformation']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}


### PR DESCRIPTION
As an addition to #106

Beginning in 2018 the Day of Reformation is an official holiday in Hamburg.