### PR TITLE
Australian Public Holidays

### DIFF
--- a/src/Yasumi/Provider/Australia.php
+++ b/src/Yasumi/Provider/Australia.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\Provider;
@@ -42,11 +43,9 @@ class Australia extends AbstractProvider
     public function initialize()
     {
         // Official Holidays
-        $this->calculateAustraliaDay();
         $this->calculateNewYearHolidays();
+        $this->calculateAustraliaDay();
         $this->calculateAnzacDay();
-        //$this->calculateQueensBirthday();
-        //$this->calculateLabourDay();
 
         // Add Christian holidays
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
@@ -76,7 +75,7 @@ class Australia extends AbstractProvider
     {
         $date = new DateTime("$this->year-01-26", new DateTimeZone($this->timezone));
 
-        $this->calculateHoliday('australiaDay', [], $date);
+        $this->calculateHoliday('australiaDay', ['en_AU' => 'Australia Day'], $date);
     }
 
     /**
@@ -87,6 +86,7 @@ class Australia extends AbstractProvider
      * @param string|DateTime $date
      * @param bool            $moveFromSaturday
      * @param bool            $moveFromSunday
+     * @param string		  $type
      *
      * @throws \Yasumi\Exception\InvalidDateException
      * @throws \InvalidArgumentException
@@ -98,19 +98,17 @@ class Australia extends AbstractProvider
         array $names = [],
         $date,
         $moveFromSaturday = true,
-        $moveFromSunday = true
+        $moveFromSunday = true,
+        $type = Holiday::TYPE_OFFICIAL
     ) {
-        $holidayDate = $date instanceof \DateTimeInterface ? $date : new \DateTime(
-            $date,
-            new \DateTimeZone($this->timezone)
-        );
+        $holidayDate = ($date instanceof DateTime) ? $date : new DateTime($date, new DateTimeZone($this->timezone));
 
         $day = (int)$holidayDate->format('w');
         if (($day === 0 && $moveFromSunday) || ($day === 6 && $moveFromSaturday)) {
             $holidayDate = $holidayDate->add($day === 0 ? new DateInterval('P1D') : new DateInterval('P2D'));
         }
 
-        $this->addHoliday(new Holiday($shortName, $names, $holidayDate, $this->locale));
+        $this->addHoliday(new Holiday($shortName, $names, $holidayDate, $this->locale, $type));
     }
 
     /**
@@ -118,8 +116,8 @@ class Australia extends AbstractProvider
      *
      * New Year's Day is on January 1 and is the first day of a new year in the Gregorian calendar,
      * which is used in Australia and many other countries. Due to its geographical position close
-     * to the International Date Line, Australia is one of the first countries in the world to
-     * welcome the New Year.
+     * to the International Date Line, Australia is one of the first countries in the world to welcome the New Year.
+     * If it falls on a weekend an additional public holiday is held on the next available weekday.
      *
      * @link https://www.timeanddate.com/holidays/australia/new-year-day
      *
@@ -129,11 +127,18 @@ class Australia extends AbstractProvider
      */
     public function calculateNewYearHolidays()
     {
-        $this->calculateHoliday(
-            'newYearsDay',
-            [],
-            new DateTime("$this->year-01-01", new DateTimeZone($this->timezone))
-        );
+        $newyearsday = new DateTime("$this->year-01-01", new DateTimeZone($this->timezone));
+        $this->calculateHoliday('newYearsDay', ['en_AU' => 'New Year\'s Day'], $newyearsday, false, false);
+        switch ($newyearsday->format('w')) {
+            case 0: // sunday
+                $newyearsday->add(new DateInterval('P1D'));
+                $this->calculateHoliday('newYearsHoliday', ['en_AU' => 'New Year\'s Holiday'], $newyearsday, false, false);
+                break;
+            case 6: // saturday
+                $newyearsday->add(new DateInterval('P2D'));
+                $this->calculateHoliday('newYearsHoliday', ['en_AU' => 'New Year\'s Holiday'], $newyearsday, false, false);
+                break;
+        }
     }
 
     /**
@@ -141,7 +146,9 @@ class Australia extends AbstractProvider
      *
      * Anzac Day is a national day of remembrance in Australia and New Zealand that broadly commemorates all Australians
      * and New Zealanders "who served and died in all wars, conflicts, and peacekeeping operations"
-     * Observed on 25 April each year.
+     * Observed on 25 April each year. Unlike most other Australian public holidays, If it falls on a weekend it is NOT moved
+     * to the next available weekday, nor is there an additional public holiday held. However, if it clashes with Easter,
+     * an additional public holiday is held for Easter.
      *
      * @link https://en.wikipedia.org/wiki/Anzac_Day
      * @link https://www.timeanddate.com/holidays/australia/anzac-day
@@ -157,15 +164,21 @@ class Australia extends AbstractProvider
         }
 
         $date = new DateTime("$this->year-04-25", new DateTimeZone($this->timezone));
-
-        $this->calculateHoliday('anzacDay', [], $date);
+        $this->calculateHoliday('anzacDay', ['en_AU' => 'ANZAC Day'], $date, false, false);
+        $easter = $this->calculateEaster($this->year, $this->timezone);
+        $easterMonday = $this->calculateEaster($this->year, $this->timezone);
+        $easterMonday->add(new DateInterval('P1D'));
+        if (($date->format('Y-m-d') === $easter->format('Y-m-d')) || ($date->format('Y-m-d') === $easterMonday->format('Y-m-d'))) {
+            $easterMonday->add(new DateInterval('P1D'));
+            $this->calculateHoliday('easterTuesday', ['en_AU' => 'Easter Tuesday'], $easterMonday, false, false);
+        }
     }
 
     /**
      * Christmas Day / Boxing Day.
      *
      * Christmas day, and Boxing day are public holidays in Australia,
-     * if they fall on the weekend they are moved to the next available weekday.
+     * if they fall on the weekend an additional public holiday is held on the next available weekday.
      *
      * @link https://www.timeanddate.com/holidays/australia/christmas-day-holiday
      *
@@ -177,59 +190,24 @@ class Australia extends AbstractProvider
     {
         $christmasDay = new DateTime("$this->year-12-25", new DateTimeZone($this->timezone));
         $boxingDay    = new DateTime("$this->year-12-26", new DateTimeZone($this->timezone));
+        $this->calculateHoliday('christmasDay', ['en_AU' => 'Christmas Day'], $christmasDay, false, false);
+        $this->calculateHoliday('secondChristmasDay', ['en_AU' => 'Boxing Day'], $boxingDay, false, false);
 
         switch ($christmasDay->format('w')) {
             case 0: // sunday
-                $christmasDay->add(new \DateInterval('P2D'));
+                $christmasDay->add(new DateInterval('P2D'));
+                $this->calculateHoliday('christmasHoliday', ['en_AU' => 'Christmas Holiday'], $christmasDay, false, false);
                 break;
             case 5: // friday
-                $boxingDay->add(new \DateInterval('P2D'));
+                $boxingDay->add(new DateInterval('P2D'));
+                $this->calculateHoliday('secondChristmasHoliday', ['en_AU' => 'Boxing Day Holiday'], $boxingDay, false, false);
                 break;
             case 6: // saturday
-                $christmasDay->add(new \DateInterval('P2D'));
-                $boxingDay->add(new \DateInterval('P2D'));
+                $christmasDay->add(new DateInterval('P2D'));
+                $boxingDay->add(new DateInterval('P2D'));
+                $this->calculateHoliday('christmasHoliday', ['en_AU' => 'Christmas Holiday'], $christmasDay, false, false);
+                $this->calculateHoliday('secondChristmasHoliday', ['en_AU' => 'Boxing Day Holiday'], $boxingDay, false, false);
                 break;
         }
-        $this->calculateHoliday('christmasDay', [], $christmasDay);
-        $this->calculateHoliday('secondChristmasDay', [], $boxingDay);
-    }
-
-    /**
-     * Queens Birthday.
-     *
-     * The Queen's Birthday is an Australian public holiday but the date varies across
-     * states and territories. Australia celebrates this holiday because it is a constitutional
-     * monarchy, with the English monarch as head of state.
-     *
-     * Her actual birthday is on April 21, but it's celebrated as a public holiday on the second Monday of June.
-     *  (Except QLD & WA)
-     *
-     * @link https://www.timeanddate.com/holidays/australia/queens-birthday
-     *
-     * @throws \InvalidArgumentException
-     * @throws \Exception
-     */
-    public function calculateQueensBirthday()
-    {
-        $this->calculateHoliday(
-            'queensBirthday',
-            ['en_AU' => 'Queens Birthday'],
-            'second monday of june ' . $this->year,
-            false,
-            false
-        );
-    }
-
-    /**
-     * @link https://www.timeanddate.com/holidays/australia/labour-day
-     *
-     * @throws \InvalidArgumentException
-     * @throws \Yasumi\Exception\UnknownLocaleException
-     */
-    public function calculateLabourDay()
-    {
-        $date = new DateTime('first Monday in October' . " $this->year", new DateTimeZone($this->timezone));
-
-        $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));
     }
 }

