### PR TITLE
Added Reformation Day as offical holiday since 2018 in Bremen (Germany).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Added Reformation Day as offical holiday since 2018 in Lower Saxony (Germany). [#115](https://github.com/azuyalabs/yasumi/issues/115)
 - Added Reformation Day as offical holiday since 2018 in Schleswig-Holstein (Germany). [#106](https://github.com/azuyalabs/yasumi/pull/106)
 - Added Day of Reformation as offical holiday since 2018 in Hamburg (Germany). [#108](https://github.com/azuyalabs/yasumi/pull/108)
+- Added Reformation Day as offical holiday since 2018 in Bremen (Germany). [#116](https://github.com/azuyalabs/yasumi/issues/116)
 
 ### Changed
 - Upgraded to PHPUnit 7.

--- a/src/Yasumi/Provider/Germany/Bremen.php
+++ b/src/Yasumi/Provider/Germany/Bremen.php
@@ -30,4 +30,35 @@ class Bremen extends Germany
      * country or sub-region.
      */
     const ID = 'DE-HB';
+
+    /**
+     * Initialize holidays for Bremen (Germany).
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize()
+    {
+        parent::initialize();
+
+        // Add custom Christian holidays
+        $this->calculateReformationDay();
+    }
+    /**
+     * For the German state of Bremen, Reformation Day is celebrated since 2018.
+     * Note: In 2017 all German states will celebrate Reformation Day for its 500th anniversary.
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     */
+    private function calculateReformationDay()
+    {
+        if ($this->year < 2018) {
+            return;
+        }
+        $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+    }
 }

--- a/tests/Germany/Bremen/ReformationDayTest.php
+++ b/tests/Germany/Bremen/ReformationDayTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2018 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <stelgenhof@gmail.com>
+ */
+
+namespace Yasumi\tests\Germany\Bremen;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Reformation Day in Bremen (Germany).
+ */
+class ReformationDayTest extends BremenBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    const HOLIDAY = 'reformationDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    const ESTABLISHMENT_YEAR = 2018;
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int      $year     the year for which the holiday defined in this test needs to be tested
+     * @param DateTime $expected the expected date
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year   = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+            $data[] = [$year, new DateTime("$year-10-31", new DateTimeZone(self::TIMEZONE))];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Reformationstag']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType()
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}


### PR DESCRIPTION
fixes #116