### PR TITLE
Changing Japan's holiday for the 2020 Olympic Games.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Added Day of Reformation as offical holiday since 2018 in Hamburg (Germany). [#108](https://github.com/azuyalabs/yasumi/pull/108)
 
 ### Changed
+- Changed Japanese holiday for the 2020 Olympic Games.Marine Day,Mountain Day and Health And Sports Day. [\#113](https://github.com/azuyalabs/yasumi/pull/113)
 - Summer/winter time is now fetched from PHP's tz database. [\#103](https://github.com/azuyalabs/yasumi/pull/103)
 - Changed translation for Norway's national day. [\#98](https://github.com/azuyalabs/yasumi/pull/98)
 

--- a/src/Yasumi/Provider/Japan.php
+++ b/src/Yasumi/Provider/Japan.php
@@ -139,18 +139,6 @@ class Japan extends AbstractProvider
         }
 
         /**
-         * Mountain Day. Mountain Day is held on August 11th and established since 2016.
-         */
-        if ($this->year >= 2016) {
-            $this->addHoliday(new Holiday(
-                'mountainDay',
-                ['en_US' => 'Mountain Day', 'ja_JP' => '山の日'],
-                new DateTime("$this->year-8-11", new DateTimeZone($this->timezone)),
-                $this->locale
-            ));
-        }
-
-        /**
          * Culture Day. Culture Day is held on November 11th and established since 1948.
          */
         if ($this->year >= 1948) {
@@ -191,6 +179,7 @@ class Japan extends AbstractProvider
         $this->calculateComingOfAgeDay();
         $this->calculateGreeneryDay();
         $this->calculateMarineDay();
+        $this->caluclateMountainDay();
         $this->calculateRespectForTheAgeDay();
         $this->calculateHealthAndSportsDay();
         $this->calculateAutumnalEquinoxDay();
@@ -294,7 +283,7 @@ class Japan extends AbstractProvider
     /**
      * Calculates Marine Day.
      *
-     * Marine Day was established since 1996 on July 20th. After 2003 it was changed to be the third monday of July.
+     * Marine Day was established since 1996 on July 20th. After 2003 it was changed to be the third monday of July.In 2020 is July 23th.
      *
      * @throws \Yasumi\Exception\InvalidDateException
      * @throws \InvalidArgumentException
@@ -303,7 +292,9 @@ class Japan extends AbstractProvider
     private function calculateMarineDay()
     {
         $date = null;
-        if ($this->year >= 2003) {
+        if ($this->year == 2020) {
+            $date = new DateTime("$this->year-7-23", new DateTimeZone($this->timezone));
+        } elseif ($this->year >= 2003) {
             $date = new DateTime("third monday of july $this->year", new DateTimeZone($this->timezone));
         } elseif ($this->year >= 1996) {
             $date = new DateTime("$this->year-7-20", new DateTimeZone($this->timezone));
@@ -313,6 +304,33 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'marineDay',
                 ['en_US' => 'Marine Day', 'ja_JP' => '海の日'],
+                $date,
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Calculates MountainDay
+     *
+     * Mountain Day. Mountain Day is held on August 11th and established since 2016.In 2020 is August 10th.
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     */
+    private function caluclateMountainDay()
+    {
+        $date = null;
+        if ($this->year == 2020) {
+            $date = new DateTime("$this->year-8-10", new DateTimeZone($this->timezone));
+        } elseif ($this->year >= 2016) {
+            $date = new DateTime("$this->year-8-11", new DateTimeZone($this->timezone));
+        }
+
+        if (null !== $date) {
+            $this->addHoliday(new Holiday(
+                'mountainDay',
+                ['en_US' => 'Mountain Day', 'ja_JP' => '山の日'],
                 $date,
                 $this->locale
             ));
@@ -352,7 +370,7 @@ class Japan extends AbstractProvider
      * Calculates Health And Sports Day.
      *
      * Health And Sports Day was established since 1966 on October 10th. After 2000 it was changed to be the second
-     * monday of October.
+     * monday of October.In 2020 is July 24th.
      *
      * @throws \Yasumi\Exception\InvalidDateException
      * @throws \InvalidArgumentException
@@ -361,7 +379,9 @@ class Japan extends AbstractProvider
     private function calculateHealthAndSportsDay()
     {
         $date = null;
-        if ($this->year >= 2000) {
+        if ($this->year == 2020) {
+            $date = new DateTime("$this->year-7-24", new DateTimeZone($this->timezone));
+        } elseif ($this->year >= 2000) {
             $date = new DateTime("second monday of october $this->year", new DateTimeZone($this->timezone));
         } elseif ($this->year >= 1996) {
             $date = new DateTime("$this->year-10-10", new DateTimeZone($this->timezone));

--- a/tests/Japan/HealthAndSportsDayTest.php
+++ b/tests/Japan/HealthAndSportsDayTest.php
@@ -33,6 +33,20 @@ class HealthAndSportsDayTest extends JapanBaseTestCase implements YasumiTestCase
     const ESTABLISHMENT_YEAR = 1996;
 
     /**
+     * Tests Health And Sports Day in 2020. Health And Sports Day in 2020 is July 24th for the Olympic Games.
+     */
+    public function testHealthAndSportsDayIn2020()
+    {
+        $year = 2020;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-7-24", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
      * Tests Health And Sports Day after 2000. Health And Sports Day was established since 1996 on October 10th. After
      * 2000 it was changed to be the second monday of October.
      */

--- a/tests/Japan/MarineDayTest.php
+++ b/tests/Japan/MarineDayTest.php
@@ -33,6 +33,20 @@ class MarineDayTest extends JapanBaseTestCase implements YasumiTestCaseInterface
     const ESTABLISHMENT_YEAR = 1996;
 
     /**
+     * Tests Marine Day in 2020. Marine Day in 2020 is July 23th for the Olympic Games.
+     */
+    public function testMarineDayIn2020()
+    {
+        $year = 2020;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-7-23", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
      * Tests Marine Day after 2003. Marine Day was established since 1996 on July 20th. After 2003 it was changed
      * to be the third monday of July.
      */

--- a/tests/Japan/MountainDayTest.php
+++ b/tests/Japan/MountainDayTest.php
@@ -33,6 +33,20 @@ class MountainDayTest extends JapanBaseTestCase implements YasumiTestCaseInterfa
     const ESTABLISHMENT_YEAR = 2016;
 
     /**
+     * Tests Mountain Day in 2020. Mountain Day in 2020 is August 10th for the Olympic Games.
+     */
+    public function testMountainDayIn2020()
+    {
+        $year = 2020;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-8-10", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
      * Tests Mountain Day after 2016. Mountain Day was established in 2014 and is held from 2016 on August 11th.
      */
     public function testMountainDayOnAfter2016()


### PR DESCRIPTION
It corresponds to the Japanese holiday of 2020.

In 2020
MarineDay: 2020/7/23
HealthAndSportsDay: 2020/7/24
MountainDay: 2020/8/10

http://www8.cao.go.jp/chosei/shukujitsu/gaiyou.html