--- a/src/Yasumi/Provider/Australia/ACT.php
+++ b/src/Yasumi/Provider/Australia/ACT.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia;
+
+/**
+ * Provider for all holidays in Australian Capital Territory (Australia).
+ *
+ */
+class ACT extends Australia
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    const ID = 'AU-ACT';
+
+    public $timezone = 'Australia/ACT';
+
+    /**
+     * Initialize holidays for Australian Capital Territory (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->addHoliday($this->easterSunday($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
+        $this->calculateQueensBirthday();
+        $this->calculateLabourDay();
+        $this->calculateCanberraDay();
+        $this->calculateReconciliationDay();
+    }
+
+    public function calculateCanberraDay()
+    {
+        if ($this->year < 2007) {
+            $date = new DateTime("third monday of march $this->year", new DateTimeZone($this->timezone));
+        } else {
+            $date = new DateTime("second monday of march $this->year", new DateTimeZone($this->timezone));
+        }
+        $this->addHoliday(new Holiday('canberraDay', ['en_AU' => 'Canberra Day'], $date, $this->locale));
+    }
+    
+    public function calculateReconciliationDay()
+    {
+        if ($this->year < 2018) {
+            return;
+        } else {
+            $date = new DateTime($this->year."-05-27", new DateTimeZone($this->timezone));
+            $day = (int)$date->format('w');
+            if ($day !== 1) {
+                $date = $date->add($day === 0 ? new DateInterval('P1D') : new DateInterval('P'.(8-$day).'D'));
+            }
+            $this->addHoliday(new Holiday('reconciliationDay', ['en_AU' => 'Reconciliation Day'], $date, $this->locale));
+        }
+    }
+    
+    public function calculateLabourDay()
+    {
+        $date = new DateTime("first monday of october $this->year", new DateTimeZone($this->timezone));
+
+        $this->addHoliday(new Holiday('labourDay', ['en_AU' => 'Labour Day'], $date, $this->locale));
+    }
+
+    /**
+     * Easter Saturday.
+     *
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @link http://en.wikipedia.org/wiki/Easter
+     *
+     * @param int    $year     the year for which Easter Saturday need to be created
+     * @param string $timezone the timezone in which Easter Saturday is celebrated
+     * @param string $locale   the locale for which Easter Saturday need to be displayed in.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @return \Yasumi\Holiday
+     *
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function easterSaturday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
+    {
+        return new Holiday(
+            'easterSaturday',
+            ['en_AU' => 'Easter Saturday'],
+            $this->calculateEaster($year, $timezone)->sub(new DateInterval('P1D')),
+            $locale,
+            $type
+        );
+    }
+
+    /**
+     * Easter Sunday.
+     *
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @link http://en.wikipedia.org/wiki/Easter
+     *
+     * @param int    $year     the year for which Easter Saturday need to be created
+     * @param string $timezone the timezone in which Easter Saturday is celebrated
+     * @param string $locale   the locale for which Easter Saturday need to be displayed in.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @return \Yasumi\Holiday
+     *
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function easterSunday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
+    {
+        return new Holiday(
+            'easter',
+            ['en_AU' => 'Easter Sunday'],
+            $this->calculateEaster($year, $timezone),
+            $locale,
+            $type
+        );
+    }
+
+    /**
+     * Queens Birthday.
+     *
+     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * states and territories. Australia celebrates this holiday because it is a constitutional
+     * monarchy, with the English monarch as head of state.
+     *
+     * Her actual birthday is on April 21, but it's celebrated as a public holiday on the second Monday of June.
+     *  (Except QLD & WA)
+     *
+     * @link https://www.timeanddate.com/holidays/australia/queens-birthday
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateQueensBirthday()
+    {
+        $this->calculateHoliday(
+            'queensBirthday',
+            ['en_AU' => "Queen's Birthday"],
+            'second monday of june ' . $this->year,
+            false,
+            false
+        );
+    }
+}

--- a/src/Yasumi/Provider/Australia/NSW.php
+++ b/src/Yasumi/Provider/Australia/NSW.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia;
+
+/**
+ * Provider for all holidays in New South Wales (Australia).
+ *
+ */
+class NSW extends Australia
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    const ID = 'AU-NSW';
+
+    public $timezone = 'Australia/NSW';
+
+    /**
+     * Initialize holidays for New South Wales (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->addHoliday(new Holiday('easter', ['en_AU' => 'Easter Sunday'], $this->calculateEaster($this->year, $this->timezone), $this->locale));
+        $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
+        $this->calculateQueensBirthday();
+        $this->calculateLabourDay();
+        $this->calculateBankHoliday();
+    }
+
+    public function calculateLabourDay()
+    {
+        $date = new DateTime("first monday of october $this->year", new DateTimeZone($this->timezone));
+
+        $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));
+    }
+
+    /**
+     * Easter Saturday.
+     *
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @link http://en.wikipedia.org/wiki/Easter
+     *
+     * @param int    $year     the year for which Easter Saturday need to be created
+     * @param string $timezone the timezone in which Easter Saturday is celebrated
+     * @param string $locale   the locale for which Easter Saturday need to be displayed in.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @return \Yasumi\Holiday
+     *
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function easterSaturday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
+    {
+        return new Holiday(
+            'easterSaturday',
+            ['en_AU' => 'Easter Saturday'],
+            $this->calculateEaster($year, $timezone)->sub(new DateInterval('P1D')),
+            $locale,
+            $type
+        );
+    }
+
+    /**
+     * Queens Birthday.
+     *
+     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * states and territories. Australia celebrates this holiday because it is a constitutional
+     * monarchy, with the English monarch as head of state.
+     *
+     * Her actual birthday is on April 21, but it's celebrated as a public holiday on the second Monday of June.
+     *  (Except QLD & WA)
+     *
+     * @link https://www.timeanddate.com/holidays/australia/queens-birthday
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateQueensBirthday()
+    {
+        $this->calculateHoliday(
+            'queensBirthday',
+            ['en_AU' => "Queen's Birthday"],
+            'second monday of june ' . $this->year,
+            false,
+            false
+        );
+    }
+    
+    /**
+     * Bank Holiday.
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateBankHoliday()
+    {
+        $this->calculateHoliday(
+            'bankHoliday',
+            ['en_AU' => 'Bank Holiday'],
+            'first monday of august '. $this->year,
+            false,
+            false,
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/src/Yasumi/Provider/Australia/NT.php
+++ b/src/Yasumi/Provider/Australia/NT.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia;
+
+/**
+ * Provider for all holidays in Northern Territory (Australia).
+ *
+ */
+class NT extends Australia
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    const ID = 'AU-NT';
+
+    public $timezone = 'Australia/North';
+
+    /**
+     * Initialize holidays for Northern Territory (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
+        $this->calculateQueensBirthday();
+        $this->calculateMayDay();
+        $this->calculatePicnicDay();
+    }
+
+    public function calculateMayDay()
+    {
+        $date = new DateTime("first monday of may $this->year", new DateTimeZone($this->timezone));
+
+        $this->addHoliday(new Holiday('mayDay', ['en_AU' => 'May Day'], $date, $this->locale));
+    }
+
+    /**
+     * Picnic Day
+     *
+     * @link https://en.wikipedia.org/wiki/Picnic_Day_(Australian_holiday)
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculatePicnicDay()
+    {
+        $this->calculateHoliday(
+            'picnicDay',
+            ['en_AU' => 'Picnic Day'],
+            'first monday of august ' . $this->year,
+            false,
+            false
+        );
+    }
+    
+    /**
+     * Easter Saturday.
+     *
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @link http://en.wikipedia.org/wiki/Easter
+     *
+     * @param int    $year     the year for which Easter Saturday need to be created
+     * @param string $timezone the timezone in which Easter Saturday is celebrated
+     * @param string $locale   the locale for which Easter Saturday need to be displayed in.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @return \Yasumi\Holiday
+     *
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function easterSaturday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
+    {
+        return new Holiday(
+            'easterSaturday',
+            ['en_AU' => 'Easter Saturday'],
+            $this->calculateEaster($year, $timezone)->sub(new DateInterval('P1D')),
+            $locale,
+            $type
+        );
+    }
+
+    /**
+     * Queens Birthday.
+     *
+     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * states and territories. Australia celebrates this holiday because it is a constitutional
+     * monarchy, with the English monarch as head of state.
+     *
+     * Her actual birthday is on April 21, but it's celebrated as a public holiday on the second Monday of June.
+     *  (Except QLD & WA)
+     *
+     * @link https://www.timeanddate.com/holidays/australia/queens-birthday
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateQueensBirthday()
+    {
+        $this->calculateHoliday(
+            'queensBirthday',
+            ['en_AU' => "Queen's Birthday"],
+            'second monday of june ' . $this->year,
+            false,
+            false
+        );
+    }
+}

--- a/src/Yasumi/Provider/Australia/Queensland.php
+++ b/src/Yasumi/Provider/Australia/Queensland.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia;
+
+/**
+ * Provider for all holidays in Queensland (Australia).
+ *
+ */
+class Queensland extends Australia
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    const ID = 'AU-QLD';
+
+    public $timezone = 'Australia/Queensland';
+
+    /**
+     * Initialize holidays for Queensland (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateQueensBirthday();
+        $this->calculateLabourDay();
+    }
+
+    public function calculateLabourDay()
+    {
+        if ($this->year === 2013 || $this->year === 2014 || $this->year === 2015) {
+            $date = new DateTime("first monday of october $this->year", new DateTimeZone($this->timezone));
+        } else {
+            $date = new DateTime("first monday of may $this->year", new DateTimeZone($this->timezone));
+        }
+        
+        $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));
+    }
+
+    /**
+     * Queens Birthday.
+     *
+     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * states and territories. Australia celebrates this holiday because it is a constitutional
+     * monarchy, with the English monarch as head of state.
+     *
+     * Her actual birthday is on April 21, but it's celebrated as a public holiday on the second Monday of June.
+     *  (Except QLD & WA)
+     *
+     * @link https://www.timeanddate.com/holidays/australia/queens-birthday
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateQueensBirthday()
+    {
+        if ($this->year < 2012 || $this->year === 2013 || $this->year === 2014 || $this->year === 2015) {
+            $this->calculateHoliday(
+                'queensBirthday',
+                ['en_AU' => "Queen's Birthday"],
+                'second monday of june ' . $this->year,
+                false,
+                false
+            );
+        } else {
+            $this->calculateHoliday(
+                'queensBirthday',
+                ['en_AU' => "Queen's Birthday"],
+                'first monday of october ' . $this->year,
+                false,
+                false
+            );
+        }
+    }
+}

--- a/src/Yasumi/Provider/Australia/Queensland/Brisbane.php
+++ b/src/Yasumi/Provider/Australia/Queensland/Brisbane.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia\Queensland;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia\Queensland;
+
+/**
+ * Provider for all holidays in Brisbane (Australia).
+ *
+ */
+class Brisbane extends Queensland
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region. This one is not a proper ISO3166 code, but there isn't one specifically for Brisbane,
+     * and I believe this is a logical extension.
+     */
+    const ID = 'AU-QLD-BRI';
+
+    public $timezone = 'Australia/Brisbane';
+
+    /**
+     * Initialize holidays for Brisbane (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculatePeoplesDay();
+    }
+    
+    /**
+     * Ekka People's Day.
+     *
+     * The Ekka is the annual agricultural show of Queensland, Australia. Its formal title is the Royal Queensland Show
+     * and it is held at the Brisbane Showgrounds. It was originally called the Brisbane Exhibition, however it is more
+     * commonly known as the Ekka, which is a shortening of the word exhibition. It is run by The Royal National
+     * Agricultural and Industrial Association of Queensland.
+     * Because of the cultural significance of the Ekka, the City of Brisbane holds a Wednesday public holiday known as
+     * "People's Day". The Ekka starts on the first Friday in August, except if the first Friday is before 5 August, in
+     * which case it starts on the second Friday of August. People's Day is then the Wednesday after the Ekka commences.
+     *
+     * @link https://en.wikipedia.org/wiki/Ekka
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function calculatePeoplesDay()
+    {
+        $date = new DateTime('first friday of august ' . $this->year, new DateTimeZone($this->timezone));
+        if ($date->format('d') < 5) {
+            $date = $date->add(new DateInterval('P7D'));
+        }
+        $date = $date->add(new DateInterval('P5D'));
+        $this->addHoliday(new Holiday('peoplesDay', ['en_AU' => 'Ekka People\'s Day'], $date, $this->locale));
+    }
+}

--- a/src/Yasumi/Provider/Australia/SA.php
+++ b/src/Yasumi/Provider/Australia/SA.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia;
+
+/**
+ * Provider for all holidays in South Australia (Australia).
+ *
+ */
+class SA extends Australia
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    const ID = 'AU-SA';
+
+    public $timezone = 'Australia/South';
+
+    /**
+     * Initialize holidays for South Australia (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
+        $this->calculateQueensBirthday();
+        $this->calculateLabourDay();
+        $this->calculateAdelaideCupDay();
+        
+        // South Australia have Proclamation Day instead of Boxing Day, but the date definition is slightly different,
+        // so we have to rework everything here...
+        $this->removeHoliday('christmasDay');
+        $this->removeHoliday('secondChristmasDay');
+        $this->removeHoliday('christmasHoliday');
+        $this->removeHoliday('secondChristmasHoliday');
+        $this->calculateProclamationDay();
+    }
+
+    public function calculateProclamationDay()
+    {
+        $christmasDay = new DateTime("$this->year-12-25", new DateTimeZone($this->timezone));
+        $this->calculateHoliday('christmasDay', ['en_AU' => 'Christmas Day'], $christmasDay, false, false);
+        switch ($christmasDay->format('w')) {
+            case 0: // sunday
+                $christmasDay->add(new DateInterval('P1D'));
+                $this->calculateHoliday('christmasHoliday', ['en_AU' => 'Christmas Holiday'], $christmasDay, false, false);
+                $proclamationDay = $christmasDay->add(new DateInterval('P1D'));
+                $this->calculateHoliday('proclamationDay', ['en_AU' => 'Proclamation Day'], $proclamationDay, false, false);
+                break;
+            case 5: // friday
+                $proclamationDay = $christmasDay->add(new DateInterval('P3D'));
+                $this->calculateHoliday('proclamationDay', ['en_AU' => 'Proclamation Day'], $proclamationDay, false, false);
+                break;
+            case 6: // saturday
+                $christmasDay->add(new DateInterval('P2D'));
+                $this->calculateHoliday('christmasHoliday', ['en_AU' => 'Christmas Holiday'], $christmasDay, false, false);
+                $proclamationDay = $christmasDay->add(new DateInterval('P1D'));
+                $this->calculateHoliday('proclamationDay', ['en_AU' => 'Proclamation Day'], $proclamationDay, false, false);
+                break;
+            default: // monday-thursday
+                $proclamationDay = $christmasDay->add(new DateInterval('P1D'));
+                $this->calculateHoliday('proclamationDay', ['en_AU' => 'Proclamation Day'], $proclamationDay, false, false);
+                break;
+        }
+    }
+    
+    public function calculateLabourDay()
+    {
+        $date = new DateTime("first monday of october $this->year", new DateTimeZone($this->timezone));
+
+        $this->addHoliday(new Holiday('labourDay', ['en_AU' => 'Labour Day'], $date, $this->locale));
+    }
+
+    /**
+     * Adelaide Cup Day
+     *
+     * @link https://en.wikipedia.org/wiki/Adelaide_Cup
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateAdelaideCupDay()
+    {
+        if ($this->year >= 1973) {
+            if ($this->year < 2006) {
+                $this->calculateHoliday(
+                    'adelaideCup',
+                    ['en_AU' => 'Adelaide Cup'],
+                    'third monday of may ' . $this->year,
+                    false,
+                    false
+                );
+            } else {
+                $this->calculateHoliday(
+                    'adelaideCup',
+                    ['en_AU' => 'Adelaide Cup'],
+                    'second monday of march ' . $this->year,
+                    false,
+                    false
+                );
+            }
+        }
+    }
+    
+    /**
+     * Easter Saturday.
+     *
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @link http://en.wikipedia.org/wiki/Easter
+     *
+     * @param int    $year     the year for which Easter Saturday need to be created
+     * @param string $timezone the timezone in which Easter Saturday is celebrated
+     * @param string $locale   the locale for which Easter Saturday need to be displayed in.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @return \Yasumi\Holiday
+     *
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function easterSaturday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
+    {
+        return new Holiday(
+            'easterSaturday',
+            ['en_AU' => 'Easter Saturday'],
+            $this->calculateEaster($year, $timezone)->sub(new DateInterval('P1D')),
+            $locale,
+            $type
+        );
+    }
+
+    /**
+     * Queens Birthday.
+     *
+     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * states and territories. Australia celebrates this holiday because it is a constitutional
+     * monarchy, with the English monarch as head of state.
+     *
+     * Her actual birthday is on April 21, but it's celebrated as a public holiday on the second Monday of June.
+     *  (Except QLD & WA)
+     *
+     * @link https://www.timeanddate.com/holidays/australia/queens-birthday
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateQueensBirthday()
+    {
+        $this->calculateHoliday(
+            'queensBirthday',
+            ['en_AU' => "Queen's Birthday"],
+            'second monday of june ' . $this->year,
+            false,
+            false
+        );
+    }
+}

--- a/src/Yasumi/Provider/Australia/Tasmania.php
+++ b/src/Yasumi/Provider/Australia/Tasmania.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia;
+
+/**
+ * Provider for all holidays in Tasmania (Australia).
+ *
+ */
+class Tasmania extends Australia
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    const ID = 'AU-TAS';
+
+    public $timezone = 'Australia/Tasmania';
+
+    /**
+     * Initialize holidays for Tasmania (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateEightHoursDay();
+        $this->calculateQueensBirthday();
+        $this->calculateRecreationDay();
+    }
+
+    public function calculateEightHoursDay()
+    {
+        $date = new DateTime("second monday of march $this->year", new DateTimeZone($this->timezone));
+
+        $this->addHoliday(new Holiday('eightHourDay', ['en_AU' => 'Eight Hour Day'], $date, $this->locale));
+    }
+    
+    /**
+     * Queens Birthday.
+     *
+     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * states and territories. Australia celebrates this holiday because it is a constitutional
+     * monarchy, with the English monarch as head of state.
+     *
+     * Her actual birthday is on April 21, but it's celebrated as a public holiday on the second Monday of June.
+     *  (Except QLD & WA)
+     *
+     * @link https://www.timeanddate.com/holidays/australia/queens-birthday
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateQueensBirthday()
+    {
+        $this->calculateHoliday(
+            'queensBirthday',
+            ['en_AU' => 'Queen\'s Birthday'],
+            'second monday of june ' . $this->year,
+            false,
+            false
+        );
+    }
+    
+    /**
+     * Recreation Day
+     *
+     * @link https://en.wikipedia.org/wiki/Recreation_Day_holiday
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateRecreationDay()
+    {
+        $this->calculateHoliday(
+            'recreationDay',
+            ['en_AU' => 'Recreation Day'],
+            'first monday of november ' . $this->year,
+            false,
+            false
+        );
+    }
+}

--- a/src/Yasumi/Provider/Australia/Tasmania/CentralNorth.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/CentralNorth.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia\Tasmania;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia\Tasmania;
+
+/**
+ * Provider for all holidays in central north Tasmania (Australia).
+ *
+ */
+class CentralNorth extends Tasmania
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region. This one is not a proper ISO3166 code, but there aren't any for areas within Tasmania,
+     * and I believe it to be a logical extension.
+     */
+    const ID = 'AU-TAS-CN';
+
+    public $timezone = 'Australia/Tasmania';
+
+    /**
+     * Initialize holidays for northeastern Tasmania (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateDevonportShow();
+    }
+    
+    public function calculateDevonportShow()
+    {
+        $date = new DateTime($this->year . '-12-02', new DateTimeZone($this->timezone));
+        $date = $date->modify('previous friday');
+        $this->addHoliday(new Holiday('devonportShow', ['en_AU' => 'Devonport Show'], $date, $this->locale));
+    }
+}

--- a/src/Yasumi/Provider/Australia/Tasmania/FlindersIsland.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/FlindersIsland.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia\Tasmania;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia\Tasmania;
+
+/**
+ * Provider for all holidays in Flinders Island (Australia).
+ *
+ */
+class FlindersIsland extends Tasmania
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region. This one is not a proper ISO3166 code, but there aren't any for areas within Tasmania,
+     * and I believe it to be a logical extension.
+     */
+    const ID = 'AU-TAS-FI';
+
+    public $timezone = 'Australia/Tasmania';
+
+    /**
+     * Initialize holidays for Flinders Island (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateFlindersIslandShow();
+    }
+    
+    public function calculateFlindersIslandShow()
+    {
+        $date = new DateTime('third saturday of october ' . $this->year, new DateTimeZone($this->timezone));
+        $date = $date->sub(new DateInterval('P1D'));
+        $this->addHoliday(new Holiday('flindersIslandShow', ['en_AU' => 'Flinders Island Show'], $date, $this->locale));
+    }
+}

--- a/src/Yasumi/Provider/Australia/Tasmania/KingIsland.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/KingIsland.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia\Tasmania;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia\Tasmania;
+
+/**
+ * Provider for all holidays in King Island (Australia).
+ *
+ */
+class KingIsland extends Tasmania
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region. This one is not a proper ISO3166 code, but there aren't any for areas within Tasmania,
+     * and I believe it to be a logical extension.
+     */
+    const ID = 'AU-TAS-KI';
+
+    public $timezone = 'Australia/Tasmania';
+
+    /**
+     * Initialize holidays for King Island (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateKingIslandShow();
+    }
+    
+    public function calculateKingIslandShow()
+    {
+        $this->calculateHoliday(
+            'kingIslandShow',
+            ['en_AU' => 'King Island Show'],
+            'first tuesday of march ' . $this->year,
+            false,
+            false
+        );
+    }
+}

--- a/src/Yasumi/Provider/Australia/Tasmania/Northeast.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northeast.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia\Tasmania;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia\Tasmania;
+
+/**
+ * Provider for all holidays in northeastern Tasmania (Australia).
+ *
+ */
+class Northeast extends Tasmania
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region. This one is not a proper ISO3166 code, but there aren't any for areas within Tasmania,
+     * and I believe it to be a logical extension.
+     */
+    const ID = 'AU-TAS-NE';
+
+    public $timezone = 'Australia/Tasmania';
+
+    /**
+     * Initialize holidays for northeastern Tasmania (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateLauncestonShow();
+    }
+    
+    public function calculateLauncestonShow()
+    {
+        $date = new DateTime('second saturday of october ' . $this->year, new DateTimeZone($this->timezone));
+        $date = $date->sub(new DateInterval('P2D'));
+        $this->addHoliday(new Holiday('launcestonShow', ['en_AU' => 'Royal Launceston Show'], $date, $this->locale));
+    }
+}

--- a/src/Yasumi/Provider/Australia/Tasmania/Northwest.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northwest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia\Tasmania;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia\Tasmania;
+
+/**
+ * Provider for all holidays in northwestern Tasmania (Australia).
+ *
+ */
+class Northwest extends Tasmania
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region. This one is not a proper ISO3166 code, but there aren't any for areas within Tasmania,
+     * and I believe it to be a logical extension.
+     */
+    const ID = 'AU-TAS-NW';
+
+    public $timezone = 'Australia/Tasmania';
+
+    /**
+     * Initialize holidays for northwestern Tasmania (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateBurnieShow();
+    }
+    
+    public function calculateBurnieShow()
+    {
+        $date = new DateTime('first saturday of october ' . $this->year, new DateTimeZone($this->timezone));
+        $date = $date->sub(new DateInterval('P1D'));
+        $this->addHoliday(new Holiday('burnieShow', ['en_AU' => 'Burnie Show'], $date, $this->locale));
+    }
+}

--- a/src/Yasumi/Provider/Australia/Tasmania/Northwest/CircularHead.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northwest/CircularHead.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia\Tasmania\Northwest;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia\Tasmania\Northwest;
+
+/**
+ * Provider for all holidays in Circular Head (Australia).
+ *
+ */
+class CircularHead extends Northwest
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region. This one is not a proper ISO3166 code, but there aren't any for areas within Tasmania,
+     * and I believe it to be a logical extension.
+     */
+    const ID = 'AU-TAS-NW-CH';
+
+    public $timezone = 'Australia/Tasmania';
+
+    /**
+     * Initialize holidays for Circular Head (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateAGFEST();
+    }
+    
+    public function calculateAGFEST()
+    {
+        $date = new DateTime('first thursday of may ' . $this->year, new DateTimeZone($this->timezone));
+        $date = $date->add(new DateInterval('P1D'));
+        $this->addHoliday(new Holiday('agfest', ['en_AU' => 'AGFEST'], $date, $this->locale));
+    }
+}

--- a/src/Yasumi/Provider/Australia/Tasmania/South.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/South.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia\Tasmania;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia\Tasmania;
+
+/**
+ * Provider for all holidays in southern Tasmania (Australia).
+ *
+ */
+class South extends Tasmania
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region. This one is not a proper ISO3166 code, but there aren't any for areas within Tasmania,
+     * and I believe it to be a logical extension.
+     */
+    const ID = 'AU-TAS-SOU';
+
+    public $timezone = 'Australia/Tasmania';
+
+    /**
+     * Initialize holidays for southern Tasmania (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateHobartShow();
+    }
+    
+    public function calculateHobartShow()
+    {
+        $date = new DateTime('fourth saturday of october ' . $this->year, new DateTimeZone($this->timezone));
+        $date = $date->sub(new DateInterval('P2D'));
+        $this->addHoliday(new Holiday('hobartShow', ['en_AU' => 'Royal Hobart Show'], $date, $this->locale));
+    }
+}

--- a/src/Yasumi/Provider/Australia/Tasmania/South/Southeast.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/South/Southeast.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia\Tasmania\South;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia\Tasmania\South;
+
+/**
+ * Provider for all holidays in southeastern Tasmania (Australia).
+ *
+ */
+class Southeast extends South
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region. This one is not a proper ISO3166 code, but there aren't any for areas within Tasmania,
+     * and I believe it to be a logical extension.
+     */
+    const ID = 'AU-TAS-SOU-SE';
+
+    public $timezone = 'Australia/Hobart';
+
+    /**
+     * Initialize holidays for southeastern Tasmania (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->removeHoliday('recreationDay');
+        $this->calculateHobartRegatta();
+    }
+    
+    public function calculateHobartRegatta()
+    {
+        $this->calculateHoliday(
+            'hobartRegatta',
+            ['en_AU' => 'Royal Hobart Regatta'],
+            'second monday of february ' . $this->year,
+            false,
+            false
+        );
+    }
+}

--- a/src/Yasumi/Provider/Australia/Victoria.php
+++ b/src/Yasumi/Provider/Australia/Victoria.php
@@ -8,10 +8,12 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\Provider\Australia;
 
+use DateInterval;
 use DateTime;
 use DateTimeZone;
 use Yasumi\Holiday;
@@ -29,6 +31,8 @@ class Victoria extends Australia
      */
     const ID = 'AU-VIC';
 
