### PR TITLE
tests: use HHVM 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
   - nightly
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.2
   - nightly
 
-dist: xenial
+dist: trusty
 sudo: required
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 7.0
   - 7.1
   - 7.2
-  - hhvm
   - nightly
 
 dist: xenial
@@ -15,8 +14,8 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install hhvm=3.\*
+  - if [[ $HHVM == true ]]; then sudo apt-get update; fi
+  - if [[ $HHVM == true ]]; then sudo apt-get install hhvm=3.\*; fi
 
 before_script:
   - composer self-update
@@ -38,3 +37,5 @@ matrix:
       env: PHPSTAN=1
     - php: 7.2
       env: PHPSTAN=1
+    - php: hhvm
+      env: HHVM=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,19 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - hhvm
   - nightly
+
+dist: xenial
+sudo: required
 
 cache:
   directories:
     - $HOME/.composer/cache
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install hhvm=3.\*
 
 before_script:
   - composer self-update


### PR DESCRIPTION
HHVM 3.30 will be the last release with PHP support. Currently not many dependencies support the HHVM engine.