+    public $timezone = 'Australia/Victoria';
+
     /**
      * Initialize holidays for Victoria (Australia).
      *
@@ -40,29 +44,19 @@ class Victoria extends Australia
     {
         parent::initialize();
 
+        $this->addHoliday($this->easterSunday($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
         $this->calculateLabourDay();
         $this->calculateQueensBirthday();
         $this->calculateMelbourneCupDay();
         $this->calculateAFLGrandFinalDay();
     }
 
-    /**
-     * @throws \Exception
-     */
-    public function calculateChristmasDay()
-    {
-        $christmasDay = new DateTime("$this->year-12-25", new DateTimeZone($this->timezone));
-        $boxingDay    = new DateTime("$this->year-12-26", new DateTimeZone($this->timezone));
-
-        $this->calculateHoliday('christmasDay', [], $christmasDay);
-        $this->calculateHoliday('secondChristmasDay', [], $boxingDay, false);
-    }
-
     public function calculateLabourDay()
     {
         $date = new DateTime("second monday of march $this->year", new DateTimeZone($this->timezone));
 
-        $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));
+        $this->addHoliday(new Holiday('labourDay', ['en_AU' => 'Labour Day'], $date, $this->locale));
     }
 
     public function calculateMelbourneCupDay()
@@ -81,6 +75,12 @@ class Victoria extends Australia
             case 2016:
                 $aflGrandFinalFriday = '2016-09-30';
                 break;
+            case 2017:
+                $aflGrandFinalFriday = '2017-09-29';
+                break;
+            case 2018:
+                $aflGrandFinalFriday = '2018-09-28';
+                break;
             default:
                 return;
         }
@@ -93,5 +93,95 @@ class Victoria extends Australia
             $date,
             $this->locale
         ));
+    }
+
+    /**
+     * Queens Birthday.
+     *
+     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * states and territories. Australia celebrates this holiday because it is a constitutional
+     * monarchy, with the English monarch as head of state.
+     *
+     * Her actual birthday is on April 21, but it's celebrated as a public holiday on the second Monday of June.
+     *  (Except QLD & WA)
+     *
+     * @link https://www.timeanddate.com/holidays/australia/queens-birthday
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateQueensBirthday()
+    {
+        $this->calculateHoliday(
+            'queensBirthday',
+            ['en_AU' => 'Queen\'s Birthday'],
+            'second monday of june ' . $this->year,
+            false,
+            false
+        );
+    }
+
+    /**
+     * Easter Saturday.
+     *
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @link http://en.wikipedia.org/wiki/Easter
+     *
+     * @param int    $year     the year for which Easter Saturday need to be created
+     * @param string $timezone the timezone in which Easter Saturday is celebrated
+     * @param string $locale   the locale for which Easter Saturday need to be displayed in.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @return \Yasumi\Holiday
+     *
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function easterSaturday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
+    {
+        return new Holiday(
+            'easterSaturday',
+            ['en_AU' => 'Easter Saturday'],
+            $this->calculateEaster($year, $timezone)->sub(new DateInterval('P1D')),
+            $locale,
+            $type
+        );
+    }
+    
+    /**
+     * Easter Sunday.
+     *
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @link http://en.wikipedia.org/wiki/Easter
+     *
+     * @param int    $year     the year for which Easter Saturday need to be created
+     * @param string $timezone the timezone in which Easter Saturday is celebrated
+     * @param string $locale   the locale for which Easter Saturday need to be displayed in.
+     * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @return \Yasumi\Holiday
+     *
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function easterSunday($year, $timezone, $locale, $type = Holiday::TYPE_OFFICIAL)
+    {
+        return new Holiday(
+            'easter',
+            ['en_AU' => 'Easter Sunday'],
+            $this->calculateEaster($year, $timezone),
+            $locale,
+            $type
+        );
     }
 }

--- a/src/Yasumi/Provider/Australia/WA.php
+++ b/src/Yasumi/Provider/Australia/WA.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\Provider\Australia;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\Australia;
+
+/**
+ * Provider for all holidays in Western Australia (Australia).
+ *
+ */
+class WA extends Australia
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    const ID = 'AU-WA';
+
+    public $timezone = 'Australia/West';
+
+    /**
+     * Initialize holidays for Western Australia (Australia).
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->calculateQueensBirthday();
+        $this->calculateLabourDay();
+        $this->calculateWesternAustraliaDay();
+    }
+
+    public function calculateLabourDay()
+    {
+        $date = new DateTime("first monday of march $this->year", new DateTimeZone($this->timezone));
+
+        $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));
+    }
+
+    /**
+     * Western Australia Day
+     *
+     * @link https://en.wikipedia.org/wiki/Western_Australia_Day
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateWesternAustraliaDay()
+    {
+        $this->calculateHoliday(
+            'westernAustraliaDay',
+            ['en_AU' => 'Western Australia Day'],
+            'first monday of june ' . $this->year,
+            false,
+            false
+        );
+    }
+    
+    /**
+     * Queens Birthday.
+     *
+     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * states and territories. Australia celebrates this holiday because it is a constitutional
+     * monarchy, with the English monarch as head of state.
+     *
+     * Her actual birthday is on April 21, but it's celebrated as a public holiday on the second Monday of June.
+     *  (Except QLD & WA)
+     *
+     * @link https://www.timeanddate.com/holidays/australia/queens-birthday
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function calculateQueensBirthday()
+    {
+        if ($this->year === 2011) {
+            $this->calculateHoliday(
+                'queensBirthday',
+                ['en_AU' => "Queen's Birthday"],
+                '2011-10-28',
+                false,
+                false
+            );
+        } elseif ($this->year === 2012) {
+            $this->calculateHoliday(
+                'queensBirthday',
+                ['en_AU' => "Queen's Birthday"],
+                '2012-10-01',
+                false,
+                false
+            );
+        } else {
+            $this->calculateHoliday(
+                'queensBirthday',
+                ['en_AU' => "Queen's Birthday"],
+                'last monday of september ' . $this->year,
+                false,
+                false
+            );
+        }
+    }
+}

--- a/tests/Australia/ACT/ACTBaseTestCase.php
+++ b/tests/Australia/ACT/ACTBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+use Yasumi\tests\Australia\AustraliaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the ACT holiday provider.
+ */
+abstract class ACTBaseTestCase extends AustraliaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\ACT';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/ACT';
+}

--- a/tests/Australia/ACT/ACTTest.php
+++ b/tests/Australia/ACT/ACTTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in ACT (Australia).
+ */
+class ACTTest extends ACTBaseTestCase
+{
+    public $region = 'Australia\ACT';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in ACT (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'easter',
+            'easterSaturday',
+            'queensBirthday',
+            'labourDay',
+            'canberraDay',
+            'reconciliationDay'
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(2018, 2100);
+    }
+}

--- a/tests/Australia/ACT/AnzacDayTest.php
+++ b/tests/Australia/ACT/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+/**
+ * Class for testing ANZAC day in ACT (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\AnzacDayTest
+{
+}

--- a/tests/Australia/ACT/AustraliaDayTest.php
+++ b/tests/Australia/ACT/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+/**
+ * Class for testing Australia day in ACT (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\AustraliaDayTest
+{
+}

--- a/tests/Australia/ACT/BoxingDayTest.php
+++ b/tests/Australia/ACT/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+/**
+ * Class for testing Boxing Day in ACT (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\BoxingDayTest
+{
+}

--- a/tests/Australia/ACT/CanberraDayTest.php
+++ b/tests/Australia/ACT/CanberraDayTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Canberra Day in ACT (Australia)..
+ */
+class CanberraDayTest extends ACTBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'canberraDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1913;
+
+    /**
+     * Tests Canberra Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-03-08'],
+            [2011, '2011-03-14'],
+            [2012, '2012-03-12'],
+            [2013, '2013-03-11'],
+            [2014, '2014-03-10'],
+            [2015, '2015-03-09'],
+            [2016, '2016-03-14'],
+            [2017, '2017-03-13'],
+            [2018, '2018-03-12'],
+            [2019, '2019-03-11'],
+            [2020, '2020-03-09'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Canberra Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/ACT/ChristmasDayTest.php
+++ b/tests/Australia/ACT/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+/**
+ * Class for testing Christmas Day in ACT (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\ChristmasDayTest
+{
+}

--- a/tests/Australia/ACT/EasterMondayTest.php
+++ b/tests/Australia/ACT/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+/**
+ * Class for testing Easter Monday in ACT (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\EasterMondayTest
+{
+}

--- a/tests/Australia/ACT/EasterSaturdayTest.php
+++ b/tests/Australia/ACT/EasterSaturdayTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Saturday in ACT (Australia)..
+ */
+class EasterSaturdayTest extends ACTBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'easterSaturday';
+
+    /**
+     * Tests Easter Saturday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, $this->timezone);
+            $date->sub(new DateInterval('P1D'));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Saturday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/ACT/EasterSundayTest.php
+++ b/tests/Australia/ACT/EasterSundayTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Sunday in ACT (Australia)..
+ */
+class EasterSundayTest extends ACTBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'easter';
+
+    /**
+     * Tests Easter Sunday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, $this->timezone);
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Sunday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/ACT/GoodFridayTest.php
+++ b/tests/Australia/ACT/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+/**
+ * Class for testing Good Friday in ACT (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\GoodFridayTest
+{
+}

--- a/tests/Australia/ACT/LabourDayTest.php
+++ b/tests/Australia/ACT/LabourDayTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Labour Day in ACT (Australia)..
+ */
+class LabourDayTest extends ACTBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'labourDay';
+
+    /**
+     * Tests Labour Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-10-04'],
+            [2011, '2011-10-03'],
+            [2012, '2012-10-01'],
+            [2013, '2013-10-07'],
+            [2014, '2014-10-06'],
+            [2015, '2015-10-05'],
+            [2016, '2016-10-03'],
+            [2017, '2017-10-02'],
+            [2018, '2018-10-01'],
+            [2019, '2019-10-07'],
+            [2020, '2020-10-05'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Labour Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/ACT/NewYearsDayTest.php
+++ b/tests/Australia/ACT/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+/**
+ * Class for testing New Years Day in ACT (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\NewYearsDayTest
+{
+}

--- a/tests/Australia/ACT/QueensBirthdayTest.php
+++ b/tests/Australia/ACT/QueensBirthdayTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Queen's Birthday in ACT (Australia)..
+ */
+class QueensBirthdayTest extends ACTBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'queensBirthday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1950;
+
+    /**
+     * Tests Queen's Birthday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-06-14'],
+            [2011, '2011-06-13'],
+            [2012, '2012-06-11'],
+            [2013, '2013-06-10'],
+            [2014, '2014-06-09'],
+            [2015, '2015-06-08'],
+            [2016, '2016-06-13'],
+            [2017, '2017-06-12'],
+            [2018, '2018-06-11'],
+            [2019, '2019-06-10'],
+            [2020, '2020-06-08'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Queen\'s Birthday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/ACT/ReconciliationDayTest.php
+++ b/tests/Australia/ACT/ReconciliationDayTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\ACT;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Reconciliation Day in ACT (Australia)..
+ */
+class ReconciliationDayTest extends ACTBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'reconciliationDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 2018;
+
+    /**
+     * Tests Reconciliation Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2018, '2018-05-28'],
+            [2019, '2019-05-27'],
+            [2020, '2020-06-01'],
+            [2021, '2021-05-31'],
+            [2022, '2022-05-30'],
+            [2023, '2023-05-29'],
+            [2024, '2024-05-27'],
+            [2025, '2025-06-02'],
+            [2026, '2026-06-01'],
+            [2027, '2027-05-31'],
+            [2028, '2028-05-29'],
+            [2029, '2029-05-28'],
+            [2030, '2030-05-27'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Reconciliation Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/AnzacDayTest.php
+++ b/tests/Australia/AnzacDayTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\tests\Australia;
@@ -51,7 +52,7 @@ class AnzacDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInterf
     }
 
     /**
-     *  Tests that Labour Day is not present before 1921
+     *  Tests that ANZAC Day is not present before 1921
      */
     public function testNotHoliday()
     {
@@ -66,18 +67,18 @@ class AnzacDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInterf
     public function HolidayDataProvider()
     {
         $data = [
-            [2010, '2010-04-26'],
+            [2010, '2010-04-25'],
             [2011, '2011-04-25'],
             [2012, '2012-04-25'],
             [2013, '2013-04-25'],
             [2014, '2014-04-25'],
-            [2015, '2015-04-27'],
+            [2015, '2015-04-25'],
             [2016, '2016-04-25'],
             [2017, '2017-04-25'],
             [2018, '2018-04-25'],
             [2019, '2019-04-25'],
             [2019, '2019-04-25'],
-            [2020, '2020-04-27'],
+            [2020, '2020-04-25'],
         ];
 
         return $data;

--- a/tests/Australia/BoxingDayTest.php
+++ b/tests/Australia/BoxingDayTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\tests\Australia;
@@ -26,16 +27,18 @@ class BoxingDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInter
      * The name of the holiday
      */
     const HOLIDAY = 'secondChristmasDay';
+    const HOLIDAY2 = 'secondChristmasHoliday';
 
     /**
      * Tests Boxing Day
      *
      * @dataProvider HolidayDataProvider
      *
-     * @param int    $year     the year for which the holiday defined in this test needs to be tested
-     * @param string $expected the expected date
+     * @param int    $year          the year for which the holiday defined in this test needs to be tested
+     * @param string $expected      the expected date
+     * @param string $expectedExtra the expected date for the additional holiday, or null if no additional holiday
      */
-    public function testHoliday($year, $expected)
+    public function testHoliday($year, $expected, $expectedExtra)
     {
         $this->assertHoliday(
             $this->region,
@@ -43,6 +46,20 @@ class BoxingDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInter
             $year,
             new DateTime($expected, new DateTimeZone($this->timezone))
         );
+        if ($expectedExtra === null) {
+            $this->assertNotHoliday(
+                $this->region,
+                self::HOLIDAY2,
+                $year
+            );
+        } else {
+            $this->assertHoliday(
+                $this->region,
+                self::HOLIDAY2,
+                $year,
+                new DateTime($expectedExtra, new DateTimeZone($this->timezone))
+            );
+        }
     }
 
     /**
@@ -53,17 +70,17 @@ class BoxingDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInter
     public function HolidayDataProvider()
     {
         $data = [
-            [2010, '2010-12-28'],
-            [2011, '2011-12-26'],
-            [2012, '2012-12-26'],
-            [2013, '2013-12-26'],
-            [2014, '2014-12-26'],
-            [2015, '2015-12-28'],
-            [2016, '2016-12-26'],
-            [2017, '2017-12-26'],
-            [2018, '2018-12-26'],
-            [2019, '2019-12-26'],
-            [2020, '2020-12-28'],
+            [2010, '2010-12-26', '2010-12-28'],
+            [2011, '2011-12-26', null],
+            [2012, '2012-12-26', null],
+            [2013, '2013-12-26', null],
+            [2014, '2014-12-26', null],
+            [2015, '2015-12-26', '2015-12-28'],
+            [2016, '2016-12-26', null],
+            [2017, '2017-12-26', null],
+            [2018, '2018-12-26', null],
+            [2019, '2019-12-26', null],
+            [2020, '2020-12-26', '2020-12-28'],
         ];
 
         return $data;
@@ -80,6 +97,12 @@ class BoxingDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInter
             $this->generateRandomYear(),
             [self::LOCALE => 'Boxing Day']
         );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY2,
+            2020,
+            [self::LOCALE => 'Boxing Day Holiday']
+        );
     }
 
     /**
@@ -88,5 +111,6 @@ class BoxingDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInter
     public function testHolidayType()
     {
         $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY2, 2020, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/ChristmasDayTest.php
+++ b/tests/Australia/ChristmasDayTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\tests\Australia;
@@ -18,7 +19,7 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing Christmas Day in the Australia.
+ * Class for testing Christmas Day in Australia.
  */
 class ChristmasDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInterface
 {
@@ -26,16 +27,18 @@ class ChristmasDayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
      * The name of the holiday
      */
     const HOLIDAY = 'christmasDay';
+    const HOLIDAY2 = 'christmasHoliday';
 
     /**
      * Tests Christmas Day
      *
      * @dataProvider HolidayDataProvider
      *
-     * @param int    $year     the year for which the holiday defined in this test needs to be tested
-     * @param string $expected the expected date
+     * @param int    $year          the year for which the holiday defined in this test needs to be tested
+     * @param string $expected      the expected date
+     * @param string $expectedExtra the expected date for the additional holiday, or null if no additional holiday
      */
-    public function testHoliday($year, $expected)
+    public function testHoliday($year, $expected, $expectedExtra)
     {
         $this->assertHoliday(
             $this->region,
@@ -43,6 +46,20 @@ class ChristmasDayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
             $year,
             new DateTime($expected, new DateTimeZone($this->timezone))
         );
+        if ($expectedExtra === null) {
+            $this->assertNotHoliday(
+                $this->region,
+                self::HOLIDAY2,
+                $year
+            );
+        } else {
+            $this->assertHoliday(
+                $this->region,
+                self::HOLIDAY2,
+                $year,
+                new DateTime($expectedExtra, new DateTimeZone($this->timezone))
+            );
+        }
     }
 
     /**
@@ -53,17 +70,17 @@ class ChristmasDayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
     public function HolidayDataProvider()
     {
         $data = [
-            [2010, '2010-12-27'],
-            [2011, '2011-12-27'],
-            [2012, '2012-12-25'],
-            [2013, '2013-12-25'],
-            [2014, '2014-12-25'],
-            [2015, '2015-12-25'],
-            [2016, '2016-12-27'],
-            [2017, '2017-12-25'],
-            [2018, '2018-12-25'],
-            [2019, '2019-12-25'],
-            [2020, '2020-12-25'],
+            [2010, '2010-12-25', '2010-12-27'],
+            [2011, '2011-12-25', '2011-12-27'],
+            [2012, '2012-12-25', null],
+            [2013, '2013-12-25', null],
+            [2014, '2014-12-25', null],
+            [2015, '2015-12-25', null],
+            [2016, '2016-12-25', '2016-12-27'],
+            [2017, '2017-12-25', null],
+            [2018, '2018-12-25', null],
+            [2019, '2019-12-25', null],
+            [2020, '2020-12-25', null],
         ];
 
         return $data;
@@ -80,6 +97,12 @@ class ChristmasDayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
             $this->generateRandomYear(),
             [self::LOCALE => 'Christmas Day']
         );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY2,
+            2016,
+            [self::LOCALE => 'Christmas Holiday']
+        );
     }
 
     /**
@@ -88,5 +111,6 @@ class ChristmasDayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
     public function testHolidayType()
     {
         $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY2, 2016, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/EasterMondayTest.php
+++ b/tests/Australia/EasterMondayTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\tests\Australia;
@@ -27,6 +28,7 @@ class EasterMondayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
      * The name of the holiday
      */
     const HOLIDAY = 'easterMonday';
+    const HOLIDAY2 = 'easterTuesday';
 
     /**
      * Tests Easter Monday
@@ -41,6 +43,24 @@ class EasterMondayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
         $this->assertHoliday(
             $this->region,
             self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Tests Easter Tuesday for those years when ANZAC Day clashes with Easter Sunday or Monday
+     *
+     * @dataProvider HolidayDataProvider2
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday2($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY2,
             $year,
             new DateTime($expected, new DateTimeZone($this->timezone))
         );
@@ -67,6 +87,25 @@ class EasterMondayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
     }
 
     /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider2()
+    {
+        $data = [];
+
+        $data = [
+            [2011, '2011-04-26'],
+            [2038, '2038-04-27'],
+            [2095, '2095-04-26'],
+            [2163, '2163-04-26'],
+        ];
+        
+        return $data;
+    }
+
+    /**
      * Tests the translated name of the holiday defined in this test.
      */
     public function testTranslation()
@@ -77,6 +116,12 @@ class EasterMondayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
             $this->generateRandomYear(),
             [self::LOCALE => 'Easter Monday']
         );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY2,
+            2011,
+            [self::LOCALE => 'Easter Tuesday']
+        );
     }
 
     /**
@@ -85,5 +130,6 @@ class EasterMondayTest extends AustraliaBaseTestCase implements YasumiTestCaseIn
     public function testHolidayType()
     {
         $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY2, 2011, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/NSW/AnzacDayTest.php
+++ b/tests/Australia/NSW/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+/**
+ * Class for testing ANZAC day in NSW (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\AnzacDayTest
+{
+}

--- a/tests/Australia/NSW/AustraliaDayTest.php
+++ b/tests/Australia/NSW/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+/**
+ * Class for testing Australia day in NSW (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\AustraliaDayTest
+{
+}

--- a/tests/Australia/NSW/BankHolidayTest.php
+++ b/tests/Australia/NSW/BankHolidayTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Bank Holiday in NSW (Australia)..
+ */
+class BankHolidayTest extends NSWBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'bankHoliday';
+
+    /**
+     * Tests Bank Holiday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-08-02'],
+            [2011, '2011-08-01'],
+            [2012, '2012-08-06'],
+            [2013, '2013-08-05'],
+            [2014, '2014-08-04'],
+            [2015, '2015-08-03'],
+            [2016, '2016-08-01'],
+            [2017, '2017-08-07'],
+            [2018, '2018-08-06'],
+            [2019, '2019-08-05'],
+            [2020, '2020-08-03'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_BANK);
+    }
+}

--- a/tests/Australia/NSW/BoxingDayTest.php
+++ b/tests/Australia/NSW/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+/**
+ * Class for testing Boxing Day in NSW (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\BoxingDayTest
+{
+}

--- a/tests/Australia/NSW/ChristmasDayTest.php
+++ b/tests/Australia/NSW/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+/**
+ * Class for testing Christmas Day in NSW (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\ChristmasDayTest
+{
+}

--- a/tests/Australia/NSW/EasterMondayTest.php
+++ b/tests/Australia/NSW/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+/**
+ * Class for testing Easter Monday in NSW (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\EasterMondayTest
+{
+}

--- a/tests/Australia/NSW/EasterSaturdayTest.php
+++ b/tests/Australia/NSW/EasterSaturdayTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Saturday in NSW (Australia)..
+ */
+class EasterSaturdayTest extends NSWBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'easterSaturday';
+
+    /**
+     * Tests Easter Saturday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, $this->timezone);
+            $date->sub(new DateInterval('P1D'));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Saturday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/NSW/EasterSundayTest.php
+++ b/tests/Australia/NSW/EasterSundayTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Sunday in NSW (Australia)..
+ */
+class EasterSundayTest extends NSWBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'easter';
+
+    /**
+     * Tests Easter Sunday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, $this->timezone);
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Sunday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/NSW/GoodFridayTest.php
+++ b/tests/Australia/NSW/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+/**
+ * Class for testing Good Friday in NSW (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\GoodFridayTest
+{
+}

--- a/tests/Australia/NSW/LabourDayTest.php
+++ b/tests/Australia/NSW/LabourDayTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Labour Day in NSW (Australia)..
+ */
+class LabourDayTest extends NSWBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'labourDay';
+
+    /**
+     * Tests Labour Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-10-04'],
+            [2011, '2011-10-03'],
+            [2012, '2012-10-01'],
+            [2013, '2013-10-07'],
+            [2014, '2014-10-06'],
+            [2015, '2015-10-05'],
+            [2016, '2016-10-03'],
+            [2017, '2017-10-02'],
+            [2018, '2018-10-01'],
+            [2019, '2019-10-07'],
+            [2020, '2020-10-05'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Labour Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/NSW/NSWBaseTestCase.php
+++ b/tests/Australia/NSW/NSWBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+use Yasumi\tests\Australia\AustraliaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the NSW holiday provider.
+ */
+abstract class NSWBaseTestCase extends AustraliaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\NSW';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/NSW';
+}

--- a/tests/Australia/NSW/NSWTest.php
+++ b/tests/Australia/NSW/NSWTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in NSW (Australia).
+ */
+class NSWTest extends NSWBaseTestCase
+{
+    public $region = 'Australia\NSW';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in NSW (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'easter',
+            'easterSaturday',
+            'queensBirthday',
+            'labourDay',
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Tests if all bank holidays in NSW (Australia) are defined by the provider class
+     */
+    public function testBankHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'bankHoliday',
+        ], $this->region, $this->year, Holiday::TYPE_BANK);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/NSW/NewYearsDayTest.php
+++ b/tests/Australia/NSW/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+/**
+ * Class for testing New Years Day in NSW (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\NewYearsDayTest
+{
+}

--- a/tests/Australia/NSW/QueensBirthdayTest.php
+++ b/tests/Australia/NSW/QueensBirthdayTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NSW;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Queen's Birthday in NSW (Australia)..
+ */
+class QueensBirthdayTest extends NSWBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'queensBirthday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1950;
+
+    /**
+     * Tests Queen's Birthday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-06-14'],
+            [2011, '2011-06-13'],
+            [2012, '2012-06-11'],
+            [2013, '2013-06-10'],
+            [2014, '2014-06-09'],
+            [2015, '2015-06-08'],
+            [2016, '2016-06-13'],
+            [2017, '2017-06-12'],
+            [2018, '2018-06-11'],
+            [2019, '2019-06-10'],
+            [2020, '2020-06-08'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Queen\'s Birthday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/NT/AnzacDayTest.php
+++ b/tests/Australia/NT/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+/**
+ * Class for testing ANZAC day in NT (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\AnzacDayTest
+{
+}

--- a/tests/Australia/NT/AustraliaDayTest.php
+++ b/tests/Australia/NT/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+/**
+ * Class for testing Australia day in NT (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\AustraliaDayTest
+{
+}

--- a/tests/Australia/NT/BoxingDayTest.php
+++ b/tests/Australia/NT/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+/**
+ * Class for testing Boxing Day in NT (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\BoxingDayTest
+{
+}

--- a/tests/Australia/NT/ChristmasDayTest.php
+++ b/tests/Australia/NT/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+/**
+ * Class for testing Christmas Day in NT (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\ChristmasDayTest
+{
+}

--- a/tests/Australia/NT/EasterMondayTest.php
+++ b/tests/Australia/NT/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+/**
+ * Class for testing Easter Monday in NT (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\EasterMondayTest
+{
+}

--- a/tests/Australia/NT/EasterSaturdayTest.php
+++ b/tests/Australia/NT/EasterSaturdayTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Saturday in NT (Australia)..
+ */
+class EasterSaturdayTest extends NTBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'easterSaturday';
+
+    /**
+     * Tests Easter Saturday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, $this->timezone);
+            $date->sub(new DateInterval('P1D'));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Saturday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/NT/GoodFridayTest.php
+++ b/tests/Australia/NT/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+/**
+ * Class for testing Good Friday in NT (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\GoodFridayTest
+{
+}

--- a/tests/Australia/NT/MayDayTest.php
+++ b/tests/Australia/NT/MayDayTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing May Day in NT (Australia)..
+ */
+class MayDayTest extends NTBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'mayDay';
+
+    /**
+     * Tests May Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-05-03'],
+            [2011, '2011-05-02'],
+            [2012, '2012-05-07'],
+            [2013, '2013-05-06'],
+            [2014, '2014-05-05'],
+            [2015, '2015-05-04'],
+            [2016, '2016-05-02'],
+            [2017, '2017-05-01'],
+            [2018, '2018-05-07'],
+            [2019, '2019-05-06'],
+            [2020, '2020-05-04'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'May Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/NT/NTBaseTestCase.php
+++ b/tests/Australia/NT/NTBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+use Yasumi\tests\Australia\AustraliaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the NT holiday provider.
+ */
+abstract class NTBaseTestCase extends AustraliaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\NT';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/North';
+}

--- a/tests/Australia/NT/NTTest.php
+++ b/tests/Australia/NT/NTTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in NT (Australia).
+ */
+class NTTest extends NTBaseTestCase
+{
+    public $region = 'Australia\NT';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in NT (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'easterSaturday',
+            'queensBirthday',
+            'mayDay',
+            'picnicDay',
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/NT/NewYearsDayTest.php
+++ b/tests/Australia/NT/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+/**
+ * Class for testing New Years Day in NT (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\NewYearsDayTest
+{
+}

--- a/tests/Australia/NT/PicnicDayTest.php
+++ b/tests/Australia/NT/PicnicDayTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\NT;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Picnic Day in NT (Australia)..
+ */
+class PicnicDayTest extends NTBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'picnicDay';
+
+    /**
+     * Tests Picnic Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-08-02'],
+            [2011, '2011-08-01'],
+            [2012, '2012-08-06'],
+            [2013, '2013-08-05'],
+            [2014, '2014-08-04'],
+            [2015, '2015-08-03'],
+            [2016, '2016-08-01'],
+            [2017, '2017-08-07'],
+            [2018, '2018-08-06'],
+            [2019, '2019-08-05'],
+            [2020, '2020-08-03'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Picnic Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/NT/QueensBirthdayTest.php
+++ b/tests/Australia/NT/QueensBirthdayTest.php
@@ -8,9 +8,10 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
-namespace Yasumi\tests\Australia;
+namespace Yasumi\tests\Australia\NT;
 
 use DateTime;
 use DateTimeZone;
@@ -18,9 +19,9 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing QueensBirthday in Australia.
+ * Class for testing Queen's Birthday in NT (Australia)..
  */
-abstract class QueensBirthdayTest extends AustraliaBaseTestCase implements YasumiTestCaseInterface
+class QueensBirthdayTest extends NTBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday
@@ -32,10 +33,8 @@ abstract class QueensBirthdayTest extends AustraliaBaseTestCase implements Yasum
      */
     const ESTABLISHMENT_YEAR = 1950;
 
-    protected $dateFormat; // picked a random date -- sorry :)
-
     /**
-     * Tests Labour Day
+     * Tests Queen's Birthday
      *
      * @dataProvider HolidayDataProvider
      *
@@ -51,7 +50,6 @@ abstract class QueensBirthdayTest extends AustraliaBaseTestCase implements Yasum
             new DateTime($expected, new DateTimeZone($this->timezone))
         );
     }
-
 
     /**
      * Returns a list of test dates
@@ -86,7 +84,7 @@ abstract class QueensBirthdayTest extends AustraliaBaseTestCase implements Yasum
             $this->region,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            [self::LOCALE => 'Queens Birthday']
+            [self::LOCALE => 'Queen\'s Birthday']
         );
     }
 

--- a/tests/Australia/NewYearsDayTest.php
+++ b/tests/Australia/NewYearsDayTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\tests\Australia;
@@ -26,16 +27,18 @@ class NewYearsDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInt
      * The name of the holiday
      */
     const HOLIDAY = 'newYearsDay';
+    const HOLIDAY2 = 'newYearsHoliday';
 
     /**
      * Tests New Years Day
      *
      * @dataProvider HolidayDataProvider
      *
-     * @param int    $year     the year for which the holiday defined in this test needs to be tested
-     * @param string $expected the expected date
+     * @param int    $year          the year for which the holiday defined in this test needs to be tested
+     * @param string $expected      the expected date
+     * @param string $expectedExtra the expected date for the additional holiday, or null if no additional holiday
      */
-    public function testHoliday($year, $expected)
+    public function testHoliday($year, $expected, $expectedExtra)
     {
         $this->assertHoliday(
             $this->region,
@@ -43,6 +46,20 @@ class NewYearsDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInt
             $year,
             new DateTime($expected, new DateTimeZone($this->timezone))
         );
+        if ($expectedExtra === null) {
+            $this->assertNotHoliday(
+                $this->region,
+                self::HOLIDAY2,
+                $year
+            );
+        } else {
+            $this->assertHoliday(
+                $this->region,
+                self::HOLIDAY2,
+                $year,
+                new DateTime($expectedExtra, new DateTimeZone($this->timezone))
+            );
+        }
     }
 
     /**
@@ -53,19 +70,18 @@ class NewYearsDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInt
     public function HolidayDataProvider()
     {
         $data = [
-            [2010, '2010-01-01'],
-            [2011, '2011-01-03'],
-            [2012, '2012-01-02'],
-            [2013, '2013-01-01'],
-            [2014, '2014-01-01'],
-            [2015, '2015-01-01'],
-            [2016, '2016-01-01'],
-            [2017, '2017-01-02'],
-            [2018, '2018-01-01'],
-            [2019, '2019-01-01'],
-            [2020, '2020-01-01'],
+            [2010, '2010-01-01', null],
+            [2011, '2011-01-01', '2011-01-03'],
+            [2012, '2012-01-01', '2012-01-02'],
+            [2013, '2013-01-01', null],
+            [2014, '2014-01-01', null],
+            [2015, '2015-01-01', null],
+            [2016, '2016-01-01', null],
+            [2017, '2017-01-01', '2017-01-02'],
+            [2018, '2018-01-01', null],
+            [2019, '2019-01-01', null],
+            [2020, '2020-01-01', null],
         ];
-
 
         return $data;
     }
@@ -81,6 +97,12 @@ class NewYearsDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInt
             $this->generateRandomYear(),
             [self::LOCALE => 'New Year\'s Day']
         );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY2,
+            2017,
+            [self::LOCALE => 'New Year\'s Holiday']
+        );
     }
 
     /**
@@ -89,5 +111,6 @@ class NewYearsDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInt
     public function testHolidayType()
     {
         $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY2, 2017, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/Queensland/AnzacDayTest.php
+++ b/tests/Australia/Queensland/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+/**
+ * Class for testing ANZAC day in Queensland (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\AnzacDayTest
+{
+}

--- a/tests/Australia/Queensland/AustraliaDayTest.php
+++ b/tests/Australia/Queensland/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+/**
+ * Class for testing Australia day in Queensland (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\AustraliaDayTest
+{
+}

--- a/tests/Australia/Queensland/BoxingDayTest.php
+++ b/tests/Australia/Queensland/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+/**
+ * Class for testing Boxing Day in Queensland (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\BoxingDayTest
+{
+}

--- a/tests/Australia/Queensland/Brisbane/AnzacDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+/**
+ * Class for testing ANZAC day in Brisbane (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\Queensland\AnzacDayTest
+{
+}

--- a/tests/Australia/Queensland/Brisbane/AustraliaDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+/**
+ * Class for testing Australia day in Brisbane (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\Queensland\AustraliaDayTest
+{
+}

--- a/tests/Australia/Queensland/Brisbane/BoxingDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+/**
+ * Class for testing Boxing Day in Brisbane (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\Queensland\BoxingDayTest
+{
+}

--- a/tests/Australia/Queensland/Brisbane/BrisbaneBaseTestCase.php
+++ b/tests/Australia/Queensland/Brisbane/BrisbaneBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+use Yasumi\tests\Australia\Queensland\QueenslandBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the Queensland holiday provider.
+ */
+abstract class BrisbaneBaseTestCase extends QueenslandBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Queensland\Brisbane';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Brisbane';
+}

--- a/tests/Australia/Queensland/Brisbane/BrisbaneTest.php
+++ b/tests/Australia/Queensland/Brisbane/BrisbaneTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in Queensland (Australia).
+ */
+class BrisbaneTest extends BrisbaneBaseTestCase
+{
+    public $region = 'Australia\Queensland\Brisbane';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in Queensland (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'labourDay',
+            'peoplesDay',
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/Queensland/Brisbane/ChristmasDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+/**
+ * Class for testing Christmas Day in Brisbane (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\Queensland\ChristmasDayTest
+{
+}

--- a/tests/Australia/Queensland/Brisbane/EasterMondayTest.php
+++ b/tests/Australia/Queensland/Brisbane/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+/**
+ * Class for testing Easter Monday in Brisbane (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\Queensland\EasterMondayTest
+{
+}

--- a/tests/Australia/Queensland/Brisbane/GoodFridayTest.php
+++ b/tests/Australia/Queensland/Brisbane/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+/**
+ * Class for testing Good Friday in Brisbane (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\Queensland\GoodFridayTest
+{
+}

--- a/tests/Australia/Queensland/Brisbane/LabourDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/LabourDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+/**
+ * Class for testing Labour Day in Brisbane (Australia)..
+ */
+class LabourDayTest extends \Yasumi\tests\Australia\Queensland\LabourDayTest
+{
+}

--- a/tests/Australia/Queensland/Brisbane/NewYearsDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+/**
+ * Class for testing New Years Day in Brisbane (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\Queensland\NewYearsDayTest
+{
+}

--- a/tests/Australia/Queensland/Brisbane/PeoplesDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/PeoplesDayTest.php
@@ -7,10 +7,10 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
-namespace Yasumi\tests\Australia;
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
 
 use DateTime;
 use DateTimeZone;
@@ -18,20 +18,17 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing Labour Day in Australia.
+ * Class for testing Ekka People's Day in Brisbane (Australia)..
  */
-abstract class LabourDayTest extends AustraliaBaseTestCase implements YasumiTestCaseInterface
+class PeoplesDayTest extends BrisbaneBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday
      */
-    const HOLIDAY = 'labourDay';
-
-
-    protected $dateFormat; // picked a random date -- sorry :)
+    const HOLIDAY = 'peoplesDay';
 
     /**
-     * Tests Labour Day
+     * Tests Ekka People's Day
      *
      * @dataProvider HolidayDataProvider
      *
@@ -48,7 +45,6 @@ abstract class LabourDayTest extends AustraliaBaseTestCase implements YasumiTest
         );
     }
 
-
     /**
      * Returns a list of test dates
      *
@@ -56,7 +52,21 @@ abstract class LabourDayTest extends AustraliaBaseTestCase implements YasumiTest
      */
     public function HolidayDataProvider()
     {
-        return [];
+        $data = [
+            [2010, '2010-08-11'],
+            [2011, '2011-08-10'],
+            [2012, '2012-08-15'],
+            [2013, '2013-08-14'],
+            [2014, '2014-08-13'],
+            [2015, '2015-08-12'],
+            [2016, '2016-08-10'],
+            [2017, '2017-08-16'],
+            [2018, '2018-08-15'],
+            [2019, '2019-08-14'],
+            [2020, '2020-08-12'],
+        ];
+
+        return $data;
     }
 
     /**
@@ -68,7 +78,7 @@ abstract class LabourDayTest extends AustraliaBaseTestCase implements YasumiTest
             $this->region,
             self::HOLIDAY,
             $this->generateRandomYear(1990),
-            [self::LOCALE => 'Labour Day']
+            [self::LOCALE => 'Ekka People\'s Day']
         );
     }
 

--- a/tests/Australia/Queensland/Brisbane/QueensBirthdayTest.php
+++ b/tests/Australia/Queensland/Brisbane/QueensBirthdayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+/**
+ * Class for testing Queen's Birthday in Brisbane (Australia)..
+ */
+class QueensBirthdayTest extends \Yasumi\tests\Australia\Queensland\QueensBirthdayTest
+{
+}

--- a/tests/Australia/Queensland/ChristmasDayTest.php
+++ b/tests/Australia/Queensland/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+/**
+ * Class for testing Christmas Day in Queensland (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\ChristmasDayTest
+{
+}

--- a/tests/Australia/Queensland/EasterMondayTest.php
+++ b/tests/Australia/Queensland/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+/**
+ * Class for testing Easter Monday in Queensland (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\EasterMondayTest
+{
+}

--- a/tests/Australia/Queensland/GoodFridayTest.php
+++ b/tests/Australia/Queensland/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+/**
+ * Class for testing Good Friday in Queensland (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\GoodFridayTest
+{
+}

--- a/tests/Australia/Queensland/LabourDayTest.php
+++ b/tests/Australia/Queensland/LabourDayTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Labour Day in Queensland (Australia)..
+ */
+class LabourDayTest extends QueenslandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'labourDay';
+
+    /**
+     * Tests Labour Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-05-03'],
+            [2011, '2011-05-02'],
+            [2012, '2012-05-07'],
+            [2013, '2013-10-07'],
+            [2014, '2014-10-06'],
+            [2015, '2015-10-05'],
+            [2016, '2016-05-02'],
+            [2017, '2017-05-01'],
+            [2018, '2018-05-07'],
+            [2019, '2019-05-06'],
+            [2020, '2020-05-04'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Labour Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Queensland/NewYearsDayTest.php
+++ b/tests/Australia/Queensland/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+/**
+ * Class for testing New Years Day in Queensland (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\NewYearsDayTest
+{
+}

--- a/tests/Australia/Queensland/QueensBirthdayTest.php
+++ b/tests/Australia/Queensland/QueensBirthdayTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Queen's Birthday in Queensland (Australia)..
+ */
+class QueensBirthdayTest extends QueenslandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'queensBirthday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1950;
+
+    /**
+     * Tests Queen's Birthday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-06-14'],
+            [2011, '2011-06-13'],
+            [2012, '2012-10-01'],
+            [2013, '2013-06-10'],
+            [2014, '2014-06-09'],
+            [2015, '2015-06-08'],
+            [2016, '2016-10-03'],
+            [2017, '2017-10-02'],
+            [2018, '2018-10-01'],
+            [2019, '2019-10-07'],
+            [2020, '2020-10-05'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Queen\'s Birthday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/Queensland/QueenslandBaseTestCase.php
+++ b/tests/Australia/Queensland/QueenslandBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+use Yasumi\tests\Australia\AustraliaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the Queensland holiday provider.
+ */
+abstract class QueenslandBaseTestCase extends AustraliaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Queensland';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Queensland';
+}

--- a/tests/Australia/Queensland/QueenslandTest.php
+++ b/tests/Australia/Queensland/QueenslandTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in Queensland (Australia).
+ */
+class QueenslandTest extends QueenslandBaseTestCase
+{
+    public $region = 'Australia\Queensland';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in Queensland (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'labourDay',
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/SA/AdelaideCupDayTest.php
+++ b/tests/Australia/SA/AdelaideCupDayTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Adelaide Cup Day in SA (Australia)..
+ */
+class AdelaideCupDayTest extends SABaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'adelaideCup';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1973;
+
+    /**
+     * Tests Adelaide Cup Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2000, '2000-05-15'],
+            [2001, '2001-05-21'],
+            [2002, '2002-05-20'],
+            [2003, '2003-05-19'],
+            [2004, '2004-05-17'],
+            [2005, '2005-05-16'],
+            [2006, '2006-03-13'],
+            [2007, '2007-03-12'],
+            [2008, '2008-03-10'],
+            [2009, '2009-03-09'],
+            [2010, '2010-03-08'],
+            [2011, '2011-03-14'],
+            [2012, '2012-03-12'],
+            [2013, '2013-03-11'],
+            [2014, '2014-03-10'],
+            [2015, '2015-03-09'],
+            [2016, '2016-03-14'],
+            [2017, '2017-03-13'],
+            [2018, '2018-03-12'],
+            [2019, '2019-03-11'],
+            [2020, '2020-03-09'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Adelaide Cup']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/SA/AnzacDayTest.php
+++ b/tests/Australia/SA/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+/**
+ * Class for testing ANZAC day in SA (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\AnzacDayTest
+{
+}

--- a/tests/Australia/SA/AustraliaDayTest.php
+++ b/tests/Australia/SA/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+/**
+ * Class for testing Australia day in SA (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\AustraliaDayTest
+{
+}

--- a/tests/Australia/SA/ChristmasDayTest.php
+++ b/tests/Australia/SA/ChristmasDayTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Christmas Day in South Australia.
+ */
+class ChristmasDayTest extends SABaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'christmasDay';
+    const HOLIDAY2 = 'christmasHoliday';
+
+    /**
+     * Tests Christmas Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year          the year for which the holiday defined in this test needs to be tested
+     * @param string $expected      the expected date
+     * @param string $expectedExtra the expected date for the additional holiday, or null if no additional holiday
+     */
+    public function testHoliday($year, $expected, $expectedExtra)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+        if ($expectedExtra === null) {
+            $this->assertNotHoliday(
+                $this->region,
+                self::HOLIDAY2,
+                $year
+            );
+        } else {
+            $this->assertHoliday(
+                $this->region,
+                self::HOLIDAY2,
+                $year,
+                new DateTime($expectedExtra, new DateTimeZone($this->timezone))
+            );
+        }
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-12-25', '2010-12-27'],
+            [2011, '2011-12-25', '2011-12-26'],
+            [2012, '2012-12-25', null],
+            [2013, '2013-12-25', null],
+            [2014, '2014-12-25', null],
+            [2015, '2015-12-25', null],
+            [2016, '2016-12-25', '2016-12-26'],
+            [2017, '2017-12-25', null],
+            [2018, '2018-12-25', null],
+            [2019, '2019-12-25', null],
+            [2020, '2020-12-25', null],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Christmas Day']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY2,
+            2016,
+            [self::LOCALE => 'Christmas Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType($this->region, self::HOLIDAY2, 2016, Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/SA/EasterMondayTest.php
+++ b/tests/Australia/SA/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+/**
+ * Class for testing Easter Monday in SA (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\EasterMondayTest
+{
+}

--- a/tests/Australia/SA/EasterSaturdayTest.php
+++ b/tests/Australia/SA/EasterSaturdayTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Saturday in SA (Australia)..
+ */
+class EasterSaturdayTest extends SABaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'easterSaturday';
+
+    /**
+     * Tests Easter Saturday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, $this->timezone);
+            $date->sub(new DateInterval('P1D'));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Saturday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/SA/GoodFridayTest.php
+++ b/tests/Australia/SA/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+/**
+ * Class for testing Good Friday in SA (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\GoodFridayTest
+{
+}

--- a/tests/Australia/SA/LabourDayTest.php
+++ b/tests/Australia/SA/LabourDayTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Labour Day in SA (Australia)..
+ */
+class LabourDayTest extends SABaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'labourDay';
+
+    /**
+     * Tests Labour Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-10-04'],
+            [2011, '2011-10-03'],
+            [2012, '2012-10-01'],
+            [2013, '2013-10-07'],
+            [2014, '2014-10-06'],
+            [2015, '2015-10-05'],
+            [2016, '2016-10-03'],
+            [2017, '2017-10-02'],
+            [2018, '2018-10-01'],
+            [2019, '2019-10-07'],
+            [2020, '2020-10-05'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Labour Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/SA/NewYearsDayTest.php
+++ b/tests/Australia/SA/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+/**
+ * Class for testing New Years Day in SA (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\NewYearsDayTest
+{
+}

--- a/tests/Australia/SA/ProclamationDayTest.php
+++ b/tests/Australia/SA/ProclamationDayTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Proclamation Day in SA (Australia)..
+ */
+class ProclamationDayTest extends SABaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'proclamationDay';
+
+    /**
+     * Tests Proclamation Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-12-28'],
+            [2011, '2011-12-27'],
+            [2012, '2012-12-26'],
+            [2013, '2013-12-26'],
+            [2014, '2014-12-26'],
+            [2015, '2015-12-28'],
+            [2016, '2016-12-27'],
+            [2017, '2017-12-26'],
+            [2018, '2018-12-26'],
+            [2019, '2019-12-26'],
+            [2020, '2020-12-28'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Proclamation Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/SA/QueensBirthdayTest.php
+++ b/tests/Australia/SA/QueensBirthdayTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Queen's Birthday in SA (Australia)..
+ */
+class QueensBirthdayTest extends SABaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'queensBirthday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1950;
+
+    /**
+     * Tests Queen's Birthday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-06-14'],
+            [2011, '2011-06-13'],
+            [2012, '2012-06-11'],
+            [2013, '2013-06-10'],
+            [2014, '2014-06-09'],
+            [2015, '2015-06-08'],
+            [2016, '2016-06-13'],
+            [2017, '2017-06-12'],
+            [2018, '2018-06-11'],
+            [2019, '2019-06-10'],
+            [2020, '2020-06-08'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Queen\'s Birthday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/SA/SABaseTestCase.php
+++ b/tests/Australia/SA/SABaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+use Yasumi\tests\Australia\AustraliaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the Victoria holiday provider.
+ */
+abstract class SABaseTestCase extends AustraliaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\SA';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/South';
+}

--- a/tests/Australia/SA/SATest.php
+++ b/tests/Australia/SA/SATest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\SA;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in SA (Australia).
+ */
+class SATest extends SABaseTestCase
+{
+    public $region = 'Australia\SA';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in SA (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'proclamationDay',
+            'australiaDay',
+            'anzacDay',
+            'easterSaturday',
+            'queensBirthday',
+            'labourDay',
+            'adelaideCup'
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1973);
+    }
+}

--- a/tests/Australia/Tasmania/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+/**
+ * Class for testing ANZAC day in Tasmania (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\AnzacDayTest
+{
+}

--- a/tests/Australia/Tasmania/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+/**
+ * Class for testing Australia day in Tasmania (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\AustraliaDayTest
+{
+}

--- a/tests/Australia/Tasmania/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+/**
+ * Class for testing Boxing Day in Tasmania (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\BoxingDayTest
+{
+}

--- a/tests/Australia/Tasmania/CentralNorth/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing ANZAC day in central north Tasmania (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\Tasmania\AnzacDayTest
+{
+}

--- a/tests/Australia/Tasmania/CentralNorth/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing Australia day in central north Tasmania (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\Tasmania\AustraliaDayTest
+{
+}

--- a/tests/Australia/Tasmania/CentralNorth/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing Boxing Day in central north Tasmania (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\Tasmania\BoxingDayTest
+{
+}

--- a/tests/Australia/Tasmania/CentralNorth/CentralNorthBaseTestCase.php
+++ b/tests/Australia/Tasmania/CentralNorth/CentralNorthBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+use Yasumi\tests\Australia\Tasmania\TasmaniaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the central north Tasmania holiday provider.
+ */
+abstract class CentralNorthBaseTestCase extends TasmaniaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Tasmania\CentralNorth';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Tasmania';
+}

--- a/tests/Australia/Tasmania/CentralNorth/CentralNorthTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/CentralNorthTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in central north Tasmania (Australia).
+ */
+class CentralNorthTest extends CentralNorthBaseTestCase
+{
+    public $region = 'Australia\Tasmania\CentralNorth';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in central north Tasmania (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'eightHourDay',
+            'recreationDay',
+            'devonportShow'
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/Tasmania/CentralNorth/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing Christmas Day in central north Tasmania (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\Tasmania\ChristmasDayTest
+{
+}

--- a/tests/Australia/Tasmania/CentralNorth/DevonportShowTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/DevonportShowTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Devonport Show Day in central north Tasmania (Australia)..
+ */
+class DevonportShowTest extends CentralNorthBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'devonportShow';
+
+    /**
+     * Tests Devonport Show Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-11-26'],
+            [2011, '2011-11-25'],
+            [2012, '2012-11-30'],
+            [2013, '2013-11-29'],
+            [2014, '2014-11-28'],
+            [2015, '2015-11-27'],
+            [2016, '2016-11-25'],
+            [2017, '2017-12-01'],
+            [2018, '2018-11-30'],
+            [2019, '2019-11-29'],
+            [2020, '2020-11-27'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Devonport Show']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Tasmania/CentralNorth/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing Easter Monday in central north Tasmania (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\Tasmania\EasterMondayTest
+{
+}

--- a/tests/Australia/Tasmania/CentralNorth/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/EightHourDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing Eight Hour Day in central north Tasmania (Australia)..
+ */
+class EightHourDayTest extends \Yasumi\tests\Australia\Tasmania\EightHourDayTest
+{
+}

--- a/tests/Australia/Tasmania/CentralNorth/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing Good Friday in central north Tasmania (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\Tasmania\GoodFridayTest
+{
+}

--- a/tests/Australia/Tasmania/CentralNorth/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing New Years Day in central north Tasmania (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\Tasmania\NewYearsDayTest
+{
+}

--- a/tests/Australia/Tasmania/CentralNorth/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/QueensBirthdayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing Queen's Birthday in central north Tasmania (Australia)..
+ */
+class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
+{
+}

--- a/tests/Australia/Tasmania/CentralNorth/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/RecreationDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing Recreation Day in central north Tasmania (Australia)..
+ */
+class RecreationDayTest extends \Yasumi\tests\Australia\Tasmania\RecreationDayTest
+{
+}

--- a/tests/Australia/Tasmania/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+/**
+ * Class for testing Christmas Day in Tasmania (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\ChristmasDayTest
+{
+}

--- a/tests/Australia/Tasmania/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+/**
+ * Class for testing Easter Monday in Tasmania (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\EasterMondayTest
+{
+}

--- a/tests/Australia/Tasmania/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/EightHourDayTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Eight Hour Day in Tasmania (Australia)..
+ */
+class EightHourDayTest extends TasmaniaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'eightHourDay';
+
+    /**
+     * Tests Eight Hour Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-03-08'],
+            [2011, '2011-03-14'],
+            [2012, '2012-03-12'],
+            [2013, '2013-03-11'],
+            [2014, '2014-03-10'],
+            [2015, '2015-03-09'],
+            [2016, '2016-03-14'],
+            [2017, '2017-03-13'],
+            [2018, '2018-03-12'],
+            [2019, '2019-03-11'],
+            [2020, '2020-03-09'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Eight Hour Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Tasmania/FlindersIsland/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing ANZAC day in Flinders Island (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\Tasmania\AnzacDayTest
+{
+}

--- a/tests/Australia/Tasmania/FlindersIsland/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing Australia day in Flinders Island (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\Tasmania\AustraliaDayTest
+{
+}

--- a/tests/Australia/Tasmania/FlindersIsland/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing Boxing Day in Flinders Island (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\Tasmania\BoxingDayTest
+{
+}

--- a/tests/Australia/Tasmania/FlindersIsland/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing Christmas Day in Flinders Island (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\Tasmania\ChristmasDayTest
+{
+}

--- a/tests/Australia/Tasmania/FlindersIsland/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing Easter Monday in Flinders Island (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\Tasmania\EasterMondayTest
+{
+}

--- a/tests/Australia/Tasmania/FlindersIsland/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/EightHourDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing Eight Hour Day in Flinders Island (Australia)..
+ */
+class EightHourDayTest extends \Yasumi\tests\Australia\Tasmania\EightHourDayTest
+{
+}

--- a/tests/Australia/Tasmania/FlindersIsland/FlindersIslandBaseTestCase.php
+++ b/tests/Australia/Tasmania/FlindersIsland/FlindersIslandBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+use Yasumi\tests\Australia\Tasmania\TasmaniaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the Flinders Island holiday provider.
+ */
+abstract class FlindersIslandBaseTestCase extends TasmaniaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Tasmania\FlindersIsland';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Tasmania';
+}

--- a/tests/Australia/Tasmania/FlindersIsland/FlindersIslandShowTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/FlindersIslandShowTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Flinders Island Show Day in Flinders Island (Australia)..
+ */
+class FlindersIslandShowTest extends FlindersIslandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'flindersIslandShow';
+
+    /**
+     * Tests Flinders Island Show Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-10-15'],
+            [2011, '2011-10-14'],
+            [2012, '2012-10-19'],
+            [2013, '2013-10-18'],
+            [2014, '2014-10-17'],
+            [2015, '2015-10-16'],
+            [2016, '2016-10-14'],
+            [2017, '2017-10-20'],
+            [2018, '2018-10-19'],
+            [2019, '2019-10-18'],
+            [2020, '2020-10-16'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Flinders Island Show']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Tasmania/FlindersIsland/FlindersIslandTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/FlindersIslandTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in Flinders Island (Australia).
+ */
+class FlindersIslandTest extends FlindersIslandBaseTestCase
+{
+    public $region = 'Australia\Tasmania\FlindersIsland';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in Flinders Island (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'eightHourDay',
+            'recreationDay',
+            'flindersIslandShow'
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/Tasmania/FlindersIsland/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing Good Friday in Flinders Island (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\Tasmania\GoodFridayTest
+{
+}

--- a/tests/Australia/Tasmania/FlindersIsland/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing New Years Day in Flinders Island (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\Tasmania\NewYearsDayTest
+{
+}

--- a/tests/Australia/Tasmania/FlindersIsland/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/QueensBirthdayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing Queen's Birthday in Flinders Island (Australia)..
+ */
+class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
+{
+}

--- a/tests/Australia/Tasmania/FlindersIsland/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/RecreationDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing Recreation Day in Flinders Island (Australia)..
+ */
+class RecreationDayTest extends \Yasumi\tests\Australia\Tasmania\RecreationDayTest
+{
+}

--- a/tests/Australia/Tasmania/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+/**
+ * Class for testing Good Friday in Tasmania (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\GoodFridayTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing ANZAC day in King Island (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\Tasmania\AnzacDayTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing Australia day in King Island (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\Tasmania\AustraliaDayTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing Boxing Day in King Island (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\Tasmania\BoxingDayTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing Christmas Day in King Island (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\Tasmania\ChristmasDayTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing Easter Monday in King Island (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\Tasmania\EasterMondayTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/EightHourDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing Eight Hour Day in King Island (Australia)..
+ */
+class EightHourDayTest extends \Yasumi\tests\Australia\Tasmania\EightHourDayTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing Good Friday in King Island (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\Tasmania\GoodFridayTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/KingIslandBaseTestCase.php
+++ b/tests/Australia/Tasmania/KingIsland/KingIslandBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+use Yasumi\tests\Australia\Tasmania\TasmaniaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the King Island holiday provider.
+ */
+abstract class KingIslandBaseTestCase extends TasmaniaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Tasmania\KingIsland';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Tasmania';
+}

--- a/tests/Australia/Tasmania/KingIsland/KingIslandShowTest.php
+++ b/tests/Australia/Tasmania/KingIsland/KingIslandShowTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing King Island Show Day in King Island (Australia)..
+ */
+class KingIslandShowTest extends KingIslandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'kingIslandShow';
+
+    /**
+     * Tests King Island Show Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-03-02'],
+            [2011, '2011-03-01'],
+            [2012, '2012-03-06'],
+            [2013, '2013-03-05'],
+            [2014, '2014-03-04'],
+            [2015, '2015-03-03'],
+            [2016, '2016-03-01'],
+            [2017, '2017-03-07'],
+            [2018, '2018-03-06'],
+            [2019, '2019-03-05'],
+            [2020, '2020-03-03'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'King Island Show']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Tasmania/KingIsland/KingIslandTest.php
+++ b/tests/Australia/Tasmania/KingIsland/KingIslandTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in Flinders Island (Australia).
+ */
+class KingIslandTest extends KingIslandBaseTestCase
+{
+    public $region = 'Australia\Tasmania\KingIsland';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in King Island (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'eightHourDay',
+            'recreationDay',
+            'kingIslandShow'
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/Tasmania/KingIsland/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing New Years Day in King Island (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\Tasmania\NewYearsDayTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/QueensBirthdayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing Queen's Birthday in King Island (Australia)..
+ */
+class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/RecreationDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing Recreation Day in King Island (Australia)..
+ */
+class RecreationDayTest extends \Yasumi\tests\Australia\Tasmania\RecreationDayTest
+{
+}

--- a/tests/Australia/Tasmania/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+/**
+ * Class for testing New Years Day in Tasmania (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\NewYearsDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing ANZAC day in northeastern Tasmania (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\Tasmania\AnzacDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing Australia day in northeastern Tasmania (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\Tasmania\AustraliaDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing Boxing Day in northeastern Tasmania (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\Tasmania\BoxingDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing Christmas Day in northeastern Tasmania (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\Tasmania\ChristmasDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/Northeast/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing Easter Monday in northeastern Tasmania (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\Tasmania\EasterMondayTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/EightHourDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing Eight Hour Day in northeastern Tasmania (Australia)..
+ */
+class EightHourDayTest extends \Yasumi\tests\Australia\Tasmania\EightHourDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/Northeast/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing Good Friday in northeastern Tasmania (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\Tasmania\GoodFridayTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/LauncestonShowTest.php
+++ b/tests/Australia/Tasmania/Northeast/LauncestonShowTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Launceston Show Day in northeastern Tasmania (Australia)..
+ */
+class LauncestonShowTest extends NortheastBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'launcestonShow';
+
+    /**
+     * Tests Launceston Show Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-10-07'],
+            [2011, '2011-10-06'],
+            [2012, '2012-10-11'],
+            [2013, '2013-10-10'],
+            [2014, '2014-10-09'],
+            [2015, '2015-10-08'],
+            [2016, '2016-10-06'],
+            [2017, '2017-10-12'],
+            [2018, '2018-10-11'],
+            [2019, '2019-10-10'],
+            [2020, '2020-10-08'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Royal Launceston Show']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Tasmania/Northeast/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing New Years Day in northeastern Tasmania (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\Tasmania\NewYearsDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/NortheastBaseTestCase.php
+++ b/tests/Australia/Tasmania/Northeast/NortheastBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+use Yasumi\tests\Australia\Tasmania\TasmaniaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the northeastern Tasmania holiday provider.
+ */
+abstract class NortheastBaseTestCase extends TasmaniaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Tasmania\Northeast';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Tasmania';
+}

--- a/tests/Australia/Tasmania/Northeast/NortheastTest.php
+++ b/tests/Australia/Tasmania/Northeast/NortheastTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in northeastern Tasmania (Australia).
+ */
+class NortheastTest extends NortheastBaseTestCase
+{
+    public $region = 'Australia\Tasmania\Northeast';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in northeastern Tasmania (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'eightHourDay',
+            'recreationDay',
+            'launcestonShow'
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/Tasmania/Northeast/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/Northeast/QueensBirthdayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing Queen's Birthday in northeast Tasmania (Australia)..
+ */
+class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/RecreationDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing Recreation Day in northeastern Tasmania (Australia)..
+ */
+class RecreationDayTest extends \Yasumi\tests\Australia\Tasmania\RecreationDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing ANZAC day in northwestern Tasmania (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\Tasmania\AnzacDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing Australia day in northwestern Tasmania (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\Tasmania\AustraliaDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing Boxing Day in northwestern Tasmania (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\Tasmania\BoxingDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/BurnieShowTest.php
+++ b/tests/Australia/Tasmania/Northwest/BurnieShowTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Burnie Show Day in northwestern Tasmania (Australia)..
+ */
+class BurnieShowTest extends NorthwestBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'burnieShow';
+
+    /**
+     * Tests Burnie Show Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-10-01'],
+            [2011, '2011-09-30'],
+            [2012, '2012-10-05'],
+            [2013, '2013-10-04'],
+            [2014, '2014-10-03'],
+            [2015, '2015-10-02'],
+            [2016, '2016-09-30'],
+            [2017, '2017-10-06'],
+            [2018, '2018-10-05'],
+            [2019, '2019-10-04'],
+            [2020, '2020-10-02'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Burnie Show']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Tasmania/Northwest/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing Christmas Day in northwestern Tasmania (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\Tasmania\ChristmasDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/AGFESTTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/AGFESTTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing AGFEST in northwestern Tasmania (Australia)..
+ */
+class AGFESTTest extends CircularHeadBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'agfest';
+
+    /**
+     * Tests AGFEST
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-05-07'],
+            [2011, '2011-05-06'],
+            [2012, '2012-05-04'],
+            [2013, '2013-05-03'],
+            [2014, '2014-05-02'],
+            [2015, '2015-05-08'],
+            [2016, '2016-05-06'],
+            [2017, '2017-05-05'],
+            [2018, '2018-05-04'],
+            [2019, '2019-05-03'],
+            [2020, '2020-05-08'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'AGFEST']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing ANZAC day in Circular Head (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\AnzacDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing Australia day in Circular Head (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\AustraliaDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing Boxing Day in Circular Head (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\BoxingDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/BurnieShowTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/BurnieShowTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing Burnie Show Day in Circular Head (Australia)..
+ */
+class BurnieShowTest extends \Yasumi\tests\Australia\Tasmania\Northwest\BurnieShowTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing Christmas Day in Circular Head (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\ChristmasDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadBaseTestCase.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+use Yasumi\tests\Australia\Tasmania\Northwest\NorthwestBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the northwestern Tasmania holiday provider.
+ */
+abstract class CircularHeadBaseTestCase extends NorthwestBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Tasmania\Northwest\CircularHead';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Tasmania';
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in Circular Head (Australia).
+ */
+class CircularHeadTest extends CircularHeadBaseTestCase
+{
+    public $region = 'Australia\Tasmania\Northwest\CircularHead';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in Circular Head (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'eightHourDay',
+            'recreationDay',
+            'burnieShow',
+            'agfest',
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing Easter Monday in Circular Head (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\EasterMondayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/EightHourDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing Eight Hour Day in Circular Head (Australia)..
+ */
+class EightHourDayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\EightHourDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing Good Friday in Circular Head (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\GoodFridayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing New Years Day in Circular Head (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\NewYearsDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/QueensBirthdayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing Queen's Birthday in Circular Head (Australia)..
+ */
+class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\QueensBirthdayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/CircularHead/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/RecreationDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing Recreation Day in Circular Head (Australia)..
+ */
+class RecreationDayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\RecreationDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/Northwest/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing Easter Monday in northwestern Tasmania (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\Tasmania\EasterMondayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/EightHourDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing Eight Hour Day in northwestern Tasmania (Australia)..
+ */
+class EightHourDayTest extends \Yasumi\tests\Australia\Tasmania\EightHourDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/Northwest/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing Good Friday in northwestern Tasmania (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\Tasmania\GoodFridayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing New Years Day in northwestern Tasmania (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\Tasmania\NewYearsDayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/NorthwestBaseTestCase.php
+++ b/tests/Australia/Tasmania/Northwest/NorthwestBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+use Yasumi\tests\Australia\Tasmania\TasmaniaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the northwestern Tasmania holiday provider.
+ */
+abstract class NorthwestBaseTestCase extends TasmaniaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Tasmania\Northwest';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Tasmania';
+}

--- a/tests/Australia/Tasmania/Northwest/NorthwestTest.php
+++ b/tests/Australia/Tasmania/Northwest/NorthwestTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in northwestern Tasmania (Australia).
+ */
+class NorthwestTest extends NorthwestBaseTestCase
+{
+    public $region = 'Australia\Tasmania\Northwest';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in northwestern Tasmania (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'eightHourDay',
+            'recreationDay',
+            'burnieShow'
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/Tasmania/Northwest/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/Northwest/QueensBirthdayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing Queen's Birthday in northwest Tasmania (Australia)..
+ */
+class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/RecreationDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing Recreation Day in northwestern Tasmania (Australia)..
+ */
+class RecreationDayTest extends \Yasumi\tests\Australia\Tasmania\RecreationDayTest
+{
+}

--- a/tests/Australia/Tasmania/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/QueensBirthdayTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Queen's Birthday in Tasmania (Australia)..
+ */
+class QueensBirthdayTest extends TasmaniaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'queensBirthday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1950;
+
+    /**
+     * Tests Queen's Birthday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-06-14'],
+            [2011, '2011-06-13'],
+            [2012, '2012-06-11'],
+            [2013, '2013-06-10'],
+            [2014, '2014-06-09'],
+            [2015, '2015-06-08'],
+            [2016, '2016-06-13'],
+            [2017, '2017-06-12'],
+            [2018, '2018-06-11'],
+            [2019, '2019-06-10'],
+            [2020, '2020-06-08'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Queen\'s Birthday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/Tasmania/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/RecreationDayTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Recreation Day in Tasmania (Australia)..
+ */
+class RecreationDayTest extends TasmaniaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'recreationDay';
+
+    /**
+     * Tests Recreation Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-11-01'],
+            [2011, '2011-11-07'],
+            [2012, '2012-11-05'],
+            [2013, '2013-11-04'],
+            [2014, '2014-11-03'],
+            [2015, '2015-11-02'],
+            [2016, '2016-11-07'],
+            [2017, '2017-11-06'],
+            [2018, '2018-11-05'],
+            [2019, '2019-11-04'],
+            [2020, '2020-11-02'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Recreation Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Tasmania/South/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/South/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing ANZAC day in southern Tasmania (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\Tasmania\AnzacDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/South/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing Australia day in southern Tasmania (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\Tasmania\AustraliaDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/South/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing Boxing Day in soutehrn Tasmania (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\Tasmania\BoxingDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/South/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing Christmas Day in southern Tasmania (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\Tasmania\ChristmasDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/South/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing Easter Monday in southern Tasmania (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\Tasmania\EasterMondayTest
+{
+}

--- a/tests/Australia/Tasmania/South/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/South/EightHourDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing Eight Hour Day in southern Tasmania (Australia)..
+ */
+class EightHourDayTest extends \Yasumi\tests\Australia\Tasmania\EightHourDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/South/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing Good Friday in southern Tasmania (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\Tasmania\GoodFridayTest
+{
+}

--- a/tests/Australia/Tasmania/South/HobartShowTest.php
+++ b/tests/Australia/Tasmania/South/HobartShowTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Royal Hobart Show Day in southern Tasmania (Australia)..
+ */
+class HobartShowTest extends SouthBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'hobartShow';
+
+    /**
+     * Tests Royal Hobart Show Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-10-21'],
+            [2011, '2011-10-20'],
+            [2012, '2012-10-25'],
+            [2013, '2013-10-24'],
+            [2014, '2014-10-23'],
+            [2015, '2015-10-22'],
+            [2016, '2016-10-20'],
+            [2017, '2017-10-26'],
+            [2018, '2018-10-25'],
+            [2019, '2019-10-24'],
+            [2020, '2020-10-22'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Royal Hobart Show']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Tasmania/South/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/South/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing New Years Day in soutehrn Tasmania (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\Tasmania\NewYearsDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/South/QueensBirthdayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing Queen's Birthday in southe0rn Tasmania (Australia)..
+ */
+class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
+{
+}

--- a/tests/Australia/Tasmania/South/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/South/RecreationDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing Recreation Day in southern Tasmania (Australia)..
+ */
+class RecreationDayTest extends \Yasumi\tests\Australia\Tasmania\RecreationDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/SouthBaseTestCase.php
+++ b/tests/Australia/Tasmania/South/SouthBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+use Yasumi\tests\Australia\Tasmania\TasmaniaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the northwestern Tasmania holiday provider.
+ */
+abstract class SouthBaseTestCase extends TasmaniaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Tasmania\South';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Tasmania';
+}

--- a/tests/Australia/Tasmania/South/SouthTest.php
+++ b/tests/Australia/Tasmania/South/SouthTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in southern Tasmania (Australia).
+ */
+class SouthTest extends SouthBaseTestCase
+{
+    public $region = 'Australia\Tasmania\South';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in northwestern Tasmania (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'eightHourDay',
+            'recreationDay',
+            'hobartShow'
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/Tasmania/South/Southeast/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+/**
+ * Class for testing ANZAC day in southeastern Tasmania (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\Tasmania\South\AnzacDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast\CircularHead;
+
+/**
+ * Class for testing Australia day in southeastern Tasmania (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\Tasmania\South\AustraliaDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+/**
+ * Class for testing Boxing Day in southeastern Tasmania (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\Tasmania\South\BoxingDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+/**
+ * Class for testing Christmas Day in southeastern Tasmania (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\Tasmania\South\ChristmasDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+/**
+ * Class for testing Easter Monday in southeastern Tasmania (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\Tasmania\South\EasterMondayTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/EightHourDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+/**
+ * Class for testing Eight Hour Day in southeastern Tasmania (Australia)..
+ */
+class EightHourDayTest extends \Yasumi\tests\Australia\Tasmania\South\EightHourDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+/**
+ * Class for testing Good Friday in southeastern Tasmania (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\Tasmania\South\GoodFridayTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/HobartRegattaTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/HobartRegattaTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Burnie Show Day in northwestern Tasmania (Australia)..
+ */
+class HobartRegattaTest extends SoutheastBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'hobartRegatta';
+
+    /**
+     * Tests Royal Hobart Regatta
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-02-08'],
+            [2011, '2011-02-14'],
+            [2012, '2012-02-13'],
+            [2013, '2013-02-11'],
+            [2014, '2014-02-10'],
+            [2015, '2015-02-09'],
+            [2016, '2016-02-08'],
+            [2017, '2017-02-13'],
+            [2018, '2018-02-12'],
+            [2019, '2019-02-11'],
+            [2020, '2020-02-10'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Royal Hobart Regatta']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Tasmania/South/Southeast/HobartShowTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/HobartShowTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+/**
+ * Class for testing Hobart Show Day in southeastern Tasmania (Australia)..
+ */
+class HobartShowTest extends \Yasumi\tests\Australia\Tasmania\South\HobartShowTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+/**
+ * Class for testing New Years Day in southeastern Tasmania (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\Tasmania\South\NewYearsDayTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/QueensBirthdayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+/**
+ * Class for testing Queen's Birthday in southeastern Tasmania (Australia)..
+ */
+class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\South\QueensBirthdayTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/SoutheastBaseTestCase.php
+++ b/tests/Australia/Tasmania/South/Southeast/SoutheastBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+use Yasumi\tests\Australia\Tasmania\South\SouthBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the northwestern Tasmania holiday provider.
+ */
+abstract class SoutheastBaseTestCase extends SouthBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Tasmania\South\Southeast';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Hobart';
+}

--- a/tests/Australia/Tasmania/South/Southeast/SoutheastTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/SoutheastTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in southeastern Tasmania (Australia).
+ */
+class SoutheastTest extends SoutheastBaseTestCase
+{
+    public $region = 'Australia\Tasmania\South\Southeast';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in Circular Head (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'eightHourDay',
+            'hobartShow',
+            'hobartRegatta',
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/Tasmania/TasmaniaBaseTestCase.php
+++ b/tests/Australia/Tasmania/TasmaniaBaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+use Yasumi\tests\Australia\AustraliaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the Victoria holiday provider.
+ */
+abstract class TasmaniaBaseTestCase extends AustraliaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\Tasmania';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/Tasmania';
+}

--- a/tests/Australia/Tasmania/TasmaniaTest.php
+++ b/tests/Australia/Tasmania/TasmaniaTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in Tasmania (Australia).
+ */
+class TasmaniaTest extends TasmaniaBaseTestCase
+{
+    public $region = 'Australia\Tasmania';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in Tasmania (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'eightHourDay',
+            'recreationDay',
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/Victoria/AFLGrandFinalFridayTest.php
+++ b/tests/Australia/Victoria/AFLGrandFinalFridayTest.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\tests\Australia\Victoria;
@@ -28,7 +29,7 @@ class AFLGrandFinalFridayTest extends VictoriaBaseTestCase implements YasumiTest
     const HOLIDAY = 'aflGrandFinalFriday';
 
     const ESTABLISHMENT_YEAR = 2015;
-    const LAST_KNOWN_YEAR = 2016;
+    const LAST_KNOWN_YEAR = 2018;
 
     /**
      * Tests AFL Grand Final Friday
@@ -93,6 +94,8 @@ class AFLGrandFinalFridayTest extends VictoriaBaseTestCase implements YasumiTest
         $data = [
             [2015, '2015-10-02'],
             [2016, '2016-09-30'],
+            [2017, '2017-09-29'],
+            [2018, '2018-09-28'],
         ];
 
         return $data;

--- a/tests/Australia/Victoria/ChristmasDayTest.php
+++ b/tests/Australia/Victoria/ChristmasDayTest.php
@@ -13,7 +13,7 @@
 namespace Yasumi\tests\Australia\Victoria;
 
 /**
- * Class for testing Christmas Day in the Victoria (Australia)..
+ * Class for testing Christmas Day in Victoria (Australia)..
  */
 class ChristmasDayTest extends \Yasumi\tests\Australia\ChristmasDayTest
 {

--- a/tests/Australia/Victoria/EasterSaturdayTest.php
+++ b/tests/Australia/Victoria/EasterSaturdayTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Victoria;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Saturday in Victoria (Australia)..
+ */
+class EasterSaturdayTest extends VictoriaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'easterSaturday';
+
+    /**
+     * Tests Easter Saturday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, $this->timezone);
+            $date->sub(new DateInterval('P1D'));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Saturday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Victoria/EasterSundayTest.php
+++ b/tests/Australia/Victoria/EasterSundayTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Victoria;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Sunday in Victoria (Australia)..
+ */
+class EasterSundayTest extends VictoriaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'easter';
+
+    /**
+     * Tests Easter Sunday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, $this->timezone);
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Sunday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/Victoria/LabourDayTest.php
+++ b/tests/Australia/Victoria/LabourDayTest.php
@@ -8,20 +8,43 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\tests\Australia\Victoria;
 
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
 /**
  * Class for testing Labour Day in Victoria (Australia)..
  */
-class LabourDayTest extends \Yasumi\tests\Australia\LabourDayTest
+class LabourDayTest extends VictoriaBaseTestCase implements YasumiTestCaseInterface
 {
-    public $region = 'Australia\Victoria';
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'labourDay';
 
-    public $timezone = 'Australia/Melbourne';
-
-    protected $dateFormat = 'second Monday of March';
+    /**
+     * Tests Labour Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
 
     /**
      * Returns a list of test dates
@@ -44,7 +67,27 @@ class LabourDayTest extends \Yasumi\tests\Australia\LabourDayTest
             [2020, '2020-03-09'],
         ];
 
-
         return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Labour Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/Victoria/MelbourneCupDayTest.php
+++ b/tests/Australia/Victoria/MelbourneCupDayTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\Victoria;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Melbourne cup Day in Victoria (Australia)..
+ */
+class MelbourneCupdayTest extends VictoriaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'melbourneCup';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1877;
+
+    /**
+     * Tests Melbourne Cup Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-11-02'],
+            [2011, '2011-11-01'],
+            [2012, '2012-11-06'],
+            [2013, '2013-11-05'],
+            [2014, '2014-11-04'],
+            [2015, '2015-11-03'],
+            [2016, '2016-11-01'],
+            [2017, '2017-11-07'],
+            [2018, '2018-11-06'],
+            [2019, '2019-11-05'],
+            [2020, '2020-11-03'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Melbourne Cup']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/Victoria/QueensBirthdayTest.php
+++ b/tests/Australia/Victoria/QueensBirthdayTest.php
@@ -8,16 +8,96 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\tests\Australia\Victoria;
 
-/**
- * Class for testing Queens Birthday in Victoria (Australia)..
- */
-class QueensBirthdayTest extends \Yasumi\tests\Australia\QueensBirthdayTest
-{
-    public $region = 'Australia\Victoria';
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
 
-    protected $dateFormat = 'second monday of june';
+/**
+ * Class for testing Queen's Birthday in Victoria (Australia)..
+ */
+class QueensBirthdayTest extends VictoriaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'queensBirthday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1950;
+
+    /**
+     * Tests Queen's Birthday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-06-14'],
+            [2011, '2011-06-13'],
+            [2012, '2012-06-11'],
+            [2013, '2013-06-10'],
+            [2014, '2014-06-09'],
+            [2015, '2015-06-08'],
+            [2016, '2016-06-13'],
+            [2017, '2017-06-12'],
+            [2018, '2018-06-11'],
+            [2019, '2019-06-10'],
+            [2020, '2020-06-08'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Queen\'s Birthday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
 }

--- a/tests/Australia/Victoria/VictoriaBaseTestCase.php
+++ b/tests/Australia/Victoria/VictoriaBaseTestCase.php
@@ -8,6 +8,7 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\tests\Australia\Victoria;
@@ -30,5 +31,5 @@ abstract class VictoriaBaseTestCase extends AustraliaBaseTestCase
     /**
      * Timezone in which this provider has holidays defined
      */
-    public $timezone = 'Australia/Melbourne';
+    public $timezone = 'Australia/Victoria';
 }

--- a/tests/Australia/Victoria/VictoriaTest.php
+++ b/tests/Australia/Victoria/VictoriaTest.php
@@ -8,17 +8,17 @@
  * file that was distributed with this source code.
  *
  * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
  */
 
 namespace Yasumi\tests\Australia\Victoria;
 
 use Yasumi\Holiday;
-use Yasumi\tests\Australia\AustraliaTest;
 
 /**
  * Class for testing holidays in Victoria (Australia).
  */
-class VictoriaTest extends AustraliaTest
+class VictoriaTest extends VictoriaBaseTestCase
 {
     public $region = 'Australia\Victoria';
 
@@ -40,9 +40,12 @@ class VictoriaTest extends AustraliaTest
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
+            'easter',
+            'easterSaturday',
             'queensBirthday',
             'labourDay',
-            'aflGrandFinalFriday'
+            'aflGrandFinalFriday',
+            'melbourneCup'
         ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
@@ -51,6 +54,6 @@ class VictoriaTest extends AustraliaTest
      */
     protected function setUp()
     {
-        $this->year = $this->generateRandomYear(2015, 2016);
+        $this->year = $this->generateRandomYear(2015, 2018);
     }
 }

--- a/tests/Australia/WA/AnzacDayTest.php
+++ b/tests/Australia/WA/AnzacDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+/**
+ * Class for testing ANZAC day in WA (Australia)..
+ */
+class AnzacDayTest extends \Yasumi\tests\Australia\AnzacDayTest
+{
+}

--- a/tests/Australia/WA/AustraliaDayTest.php
+++ b/tests/Australia/WA/AustraliaDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+/**
+ * Class for testing Australia day in WA (Australia)..
+ */
+class AustraliaDayTest extends \Yasumi\tests\Australia\AustraliaDayTest
+{
+}

--- a/tests/Australia/WA/BoxingDayTest.php
+++ b/tests/Australia/WA/BoxingDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+/**
+ * Class for testing Boxing Day in WA (Australia)..
+ */
+class BoxingDayTest extends \Yasumi\tests\Australia\BoxingDayTest
+{
+}

--- a/tests/Australia/WA/ChristmasDayTest.php
+++ b/tests/Australia/WA/ChristmasDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+/**
+ * Class for testing Christmas Day in WA (Australia)..
+ */
+class ChristmasDayTest extends \Yasumi\tests\Australia\ChristmasDayTest
+{
+}

--- a/tests/Australia/WA/EasterMondayTest.php
+++ b/tests/Australia/WA/EasterMondayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+/**
+ * Class for testing Easter Monday in WA (Australia)..
+ */
+class EasterMondayTest extends \Yasumi\tests\Australia\EasterMondayTest
+{
+}

--- a/tests/Australia/WA/GoodFridayTest.php
+++ b/tests/Australia/WA/GoodFridayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+/**
+ * Class for testing Good Friday in WA (Australia)..
+ */
+class GoodFridayTest extends \Yasumi\tests\Australia\GoodFridayTest
+{
+}

--- a/tests/Australia/WA/LabourDayTest.php
+++ b/tests/Australia/WA/LabourDayTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Labour Day in WA (Australia)..
+ */
+class LabourDayTest extends WABaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'labourDay';
+
+    /**
+     * Tests Labour Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-03-01'],
+            [2011, '2011-03-07'],
+            [2012, '2012-03-05'],
+            [2013, '2013-03-04'],
+            [2014, '2014-03-03'],
+            [2015, '2015-03-02'],
+            [2016, '2016-03-07'],
+            [2017, '2017-03-06'],
+            [2018, '2018-03-05'],
+            [2019, '2019-03-04'],
+            [2020, '2020-03-02'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Labour Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Australia/WA/NewYearsDayTest.php
+++ b/tests/Australia/WA/NewYearsDayTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+/**
+ * Class for testing New Years Day in WA (Australia)..
+ */
+class NewYearsDayTest extends \Yasumi\tests\Australia\NewYearsDayTest
+{
+}

--- a/tests/Australia/WA/QueensBirthdayTest.php
+++ b/tests/Australia/WA/QueensBirthdayTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Queen's Birthday in WA (Australia)..
+ */
+class QueensBirthdayTest extends WABaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'queensBirthday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 1950;
+
+    /**
+     * Tests Queen's Birthday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-09-27'],
+            [2011, '2011-10-28'],
+            [2012, '2012-10-01'],
+            [2013, '2013-09-30'],
+            [2014, '2014-09-29'],
+            [2015, '2015-09-28'],
+            [2016, '2016-09-26'],
+            [2017, '2017-09-25'],
+            [2018, '2018-09-24'],
+            [2019, '2019-09-30'],
+            [2020, '2020-09-28'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Queen\'s Birthday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/WA/WABaseTestCase.php
+++ b/tests/Australia/WA/WABaseTestCase.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+use Yasumi\tests\Australia\AustraliaBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the Queensland holiday provider.
+ */
+abstract class WABaseTestCase extends AustraliaBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public $region = 'Australia\WA';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public $timezone = 'Australia/West';
+}

--- a/tests/Australia/WA/WATest.php
+++ b/tests/Australia/WA/WATest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in WA (Australia).
+ */
+class WATest extends WABaseTestCase
+{
+    public $region = 'Australia\WA';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in WA (Australia) are defined by the provider class
+     */
+    public function testOfficialHolidays()
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'christmasDay',
+            'secondChristmasDay',
+            'australiaDay',
+            'anzacDay',
+            'queensBirthday',
+            'labourDay',
+            'westernAustraliaDay',
+        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1921);
+    }
+}

--- a/tests/Australia/WA/WesternAustraliaDayTest.php
+++ b/tests/Australia/WA/WesternAustraliaDayTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author William Sanders <williamrsanders@hotmail.com>
+ */
+
+namespace Yasumi\tests\Australia\WA;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Western Australia Day in WA (Australia)..
+ */
+class WesternAustraliaDayTest extends WABaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    const HOLIDAY = 'westernAustraliaDay';
+
+    /**
+     * Tests Western Australia Day
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider()
+    {
+        $data = [
+            [2010, '2010-06-07'],
+            [2011, '2011-06-06'],
+            [2012, '2012-06-04'],
+            [2013, '2013-06-03'],
+            [2014, '2014-06-02'],
+            [2015, '2015-06-01'],
+            [2016, '2016-06-06'],
+            [2017, '2017-06-05'],
+            [2018, '2018-06-04'],
+            [2019, '2019-06-03'],
+            [2020, '2020-06-01'],
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1990),
+            [self::LOCALE => 'Western Australia Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType($this->region, self::HOLIDAY, $this->generateRandomYear(1990), Holiday::TYPE_OFFICIAL);
+    }
+}


### PR DESCRIPTION
Australian public holidays are actually rather complicated (particularly Tasmania...). Here are updates to properly handle (just about) all of them.