### PR TITLE
Remove locale from Holiday and Provider

### DIFF
--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -48,11 +48,6 @@ class Holiday extends DateTime implements JsonSerializable
     public const TYPE_OTHER = 'other';
 
     /**
-     * The default locale. Used for translations of holiday names and other text strings.
-     */
-    public const DEFAULT_LOCALE = 'en_US';
-
-    /**
      * @var array list of all defined locales
      */
     private static $locales = [];
@@ -87,7 +82,6 @@ class Holiday extends DateTime implements JsonSerializable
      * @param array              $names         An array containing the name/description of this holiday in various
      *                                          languages. Overrides global translations
      * @param \DateTimeInterface $date          A DateTimeInterface instance representing the date of the holiday
-     * @param string             $displayLocale Locale (i.e. language) in which the holiday information needs to be
      *                                          displayed in. (Default 'en_US')
      * @param string             $type          The type of holiday. Use the following constants: TYPE_OFFICIAL,
      *                                          TYPE_OBSERVANCE, TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an
@@ -102,7 +96,6 @@ class Holiday extends DateTime implements JsonSerializable
         string $shortName,
         array $names,
         \DateTimeInterface $date,
-        string $displayLocale = self::DEFAULT_LOCALE,
         string $type = self::TYPE_OFFICIAL
     ) {
         // Validate if short name is not empty
@@ -110,20 +103,9 @@ class Holiday extends DateTime implements JsonSerializable
             throw new InvalidArgumentException('Holiday name can not be blank.');
         }
 
-        // Load internal locales variable
-        if (empty(self::$locales)) {
-            self::$locales = Yasumi::getAvailableLocales();
-        }
-
-        // Assert display locale input
-        if (! \in_array($displayLocale, self::$locales, true)) {
-            throw new UnknownLocaleException(\sprintf('Locale "%s" is not a valid locale.', $displayLocale));
-        }
-
         // Set additional attributes
         $this->shortName     = $shortName;
         $this->translations  = $names;
-        $this->displayLocale = $displayLocale;
         $this->type          = $type;
 
         // Construct instance
@@ -157,9 +139,13 @@ class Holiday extends DateTime implements JsonSerializable
      * defined, the name in the default locale ('en_US') is returned. In case there is no translation at all, the short
      * internal name is returned.
      */
-    public function getName(): string
+    public function getName(string $locale = null): string
     {
-        return $this->translations[$this->displayLocale] ?? $this->translations[self::DEFAULT_LOCALE] ?? $this->shortName;
+        if (!$locale) {
+            $locale = Yasumi::getDefaultLocale();
+        }
+
+        return $this->translations[$locale] ?? $this->translations[Yasumi::FALLBACK_LOCALE] ?? $this->shortName;
     }
 
     /**

--- a/src/Yasumi/Provider/AbstractProvider.php
+++ b/src/Yasumi/Provider/AbstractProvider.php
@@ -81,11 +81,6 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
     protected $timezone;
 
     /**
-     * @var string the object's current locale
-     */
-    protected $locale;
-
-    /**
      * @var Holiday[] list of dates of the available holidays
      */
     private $holidays = [];
@@ -99,16 +94,14 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
      * Creates a new holiday provider (i.e. country/state).
      *
      * @param int                        $year               the year for which to provide holidays
-     * @param string                     $locale             the locale/language in which holidays need to be
      *                                                       represented
      * @param TranslationsInterface|null $globalTranslations global translations
      */
-    public function __construct($year, $locale = 'en_US', TranslationsInterface $globalTranslations = null)
+    public function __construct($year, TranslationsInterface $globalTranslations = null)
     {
         $this->clearHolidays();
 
         $this->year               = $year ?: \getdate()['year'];
-        $this->locale             = $locale;
         $this->globalTranslations = $globalTranslations;
 
         $this->initialize();
@@ -366,7 +359,7 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
         // Get calling class name
         $hReflectionClass = new \ReflectionClass(\get_class($this));
 
-        return Yasumi::create($hReflectionClass->getShortName(), $year, $this->locale)->getHoliday($shortName);
+        return Yasumi::create($hReflectionClass->getShortName(), $year)->getHoliday($shortName);
     }
 
     /**

--- a/src/Yasumi/Provider/ChristianHolidays.php
+++ b/src/Yasumi/Provider/ChristianHolidays.php
@@ -36,7 +36,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Easter need to be created
      * @param string $timezone the timezone in which Easter is celebrated
-     * @param string $locale   the locale for which Easter need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -47,9 +46,18 @@ trait ChristianHolidays
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    public function easter(int $year, string $timezone, string $locale, string $type = Holiday::TYPE_OFFICIAL): Holiday
+    public function easter(
+        int $year,
+        string $timezone,
+        string $type = Holiday::TYPE_OFFICIAL
+    ): Holiday
     {
-        return new Holiday('easter', [], $easter = $this->calculateEaster($year, $timezone), $locale, $type);
+        return new Holiday(
+            'easter',
+            [],
+            $easter = $this->calculateEaster($year, $timezone),
+            $type
+        );
     }
 
     /**
@@ -63,7 +71,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Easter Monday need to be created
      * @param string $timezone the timezone in which Easter Monday is celebrated
-     * @param string $locale   the locale for which Easter Monday need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -77,14 +84,12 @@ trait ChristianHolidays
     public function easterMonday(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'easterMonday',
             [],
             $this->calculateEaster($year, $timezone)->add(new DateInterval('P1D')),
-            $locale,
             $type
         );
     }
@@ -100,7 +105,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Ascension need to be created
      * @param string $timezone the timezone in which Ascension is celebrated
-     * @param string $locale   the locale for which Ascension need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -114,14 +118,12 @@ trait ChristianHolidays
     public function ascensionDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'ascensionDay',
             [],
             $this->calculateEaster($year, $timezone)->add(new DateInterval('P39D')),
-            $locale,
             $type
         );
     }
@@ -134,7 +136,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Pentecost need to be created
      * @param string $timezone the timezone in which Pentecost is celebrated
-     * @param string $locale   the locale for which Pentecost need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -148,14 +149,12 @@ trait ChristianHolidays
     public function pentecost(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'pentecost',
             [],
             $this->calculateEaster($year, $timezone)->add(new DateInterval('P49D')),
-            $locale,
             $type
         );
     }
@@ -168,7 +167,7 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Pentecost (Whitmonday) need to be created
      * @param string $timezone the timezone in which Pentecost (Whitmonday) is celebrated
-     * @param string $locale   the locale for which Pentecost (Whitmonday) need to be displayed in.
+     * splayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -182,14 +181,12 @@ trait ChristianHolidays
     public function pentecostMonday(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'pentecostMonday',
             [],
             $this->calculateEaster($year, $timezone)->add(new DateInterval('P50D')),
-            $locale,
             $type
         );
     }
@@ -205,7 +202,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Corpus Christi need to be created
      * @param string $timezone the timezone in which Corpus Christi is celebrated
-     * @param string $locale   the locale for which Corpus Christi need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default a type of 'other' is considered.
      *
@@ -219,14 +215,12 @@ trait ChristianHolidays
     public function corpusChristi(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OTHER
     ): Holiday {
         return new Holiday(
             'corpusChristi',
             [],
             $this->calculateEaster($year, $timezone)->add(new DateInterval('P60D')),
-            $locale,
             $type
         );
     }
@@ -243,7 +237,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Christmas Eve needs to be created
      * @param string $timezone the timezone in which Christmas Eve is celebrated
-     * @param string $locale   the locale for which Christmas Eve need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default observance is considered.
      *
@@ -257,14 +250,12 @@ trait ChristianHolidays
     public function christmasEve(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OBSERVANCE
     ): Holiday {
         return new Holiday(
             'christmasEve',
             [],
             new DateTime("$year-12-24", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -278,7 +269,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Christmas Day need to be created
      * @param string $timezone the timezone in which Christmas Day is celebrated
-     * @param string $locale   the locale for which Christmas Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -292,14 +282,12 @@ trait ChristianHolidays
     public function christmasDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'christmasDay',
             [],
             new DateTime("$year-12-25", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -313,7 +301,7 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which the Second Christmas Day / Boxing Day need to be created
      * @param string $timezone the timezone in which the Second Christmas Day / Boxing Day is celebrated
-     * @param string $locale   the locale for which the Second Christmas Day / Boxing Day need to be displayed in.
+     * ed to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -327,14 +315,12 @@ trait ChristianHolidays
     public function secondChristmasDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'secondChristmasDay',
             [],
             new DateTime("$year-12-26", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -351,7 +337,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which All Saints' Day need to be created
      * @param string $timezone the timezone in which All Saints' Day is celebrated
-     * @param string $locale   the locale for which All Saints' Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -365,10 +350,14 @@ trait ChristianHolidays
     public function allSaintsDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('allSaintsDay', [], new DateTime("$year-11-1", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday(
+            'allSaintsDay',
+            [],
+            new DateTime("$year-11-1", new DateTimeZone($timezone)),
+            $type
+        );
     }
 
     /**
@@ -382,7 +371,7 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which the day of the Assumption of Mary need to be created
      * @param string $timezone the timezone in which the day of the Assumption of Mary is celebrated
-     * @param string $locale   the locale for which the day of the Assumption of Mary need to be displayed in.
+     *  displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -396,14 +385,12 @@ trait ChristianHolidays
     public function assumptionOfMary(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'assumptionOfMary',
             [],
             new DateTime("$year-8-15", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -417,7 +404,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Good Friday need to be created
      * @param string $timezone the timezone in which Good Friday is celebrated
-     * @param string $locale   the locale for which Good Friday need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -431,14 +417,12 @@ trait ChristianHolidays
     public function goodFriday(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'goodFriday',
             [],
             $this->calculateEaster($year, $timezone)->sub(new DateInterval('P2D')),
-            $locale,
             $type
         );
     }
@@ -456,7 +440,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Epiphany need to be created
      * @param string $timezone the timezone in which Epiphany is celebrated
-     * @param string $locale   the locale for which Epiphany need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -470,10 +453,14 @@ trait ChristianHolidays
     public function epiphany(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('epiphany', [], new DateTime("$year-1-6", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday(
+            'epiphany',
+            [],
+            new DateTime("$year-1-6", new DateTimeZone($timezone)),
+            $type
+        );
     }
 
     /**
@@ -487,7 +474,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Ash Wednesday need to be created
      * @param string $timezone the timezone in which Ash Wednesday is celebrated
-     * @param string $locale   the locale for which Ash Wednesday need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -501,14 +487,12 @@ trait ChristianHolidays
     public function ashWednesday(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'ashWednesday',
             [],
             $this->calculateEaster($year, $timezone)->sub(new DateInterval('P46D')),
-            $locale,
             $type
         );
     }
@@ -525,7 +509,7 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Immaculate Conception need to be created
      * @param string $timezone the timezone in which Immaculate Conception is celebrated
-     * @param string $locale   the locale for which Immaculate Conception need to be displayed in.
+     * splayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -539,14 +523,12 @@ trait ChristianHolidays
     public function immaculateConception(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'immaculateConception',
             [],
             new DateTime("$year-12-8", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -564,7 +546,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which St. Stephen's Day need to be created
      * @param string $timezone the timezone in which St. Stephen's Day is celebrated
-     * @param string $locale   the locale for which St. Stephen's Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -578,14 +559,12 @@ trait ChristianHolidays
     public function stStephensDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'stStephensDay',
             [],
             new DateTime("$year-12-26", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -603,7 +582,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which St. Joseph's Day need to be created
      * @param string $timezone the timezone in which St. Joseph's Day is celebrated
-     * @param string $locale   the locale for which St. Joseph's Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -617,10 +595,14 @@ trait ChristianHolidays
     public function stJosephsDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('stJosephsDay', [], new DateTime("$year-3-19", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday(
+            'stJosephsDay',
+            [],
+            new DateTime("$year-3-19", new DateTimeZone($timezone)),
+            $type
+        );
     }
 
     /**
@@ -635,7 +617,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which Maundy Thursday need to be created
      * @param string $timezone the timezone in which Maundy Thursday is celebrated
-     * @param string $locale   the locale for which Maundy Thursday need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -649,14 +630,12 @@ trait ChristianHolidays
     public function maundyThursday(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'maundyThursday',
             [],
             $this->calculateEaster($year, $timezone)->sub(new DateInterval('P3D')),
-            $locale,
             $type
         );
     }
@@ -673,7 +652,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which St. George's Day need to be created
      * @param string $timezone the timezone in which St. George's Day is celebrated
-     * @param string $locale   the locale for which St. George's Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -687,10 +665,14 @@ trait ChristianHolidays
     public function stGeorgesDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('stGeorgesDay', [], new DateTime("$year-4-23", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday(
+            'stGeorgesDay',
+            [],
+            new DateTime("$year-4-23", new DateTimeZone($timezone)),
+            $type
+        );
     }
 
     /**
@@ -706,7 +688,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which St. John's Day need to be created
      * @param string $timezone the timezone in which St. John's Day is celebrated
-     * @param string $locale   the locale for which St. John's Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -720,10 +701,14 @@ trait ChristianHolidays
     public function stJohnsDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('stJohnsDay', [], new DateTime("$year-06-24", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday(
+            'stJohnsDay',
+            [],
+            new DateTime("$year-06-24", new DateTimeZone($timezone)),
+            $type
+        );
     }
 
     /**
@@ -739,7 +724,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which the Annunciation needs to be created
      * @param string $timezone the timezone in which the Annunciation is celebrated
-     * @param string $locale   the locale for which the Annunciation need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -753,14 +737,12 @@ trait ChristianHolidays
     public function annunciation(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'annunciation',
             [],
             new DateTime("$year-03-25", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -807,7 +789,6 @@ trait ChristianHolidays
      *
      * @param int    $year     the year for which St. John's Day need to be created
      * @param string $timezone the timezone in which St. John's Day is celebrated
-     * @param string $locale   the locale for which St. John's Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -821,14 +802,12 @@ trait ChristianHolidays
     public function reformationDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'reformationDay',
             [],
             new DateTime("$year-10-31", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }

--- a/src/Yasumi/Provider/CommonHolidays.php
+++ b/src/Yasumi/Provider/CommonHolidays.php
@@ -35,7 +35,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which New Year's Eve need to be created
      * @param string $timezone the timezone in which New Year's Eve is celebrated
-     * @param string $locale   the locale for which New Year's Eve need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -49,10 +48,14 @@ trait CommonHolidays
     public function newYearsEve(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('newYearsEve', [], new DateTime("$year-12-31", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday(
+            'newYearsEve',
+            [],
+            new DateTime("$year-12-31", new DateTimeZone($timezone)),
+            $type
+        );
     }
 
     /**
@@ -69,7 +72,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which New Year's Day need to be created
      * @param string $timezone the timezone in which New Year's Day is celebrated
-     * @param string $locale   the locale for which New Year's Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -83,10 +85,14 @@ trait CommonHolidays
     public function newYearsDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('newYearsDay', [], new DateTime("$year-1-1", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday(
+            'newYearsDay',
+            [],
+            new DateTime("$year-1-1", new DateTimeZone($timezone)),
+            $type
+        );
     }
 
     /**
@@ -102,7 +108,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which International Workers' Day need to be created
      * @param string $timezone the timezone in which International Workers' Day is celebrated
-     * @param string $locale   the locale for which International Workers' Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -116,14 +121,12 @@ trait CommonHolidays
     public function internationalWorkersDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'internationalWorkersDay',
             [],
             new DateTime("$year-5-1", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -141,7 +144,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which Valentine's Day need to be created
      * @param string $timezone the timezone in which Valentine's Day is celebrated
-     * @param string $locale   the locale for which Valentine's Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -155,14 +157,12 @@ trait CommonHolidays
     public function valentinesDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'valentinesDay',
             [],
             new DateTime("$year-2-14", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -178,7 +178,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which World Animal Day need to be created
      * @param string $timezone the timezone in which World Animal Day is celebrated
-     * @param string $locale   the locale for which World Animal Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -192,14 +191,12 @@ trait CommonHolidays
     public function worldAnimalDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'worldAnimalDay',
             [],
             new DateTime("$year-10-4", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -217,7 +214,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which St. Martin's Day need to be created
      * @param string $timezone the timezone in which St. Martin's Day is celebrated
-     * @param string $locale   the locale for which St. Martin's Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -231,14 +227,12 @@ trait CommonHolidays
     public function stMartinsDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'stMartinsDay',
             [],
             new DateTime("$year-11-11", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -255,7 +249,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which Father's Day need to be created
      * @param string $timezone the timezone in which Father's Day is celebrated
-     * @param string $locale   the locale for which Father's Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -269,14 +262,12 @@ trait CommonHolidays
     public function fathersDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'fathersDay',
             [],
             new DateTime("third sunday of june $year", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -293,7 +284,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which Mother's Day need to be created
      * @param string $timezone the timezone in which Mother's Day is celebrated
-     * @param string $locale   the locale for which Mother's Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -307,14 +297,12 @@ trait CommonHolidays
     public function mothersDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'mothersDay',
             [],
             new DateTime("second sunday of may $year", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -331,7 +319,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which Victory in Europe Day need to be created
      * @param string $timezone the timezone in which Victory in Europe Day is celebrated
-     * @param string $locale   the locale for which Victory in Europe Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -345,14 +332,12 @@ trait CommonHolidays
     public function victoryInEuropeDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'victoryInEuropeDay',
             [],
             new DateTime("$year-5-8", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -371,7 +356,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which Armistice Day need to be created
      * @param string $timezone the timezone in which Armistice Day is celebrated
-     * @param string $locale   the locale for which Armistice Day need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -385,14 +369,12 @@ trait CommonHolidays
     public function armisticeDay(
         int $year,
         string $timezone,
-        string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
         return new Holiday(
             'armisticeDay',
             [],
             new DateTime("$year-11-11", new DateTimeZone($timezone)),
-            $locale,
             $type
         );
     }
@@ -444,7 +426,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which summer time need to be created
      * @param string $timezone the timezone in which summer time transition occurs
-     * @param string $locale   the locale for which summer time need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -454,7 +435,7 @@ trait CommonHolidays
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    public function summerTime($year, $timezone, $locale, $type = Holiday::TYPE_SEASON): ?Holiday
+    public function summerTime($year, $timezone, $type = Holiday::TYPE_SEASON): ?Holiday
     {
         $date = $this->calculateSummerWinterTime($year, $timezone, true);
 
@@ -463,7 +444,6 @@ trait CommonHolidays
                 'summerTime',
                 [],
                 $date,
-                $locale,
                 $type
             );
         }
@@ -478,7 +458,6 @@ trait CommonHolidays
      *
      * @param int    $year     the year for which summer time need to be created
      * @param string $timezone the timezone in which summer time transition occurs
-     * @param string $locale   the locale for which summer time need to be displayed in.
      * @param string $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
      *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
      *
@@ -488,7 +467,7 @@ trait CommonHolidays
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    public function winterTime($year, $timezone, $locale, $type = Holiday::TYPE_SEASON): ?Holiday
+    public function winterTime($year, $timezone, $type = Holiday::TYPE_SEASON): ?Holiday
     {
         $date = $this->calculateSummerWinterTime($year, $timezone, false);
 
@@ -497,7 +476,6 @@ trait CommonHolidays
                 'winterTime',
                 [],
                 $date,
-                $locale,
                 $type
             );
         }

--- a/src/Yasumi/Provider/Denmark.php
+++ b/src/Yasumi/Provider/Denmark.php
@@ -43,30 +43,30 @@ class Denmark extends AbstractProvider
         $this->timezone = 'Europe/Copenhagen';
 
         // Add common holidays
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
 
         // Add common Christian holidays (common in Denmark)
-        $this->addHoliday($this->maundyThursday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->ascensionDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->maundyThursday($this->year, $this->timezone));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone));
+        $this->addHoliday($this->easter($this->year, $this->timezone));
+        $this->addHoliday($this->easterMonday($this->year, $this->timezone));
+        $this->addHoliday($this->ascensionDay($this->year, $this->timezone));
+        $this->addHoliday($this->pentecost($this->year, $this->timezone));
+        $this->addHoliday($this->pentecostMonday($this->year, $this->timezone));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone));
+        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone));
         $this->calculateGreatPrayerDay();
 
-        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->christmasEve($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->newYearsEve($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->christmasEve($this->year, $this->timezone));
+        $this->addHoliday($this->newYearsEve($this->year, $this->timezone, Holiday::TYPE_OBSERVANCE));
         $this->calculateConstitutionDay();
 
-        $summerTime = $this->summerTime($this->year, $this->timezone, $this->locale);
+        $summerTime = $this->summerTime($this->year, $this->timezone);
         if ($summerTime !== null) {
             $this->addHoliday($summerTime);
         }
-        $winterTime = $this->winterTime($this->year, $this->timezone, $this->locale);
+        $winterTime = $this->winterTime($this->year, $this->timezone);
         if ($winterTime !== null) {
             $this->addHoliday($winterTime);
         }
@@ -96,8 +96,7 @@ class Denmark extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'greatPrayerDay',
                 ['da_DK' => 'Store bededag'],
-                new DateTime("fourth friday $easter", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("fourth friday $easter", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -125,7 +124,6 @@ class Denmark extends AbstractProvider
                 'constitutionDay',
                 ['da_DK' => 'Grundlovsdag'],
                 new DateTime("$this->year-6-5", new DateTimeZone($this->timezone)),
-                $this->locale,
                 Holiday::TYPE_OBSERVANCE
             ));
         }

--- a/src/Yasumi/Provider/Germany.php
+++ b/src/Yasumi/Provider/Germany.php
@@ -42,24 +42,24 @@ class Germany extends AbstractProvider
         $this->timezone = 'Europe/Berlin';
 
         // Add common holidays
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
 
         // Add common Christian holidays (common in Germany)
-        $this->addHoliday($this->ascensionDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->ascensionDay($this->year, $this->timezone));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone));
+        $this->addHoliday($this->easterMonday($this->year, $this->timezone));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone));
+        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
+        $this->addHoliday($this->pentecostMonday($this->year, $this->timezone));
+        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone));
 
         // Calculate other holidays
         $this->calculateGermanUnityDay();
 
         // Note: all German states have agreed this to be a nationwide holiday in 2017 to celebrate the 500th anniversary.
         if ($this->year === 2017) {
-            $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+            $this->addHoliday($this->reformationDay($this->year, $this->timezone));
         }
     }
 
@@ -86,8 +86,7 @@ class Germany extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'germanUnityDay',
                 ['de_DE' => 'Tag der Deutschen Einheit'],
-                new DateTime($this->year . '-10-3', new \DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime($this->year . '-10-3', new \DateTimeZone($this->timezone))
             ));
         }
     }

--- a/src/Yasumi/Provider/Germany/BadenWurttemberg.php
+++ b/src/Yasumi/Provider/Germany/BadenWurttemberg.php
@@ -45,8 +45,8 @@ class BadenWurttemberg extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->epiphany($this->year, $this->timezone, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone));
+        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, Holiday::TYPE_OTHER));
     }
 }

--- a/src/Yasumi/Provider/Germany/Bavaria.php
+++ b/src/Yasumi/Provider/Germany/Bavaria.php
@@ -46,8 +46,8 @@ class Bavaria extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->epiphany($this->year, $this->timezone, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone));
+        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, Holiday::TYPE_OTHER));
     }
 }

--- a/src/Yasumi/Provider/Germany/Brandenburg.php
+++ b/src/Yasumi/Provider/Germany/Brandenburg.php
@@ -44,8 +44,8 @@ class Brandenburg extends Germany
         parent::initialize();
 
         // Add specific Christian holidays
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->easter($this->year, $this->timezone));
+        $this->addHoliday($this->pentecost($this->year, $this->timezone));
 
         // Add custom Christian holidays
         $this->calculateReformationDay();
@@ -66,6 +66,6 @@ class Brandenburg extends Germany
             return;
         }
 
-        $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->reformationDay($this->year, $this->timezone));
     }
 }

--- a/src/Yasumi/Provider/Germany/Bremen.php
+++ b/src/Yasumi/Provider/Germany/Bremen.php
@@ -61,6 +61,6 @@ class Bremen extends Germany
         if ($this->year < 2018) {
             return;
         }
-        $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->reformationDay($this->year, $this->timezone));
     }
 }

--- a/src/Yasumi/Provider/Germany/Hamburg.php
+++ b/src/Yasumi/Provider/Germany/Hamburg.php
@@ -68,7 +68,6 @@ class Hamburg extends Germany
                 'dayOfReformation',
                 [],
                 new \DateTime("{$this->year}-10-31", new \DateTimeZone($this->timezone)),
-                $this->locale,
                 Holiday::TYPE_OFFICIAL
             )
         );

--- a/src/Yasumi/Provider/Germany/Hesse.php
+++ b/src/Yasumi/Provider/Germany/Hesse.php
@@ -46,6 +46,6 @@ class Hesse extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone));
     }
 }

--- a/src/Yasumi/Provider/Germany/LowerSaxony.php
+++ b/src/Yasumi/Provider/Germany/LowerSaxony.php
@@ -64,6 +64,6 @@ class LowerSaxony extends Germany
         if ($this->year < 2018) {
             return;
         }
-        $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->reformationDay($this->year, $this->timezone));
     }
 }

--- a/src/Yasumi/Provider/Germany/MecklenburgWesternPomerania.php
+++ b/src/Yasumi/Provider/Germany/MecklenburgWesternPomerania.php
@@ -63,6 +63,6 @@ class MecklenburgWesternPomerania extends Germany
             return;
         }
 
-        $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->reformationDay($this->year, $this->timezone));
     }
 }

--- a/src/Yasumi/Provider/Germany/NorthRhineWestphalia.php
+++ b/src/Yasumi/Provider/Germany/NorthRhineWestphalia.php
@@ -46,7 +46,7 @@ class NorthRhineWestphalia extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone));
+        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, Holiday::TYPE_OTHER));
     }
 }

--- a/src/Yasumi/Provider/Germany/RhinelandPalatinate.php
+++ b/src/Yasumi/Provider/Germany/RhinelandPalatinate.php
@@ -45,7 +45,7 @@ class RhinelandPalatinate extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone));
+        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, Holiday::TYPE_OTHER));
     }
 }

--- a/src/Yasumi/Provider/Germany/Saarland.php
+++ b/src/Yasumi/Provider/Germany/Saarland.php
@@ -46,8 +46,8 @@ class Saarland extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
-        $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone));
+        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, Holiday::TYPE_OTHER));
     }
 }

--- a/src/Yasumi/Provider/Germany/Saxony.php
+++ b/src/Yasumi/Provider/Germany/Saxony.php
@@ -65,7 +65,7 @@ class Saxony extends Germany
             return;
         }
 
-        $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->reformationDay($this->year, $this->timezone));
     }
 
     /**
@@ -92,7 +92,6 @@ class Saxony extends Germany
                 'repentanceAndPrayerDay',
                 ['de_DE' => 'Buß- und Bettag'],
                 new DateTime("next wednesday $this->year-11-15", new DateTimeZone($this->timezone)),
-                $this->locale,
                 Holiday::TYPE_OFFICIAL
             ));
         }

--- a/src/Yasumi/Provider/Germany/SaxonyAnhalt.php
+++ b/src/Yasumi/Provider/Germany/SaxonyAnhalt.php
@@ -45,7 +45,7 @@ class SaxonyAnhalt extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->epiphany($this->year, $this->timezone, Holiday::TYPE_OTHER));
         $this->calculateReformationDay();
     }
 
@@ -64,6 +64,6 @@ class SaxonyAnhalt extends Germany
             return;
         }
 
-        $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->reformationDay($this->year, $this->timezone));
     }
 }

--- a/src/Yasumi/Provider/Germany/SchleswigHolstein.php
+++ b/src/Yasumi/Provider/Germany/SchleswigHolstein.php
@@ -30,7 +30,7 @@ class SchleswigHolstein extends Germany
      * country or sub-region.
      */
     public const ID = 'DE-SH';
-    
+
     /**
      * Initialize holidays for Schleswig-Holstein (Germany).
      *
@@ -61,6 +61,6 @@ class SchleswigHolstein extends Germany
         if ($this->year < 2018) {
             return;
         }
-        $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->reformationDay($this->year, $this->timezone));
     }
 }

--- a/src/Yasumi/Provider/Germany/Thuringia.php
+++ b/src/Yasumi/Provider/Germany/Thuringia.php
@@ -63,6 +63,6 @@ class Thuringia extends Germany
             return;
         }
 
-        $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->reformationDay($this->year, $this->timezone));
     }
 }

--- a/src/Yasumi/Provider/Ireland.php
+++ b/src/Yasumi/Provider/Ireland.php
@@ -51,10 +51,10 @@ class Ireland extends AbstractProvider
         $this->calculateNewYearsDay();
 
         // Add common Christian holidays (common in Ireland)
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->easter($this->year, $this->timezone));
+        $this->addHoliday($this->easterMonday($this->year, $this->timezone));
+        $this->addHoliday($this->pentecost($this->year, $this->timezone, Holiday::TYPE_OBSERVANCE));
         $this->calculatePentecostMonday();
         $this->calculateChristmasDay();
         $this->calculateStStephensDay();
@@ -66,8 +66,7 @@ class Ireland extends AbstractProvider
         $this->addHoliday(new Holiday(
             'augustHoliday',
             ['en_IE' => 'August Holiday', 'ga_IE' => 'Lá Saoire i mí Lúnasa'],
-            new DateTime("next monday $this->year-7-31", new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime("next monday $this->year-7-31", new DateTimeZone($this->timezone))
         ));
         $this->calculateOctoberHoliday();
     }
@@ -97,7 +96,7 @@ class Ireland extends AbstractProvider
             return;
         }
 
-        $holiday = $this->newYearsDay($this->year, $this->timezone, $this->locale);
+        $holiday = $this->newYearsDay($this->year, $this->timezone);
         $this->addHoliday($holiday);
 
         // Substitute holiday is on the next available weekday if a holiday falls on a Sunday.
@@ -107,7 +106,7 @@ class Ireland extends AbstractProvider
 
             $this->addHoliday(new Holiday('substituteHoliday:' . $substituteHoliday->shortName, [
                 'en_IE' => $substituteHoliday->getName() . ' observed',
-            ], $substituteHoliday, $this->locale));
+            ], $substituteHoliday));
         }
     }
 
@@ -130,7 +129,7 @@ class Ireland extends AbstractProvider
             return;
         }
 
-        $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->pentecostMonday($this->year, $this->timezone));
     }
 
     /**
@@ -152,8 +151,7 @@ class Ireland extends AbstractProvider
         $holiday = new Holiday(
             'christmasDay',
             ['en_IE' => 'Christmas Day', 'ga_IE' => 'Lá Nollag'],
-            new DateTime($this->year . '-12-25', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime($this->year . '-12-25', new DateTimeZone($this->timezone))
         );
 
         $this->addHoliday($holiday);
@@ -165,7 +163,7 @@ class Ireland extends AbstractProvider
 
             $this->addHoliday(new Holiday('substituteHoliday:' . $substituteHoliday->shortName, [
                 'en_IE' => $substituteHoliday->getName() . ' observed',
-            ], $substituteHoliday, $this->locale));
+            ], $substituteHoliday));
         }
     }
 
@@ -189,8 +187,7 @@ class Ireland extends AbstractProvider
         $holiday = new Holiday(
             'stStephensDay',
             [],
-            new DateTime($this->year . '-12-26', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime($this->year . '-12-26', new DateTimeZone($this->timezone))
         );
 
         $this->addHoliday($holiday);
@@ -202,7 +199,7 @@ class Ireland extends AbstractProvider
 
             $this->addHoliday(new Holiday('substituteHoliday:' . $substituteHoliday->shortName, [
                 'en_IE' => $substituteHoliday->getName() . ' observed',
-            ], $substituteHoliday, $this->locale));
+            ], $substituteHoliday));
         }
     }
 
@@ -231,8 +228,7 @@ class Ireland extends AbstractProvider
         $holiday = new Holiday(
             'stPatricksDay',
             ['en_IE' => 'St. Patrick\'s Day', 'ga_IE' => 'Lá Fhéile Pádraig'],
-            new DateTime($this->year . '-3-17', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime($this->year . '-3-17', new DateTimeZone($this->timezone))
         );
 
         $this->addHoliday($holiday);
@@ -242,9 +238,11 @@ class Ireland extends AbstractProvider
             $substituteHoliday = clone $holiday;
             $substituteHoliday->modify('next monday');
 
-            $this->addHoliday(new Holiday('substituteHoliday:' . $substituteHoliday->shortName, [
-                'en_IE' => $substituteHoliday->getName() . ' observed',
-            ], $substituteHoliday, $this->locale));
+            $this->addHoliday(new Holiday(
+                'substituteHoliday:' . $substituteHoliday->shortName,
+                ['en_IE' => $substituteHoliday->getName() . ' observed'],
+                $substituteHoliday
+            ));
         }
     }
 
@@ -274,8 +272,7 @@ class Ireland extends AbstractProvider
         $this->addHoliday(new Holiday(
             'mayDay',
             ['en_IE' => 'May Day', 'ga_IE' => 'Lá Bealtaine'],
-            new DateTime("next monday $this->year-4-30", new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime("next monday $this->year-4-30", new DateTimeZone($this->timezone))
         ));
     }
 
@@ -302,8 +299,7 @@ class Ireland extends AbstractProvider
         $this->addHoliday(new Holiday(
             'juneHoliday',
             ['en_IE' => 'June Holiday', 'ga_IE' => 'Lá Saoire i mí an Mheithimh'],
-            new DateTime("next monday $this->year-5-31", new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime("next monday $this->year-5-31", new DateTimeZone($this->timezone))
         ));
     }
 
@@ -329,8 +325,7 @@ class Ireland extends AbstractProvider
         $this->addHoliday(new Holiday(
             'octoberHoliday',
             ['en_IE' => 'October Holiday', 'ga_IE' => 'Lá Saoire i mí Dheireadh Fómhair'],
-            new DateTime("previous monday $this->year-11-01", new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime("previous monday $this->year-11-01", new DateTimeZone($this->timezone))
         ));
     }
 }

--- a/src/Yasumi/Provider/Italy.php
+++ b/src/Yasumi/Provider/Italy.php
@@ -42,18 +42,18 @@ class Italy extends AbstractProvider
         $this->timezone = 'Europe/Rome';
 
         // Add common holidays
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
 
         // Add Christian holidays
-        $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->immaculateConception($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->stStephensDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->epiphany($this->year, $this->timezone));
+        $this->addHoliday($this->easter($this->year, $this->timezone));
+        $this->addHoliday($this->easterMonday($this->year, $this->timezone));
+        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone));
+        $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone));
+        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone));
+        $this->addHoliday($this->immaculateConception($this->year, $this->timezone));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone));
+        $this->addHoliday($this->stStephensDay($this->year, $this->timezone));
 
         // Calculate other holidays
         $this->calculateLiberationDay();
@@ -83,8 +83,7 @@ class Italy extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'liberationDay',
                 ['it_IT' => 'Festa della Liberazione'],
-                new DateTime("$this->year-4-25", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-4-25", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -111,8 +110,7 @@ class Italy extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'republicDay',
                 ['it_IT' => 'Festa della Republica'],
-                new DateTime("$this->year-6-2", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-6-2", new DateTimeZone($this->timezone))
             ));
         }
     }

--- a/src/Yasumi/Provider/Japan.php
+++ b/src/Yasumi/Provider/Japan.php
@@ -85,7 +85,7 @@ class Japan extends AbstractProvider
 
         // Add common holidays
         if ($this->year >= 1948) {
-            $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+            $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
         }
 
         // Calculate other holidays
@@ -119,8 +119,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'nationalFoundationDay',
                 ['en_US' => 'National Foundation Day', 'ja_JP' => '建国記念の日'],
-                new DateTime("$this->year-2-11", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-2-11", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -136,8 +135,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'showaDay',
                 ['en_US' => 'Showa Day', 'ja_JP' => '昭和の日'],
-                new DateTime("$this->year-4-29", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-4-29", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -153,8 +151,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'constitutionMemorialDay',
                 ['en_US' => 'Constitution Memorial Day', 'ja_JP' => '憲法記念日'],
-                new DateTime("$this->year-5-3", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-5-3", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -169,8 +166,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'childrensDay',
                 ['en_US' => 'Children\'s Day', 'ja_JP' => 'こどもの日'],
-                new DateTime("$this->year-5-5", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-5-5", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -186,8 +182,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'cultureDay',
                 ['en_US' => 'Culture Day', 'ja_JP' => '文化の日'],
-                new DateTime("$this->year-11-3", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-11-3", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -203,8 +198,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'laborThanksgivingDay',
                 ['en_US' => 'Labor Thanksgiving Day', 'ja_JP' => '勤労感謝の日'],
-                new DateTime("$this->year-11-23", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-11-23", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -221,8 +215,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'emperorsBirthday',
                 ['en_US' => 'Emperors Birthday', 'ja_JP' => '天皇誕生日'],
-                new DateTime("$this->year-12-23", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-12-23", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -258,8 +251,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'vernalEquinoxDay',
                 ['en_US' => 'Vernal Equinox Day', 'ja_JP' => '春分の日'],
-                new DateTime("$this->year-3-$day", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-3-$day", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -289,8 +281,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'comingOfAgeDay',
                 ['en_US' => 'Coming of Age Day', 'ja_JP' => '成人の日'],
-                $date,
-                $this->locale
+                $date
             ));
         }
     }
@@ -319,8 +310,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'greeneryDay',
                 ['en_US' => 'Greenery Day', 'ja_JP' => 'みどりの日'],
-                $date,
-                $this->locale
+                $date
             ));
         }
     }
@@ -353,8 +343,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'marineDay',
                 ['en_US' => 'Marine Day', 'ja_JP' => '海の日'],
-                $date,
-                $this->locale
+                $date
             ));
         }
     }
@@ -382,8 +371,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'mountainDay',
                 ['en_US' => 'Mountain Day', 'ja_JP' => '山の日'],
-                $date,
-                $this->locale
+                $date
             ));
         }
     }
@@ -413,8 +401,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'respectfortheAgedDay',
                 ['en_US' => 'Respect for the Aged Day', 'ja_JP' => '敬老の日'],
-                $date,
-                $this->locale
+                $date
             ));
         }
     }
@@ -447,8 +434,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'healthandSportsDay',
                 ['en_US' => 'Health And Sports Day', 'ja_JP' => '体育の日'],
-                $date,
-                $this->locale
+                $date
             ));
         }
     }
@@ -484,8 +470,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'autumnalEquinoxDay',
                 ['en_US' => 'Autumnal Equinox Day', 'ja_JP' => '秋分の日'],
-                new DateTime("$this->year-9-$day", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-9-$day", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -531,7 +516,7 @@ class Japan extends AbstractProvider
                 $substituteHoliday = new Holiday('substituteHoliday:' . $shortName, [
                     'en_US' => $date->translations['en_US'] . ' Observed',
                     'ja_JP' => '振替休日 (' . $date->translations['ja_JP'] . ')',
-                ], $substituteDay, $this->locale);
+                ], $substituteDay);
 
                 $this->addHoliday($substituteHoliday);
             }
@@ -571,7 +556,7 @@ class Japan extends AbstractProvider
                 $this->addHoliday(new Holiday('bridgeDay', [
                     'en_US' => 'Bridge Public holiday',
                     'ja_JP' => '国民の休日',
-                ], $bridgeDate, $this->locale));
+                ], $bridgeDate));
             }
         }
     }

--- a/src/Yasumi/Provider/Netherlands.php
+++ b/src/Yasumi/Provider/Netherlands.php
@@ -43,35 +43,34 @@ class Netherlands extends AbstractProvider
         $this->timezone = 'Europe/Amsterdam';
 
         // Add common holidays
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
         $this->addHoliday($this->internationalWorkersDay(
             $this->year,
             $this->timezone,
-            $this->locale,
             Holiday::TYPE_OTHER
         ));
-        $this->addHoliday($this->valentinesDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->valentinesDay($this->year, $this->timezone, Holiday::TYPE_OTHER));
 
         // World Animal Day is celebrated since 1931
         if ($this->year >= 1931) {
-            $this->addHoliday($this->worldAnimalDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
+            $this->addHoliday($this->worldAnimalDay($this->year, $this->timezone, Holiday::TYPE_OTHER));
         }
 
-        $this->addHoliday($this->stMartinsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->fathersDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
-        $this->addHoliday($this->mothersDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->stMartinsDay($this->year, $this->timezone, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->fathersDay($this->year, $this->timezone, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->mothersDay($this->year, $this->timezone, Holiday::TYPE_OTHER));
 
         // Add Christian holidays
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->ascensionDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->ashWednesday($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
-        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->easter($this->year, $this->timezone));
+        $this->addHoliday($this->easterMonday($this->year, $this->timezone));
+        $this->addHoliday($this->pentecost($this->year, $this->timezone));
+        $this->addHoliday($this->pentecostMonday($this->year, $this->timezone));
+        $this->addHoliday($this->ascensionDay($this->year, $this->timezone));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->ashWednesday($this->year, $this->timezone, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->epiphany($this->year, $this->timezone, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone));
+        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone));
 
         /**
          * Commemoration Day and Liberation Day. Instituted after WWII in 1947.
@@ -81,15 +80,13 @@ class Netherlands extends AbstractProvider
                 'commemorationDay',
                 ['en_US' => 'Commemoration Day', 'nl_NL' => 'Dodenherdenking'],
                 new DateTime("$this->year-5-4", new DateTimeZone($this->timezone)),
-                $this->locale,
-                Holiday::TYPE_OBSERVANCE
+                    Holiday::TYPE_OBSERVANCE
             ));
             $this->addHoliday(new Holiday(
                 'liberationDay',
                 ['en_US' => 'Liberation Day', 'nl_NL' => 'Bevrijdingsdag'],
                 new DateTime("$this->year-5-5", new DateTimeZone($this->timezone)),
-                $this->locale,
-                Holiday::TYPE_OBSERVANCE
+                    Holiday::TYPE_OBSERVANCE
             ));
         }
 
@@ -109,8 +106,7 @@ class Netherlands extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'kingsDay',
                 ['en_US' => 'Kings Day', 'nl_NL' => 'Koningsdag'],
-                $date,
-                $this->locale
+                $date
             ));
         }
 
@@ -135,8 +131,7 @@ class Netherlands extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'queensDay',
                 ['en_US' => 'Queen\'s Day', 'nl_NL' => 'Koninginnedag'],
-                $date,
-                $this->locale
+                $date
             ));
         }
 
@@ -150,7 +145,6 @@ class Netherlands extends AbstractProvider
             'princesDay',
             ['en_US' => 'Prince\'s Day', 'nl_NL' => 'Prinsjesdag'],
             new DateTime("third tuesday of september $this->year", new DateTimeZone($this->timezone)),
-            $this->locale,
             Holiday::TYPE_OTHER
         ));
 
@@ -161,7 +155,6 @@ class Netherlands extends AbstractProvider
             'halloween',
             ['en_US' => 'Halloween', 'nl_NL' => 'Halloween'],
             new DateTime("$this->year-10-31", new DateTimeZone($this->timezone)),
-            $this->locale,
             Holiday::TYPE_OBSERVANCE
         ));
 
@@ -172,16 +165,15 @@ class Netherlands extends AbstractProvider
             'stNicholasDay',
             ['en_US' => 'St. Nicholas\' Day', 'nl_NL' => 'Sinterklaas'],
             new DateTime("$this->year-12-5", new DateTimeZone($this->timezone)),
-            $this->locale,
             Holiday::TYPE_OBSERVANCE
         ));
 
-        $summerTime = $this->summerTime($this->year, $this->timezone, $this->locale);
+        $summerTime = $this->summerTime($this->year, $this->timezone);
         if ($summerTime !== null) {
             $this->addHoliday($summerTime);
         }
 
-        $winterTime = $this->winterTime($this->year, $this->timezone, $this->locale);
+        $winterTime = $this->winterTime($this->year, $this->timezone);
         if ($winterTime !== null) {
             $this->addHoliday($winterTime);
         }
@@ -199,7 +191,6 @@ class Netherlands extends AbstractProvider
             'carnivalDay',
             ['en_US' => 'Carnival', 'nl_NL' => 'Carnaval'],
             $carnivalDay1->sub(new DateInterval('P49D')),
-            $this->locale,
             Holiday::TYPE_OBSERVANCE
         ));
 
@@ -211,7 +202,6 @@ class Netherlands extends AbstractProvider
             'secondCarnivalDay',
             ['en_US' => 'Carnival', 'nl_NL' => 'Carnaval'],
             $carnivalDay2->sub(new DateInterval('P48D')),
-            $this->locale,
             Holiday::TYPE_OBSERVANCE
         ));
 
@@ -223,7 +213,6 @@ class Netherlands extends AbstractProvider
             'thirdCarnivalDay',
             ['en_US' => 'Carnival', 'nl_NL' => 'Carnaval'],
             $carnivalDay3->sub(new DateInterval('P47D')),
-            $this->locale,
             Holiday::TYPE_OBSERVANCE
         ));
     }

--- a/src/Yasumi/Provider/Norway.php
+++ b/src/Yasumi/Provider/Norway.php
@@ -42,19 +42,19 @@ class Norway extends AbstractProvider
         $this->timezone = 'Europe/Oslo';
 
         // Add common holidays
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
+        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone));
 
         // Add common Christian holidays (common in Norway)
-        $this->addHoliday($this->maundyThursday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->ascensionDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->maundyThursday($this->year, $this->timezone));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone));
+        $this->addHoliday($this->easter($this->year, $this->timezone));
+        $this->addHoliday($this->easterMonday($this->year, $this->timezone));
+        $this->addHoliday($this->ascensionDay($this->year, $this->timezone));
+        $this->addHoliday($this->pentecost($this->year, $this->timezone));
+        $this->addHoliday($this->pentecostMonday($this->year, $this->timezone));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone));
+        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone));
 
         // Calculate other holidays
         $this->calculateConstitutionDay();
@@ -84,8 +84,7 @@ class Norway extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'constitutionDay',
                 ['nb_NO' => 'Grunnlovsdagen'],
-                new DateTime("$this->year-5-17", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("$this->year-5-17", new DateTimeZone($this->timezone))
             ));
         }
     }

--- a/src/Yasumi/Provider/SouthAfrica.php
+++ b/src/Yasumi/Provider/SouthAfrica.php
@@ -52,13 +52,13 @@ class SouthAfrica extends AbstractProvider
         }
 
         // Add common holidays
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
+        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone));
 
         // Add common Christian holidays (common in SouthAfrica)
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone));
+        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone));
 
         // Calculate other holidays
         $this->calculateHumanRightsDay();
@@ -97,8 +97,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'humanRightsDay',
             ['en_ZA' => 'Human Rights Day'],
-            new DateTime($this->year . '-3-21', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime($this->year . '-3-21', new DateTimeZone($this->timezone))
         ));
     }
 
@@ -119,8 +118,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'familyDay',
             ['en_ZA' => 'Family Day'],
-            $this->calculateEaster($this->year, $this->timezone)->add(new DateInterval('P1D')),
-            $this->locale
+            $this->calculateEaster($this->year, $this->timezone)->add(new DateInterval('P1D'))
         ));
     }
 
@@ -142,8 +140,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'freedomDay',
             ['en_ZA' => 'Freedom Day'],
-            new DateTime($this->year . '-4-27', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime($this->year . '-4-27', new DateTimeZone($this->timezone))
         ));
     }
 
@@ -169,8 +166,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'youthDay',
             ['en_ZA' => 'Youth Day'],
-            new DateTime($this->year . '-6-16', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime($this->year . '-6-16', new DateTimeZone($this->timezone))
         ));
     }
 
@@ -196,8 +192,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             '2016MunicipalElectionsDay',
             ['en_ZA' => '2016 Municipal Elections Day'],
-            new DateTime('2016-8-3', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime('2016-8-3', new DateTimeZone($this->timezone))
         ));
     }
 
@@ -221,8 +216,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'nationalWomensDay',
             ['en_ZA' => 'National Women\'s Day'],
-            new DateTime($this->year . '-8-9', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime($this->year . '-8-9', new DateTimeZone($this->timezone))
         ));
     }
 
@@ -246,8 +240,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'heritageDay',
             ['en_ZA' => 'Heritage Day'],
-            new DateTime($this->year . '-9-24', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime($this->year . '-9-24', new DateTimeZone($this->timezone))
         ));
     }
 
@@ -273,8 +266,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'reconciliationDay',
             ['en_ZA' => 'Day of Reconciliation'],
-            new DateTime($this->year . '-12-16', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime($this->year . '-12-16', new DateTimeZone($this->timezone))
         ));
     }
 
@@ -303,8 +295,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'substituteDayOfGoodwill',
             ['en_ZA' => 'Day of Goodwill observed'],
-            new DateTime('2016-12-27', new DateTimeZone($this->timezone)),
-            $this->locale
+            new DateTime('2016-12-27', new DateTimeZone($this->timezone))
         ));
     }
 
@@ -340,9 +331,11 @@ class SouthAfrica extends AbstractProvider
                 $substituteHoliday = clone $datesIterator->current();
                 $substituteHoliday->add(new DateInterval('P1D'));
 
-                $this->addHoliday(new Holiday('substituteHoliday:' . $substituteHoliday->shortName, [
-                    'en_ZA' => $substituteHoliday->getName() . ' observed',
-                ], $substituteHoliday, $this->locale));
+                $this->addHoliday(new Holiday(
+                    'substituteHoliday:' . $substituteHoliday->shortName,
+                    [ 'en_ZA' => $substituteHoliday->getName() . ' observed'],
+                    $substituteHoliday)
+                );
             }
 
             $datesIterator->next();

--- a/src/Yasumi/Provider/Spain.php
+++ b/src/Yasumi/Provider/Spain.php
@@ -42,18 +42,18 @@ class Spain extends AbstractProvider
         $this->timezone = 'Europe/Madrid';
 
         // Add common holidays
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->valentinesDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
-        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
+        $this->addHoliday($this->valentinesDay($this->year, $this->timezone, Holiday::TYPE_OTHER));
+        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone));
 
         // Add Christian holidays (common in Spain)
-        $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->immaculateConception($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->epiphany($this->year, $this->timezone));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone));
+        $this->addHoliday($this->easter($this->year, $this->timezone, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone));
+        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone));
+        $this->addHoliday($this->immaculateConception($this->year, $this->timezone));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone));
 
         // Calculate other holidays
         $this->calculateNationalDay();
@@ -82,9 +82,7 @@ class Spain extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'nationalDay',
                 ['es_ES' => 'Fiesta Nacional de España'],
-                new DateTime("$this->year-10-12", new DateTimeZone($this->timezone)),
-                $this->locale
-            ));
+                new DateTime("$this->year-10-12", new DateTimeZone($this->timezone))            ));
         }
     }
 
@@ -108,9 +106,7 @@ class Spain extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'constitutionDay',
                 ['es_ES' => 'Día de la Constitución'],
-                new DateTime("$this->year-12-6", new DateTimeZone($this->timezone)),
-                $this->locale
-            ));
+                new DateTime("$this->year-12-6", new DateTimeZone($this->timezone))            ));
         }
     }
 }

--- a/src/Yasumi/Provider/USA.php
+++ b/src/Yasumi/Provider/USA.php
@@ -43,10 +43,10 @@ class USA extends AbstractProvider
         $this->timezone = 'America/New_York';
 
         // Add common holidays
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
 
         // Add Christian holidays
-        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone));
 
         // Calculate other holidays
         $this->calculateMartinLutherKingday();
@@ -76,7 +76,7 @@ class USA extends AbstractProvider
         if ($this->year >= 1986) {
             $this->addHoliday(new Holiday('martinLutherKingDay', [
                 'en_US' => 'Dr. Martin Luther King Jr\'s Birthday',
-            ], new DateTime("third monday of january $this->year", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("third monday of january $this->year", new DateTimeZone($this->timezone))));
         }
     }
 
@@ -101,7 +101,7 @@ class USA extends AbstractProvider
             }
             $this->addHoliday(new Holiday('memorialDay', [
                 'en_US' => 'Memorial Day',
-            ], $date, $this->locale));
+            ], $date));
         }
     }
 
@@ -122,7 +122,7 @@ class USA extends AbstractProvider
         if ($this->year >= 1776) {
             $this->addHoliday(new Holiday('independenceDay', [
                 'en_US' => 'Independence Day',
-            ], new DateTime("$this->year-7-4", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-7-4", new DateTimeZone($this->timezone))));
         }
     }
 
@@ -144,8 +144,7 @@ class USA extends AbstractProvider
                 [
                     'en_US' => 'Labour Day',
                 ],
-                new DateTime("first monday of september $this->year", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("first monday of september $this->year", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -172,7 +171,7 @@ class USA extends AbstractProvider
             }
             $this->addHoliday(new Holiday('columbusDay', [
                 'en_US' => 'Columbus Day',
-            ], $date, $this->locale));
+            ], $date));
         }
     }
 
@@ -194,7 +193,7 @@ class USA extends AbstractProvider
 
             $this->addHoliday(new Holiday('veteransDay', [
                 'en_US' => $name,
-            ], new DateTime("$this->year-11-11", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-11-11", new DateTimeZone($this->timezone))));
         }
     }
 
@@ -218,8 +217,7 @@ class USA extends AbstractProvider
                 [
                     'en_US' => 'Thanksgiving Day',
                 ],
-                new DateTime("fourth thursday of november $this->year", new DateTimeZone($this->timezone)),
-                $this->locale
+                new DateTime("fourth thursday of november $this->year", new DateTimeZone($this->timezone))
             ));
         }
     }
@@ -248,7 +246,7 @@ class USA extends AbstractProvider
             }
             $this->addHoliday(new Holiday('washingtonsBirthday', [
                 'en_US' => 'Washington\'s Birthday',
-            ], $date, $this->locale));
+            ], $date));
         }
     }
 
@@ -294,7 +292,7 @@ class USA extends AbstractProvider
                 if (null !== $substituteHoliday) {
                     $this->addHoliday(new Holiday('substituteHoliday:' . $substituteHoliday->shortName, [
                         'en_US' => $substituteHoliday->getName() . ' observed',
-                    ], $substituteHoliday, $this->locale));
+                    ], $substituteHoliday));
                 }
             }
             $datesIterator->next();

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -45,12 +45,12 @@ class Ukraine extends AbstractProvider
         $this->timezone = 'Europe/Kiev';
 
         // Add common holidays
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone));
+        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone));
 
         // Add Christian holidays
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->easter($this->year, $this->timezone));
+        $this->addHoliday($this->pentecost($this->year, $this->timezone));
 
         // Add other holidays
         $this->calculateChristmasDay();
@@ -75,8 +75,7 @@ class Ukraine extends AbstractProvider
         $this->addHoliday(new Holiday(
             'christmasDay',
             [],
-            new \DateTime("$this->year-01-07", new \DateTimeZone($this->timezone)),
-            $this->locale
+            new \DateTime("$this->year-01-07", new \DateTimeZone($this->timezone))
         ));
     }
 
@@ -98,8 +97,7 @@ class Ukraine extends AbstractProvider
         $this->addHoliday(new Holiday(
             'internationalWomensDay',
             ['uk_UA' => 'Міжнародний жіночий день', 'ru_UA' => 'Международный женский день'],
-            new \DateTime("$this->year-03-08", new \DateTimeZone($this->timezone)),
-            $this->locale
+            new \DateTime("$this->year-03-08", new \DateTimeZone($this->timezone))
         ));
     }
 
@@ -118,7 +116,7 @@ class Ukraine extends AbstractProvider
         $this->addHoliday(new Holiday('secondInternationalWorkersDay', [
             'uk_UA' => 'День міжнародної солідарності трудящих',
             'ru_UA' => 'День международной солидарности трудящихся'
-        ], new \DateTime("$this->year-05-02", new \DateTimeZone($this->timezone)), $this->locale));
+        ], new \DateTime("$this->year-05-02", new \DateTimeZone($this->timezone))));
     }
 
     /**
@@ -142,8 +140,7 @@ class Ukraine extends AbstractProvider
         $this->addHoliday(new Holiday(
             'victoryDay',
             ['uk_UA' => 'День перемоги', 'ru_UA' => 'День победы'],
-            new \DateTime("$this->year-05-09", new \DateTimeZone($this->timezone)),
-            $this->locale
+            new \DateTime("$this->year-05-09", new \DateTimeZone($this->timezone))
         ));
     }
 
@@ -168,8 +165,7 @@ class Ukraine extends AbstractProvider
         $this->addHoliday(new Holiday(
             'constitutionDay',
             ['uk_UA' => 'День Конституції', 'ru_UA' => 'День Конституции'],
-            new \DateTime("$this->year-06-28", new \DateTimeZone($this->timezone)),
-            $this->locale
+            new \DateTime("$this->year-06-28", new \DateTimeZone($this->timezone))
         ));
     }
 
@@ -196,8 +192,7 @@ class Ukraine extends AbstractProvider
         $this->addHoliday(new Holiday(
             'independenceDay',
             ['uk_UA' => 'День Незалежності', 'ru_UA' => 'День Независимости'],
-            new \DateTime("$this->year-08-24", new \DateTimeZone($this->timezone)),
-            $this->locale
+            new \DateTime("$this->year-08-24", new \DateTimeZone($this->timezone))
         ));
     }
 
@@ -225,8 +220,7 @@ class Ukraine extends AbstractProvider
         $this->addHoliday(new Holiday(
             'defenderOfUkraineDay',
             ['uk_UA' => 'День захисника України', 'ru_UA' => 'День Защитника Украины'],
-            new \DateTime("$this->year-10-14", new \DateTimeZone($this->timezone)),
-            $this->locale
+            new \DateTime("$this->year-10-14", new \DateTimeZone($this->timezone))
         ));
     }
 

--- a/src/Yasumi/Provider/UnitedKingdom.php
+++ b/src/Yasumi/Provider/UnitedKingdom.php
@@ -50,8 +50,8 @@ class UnitedKingdom extends AbstractProvider
         $this->calculateSummerBankHoliday();
 
         // Add common Christian holidays (common in the United Kingdom)
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale, Holiday::TYPE_BANK));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone));
+        $this->addHoliday($this->easterMonday($this->year, $this->timezone, Holiday::TYPE_BANK));
         $this->calculateChristmasHolidays();
     }
 
@@ -91,7 +91,7 @@ class UnitedKingdom extends AbstractProvider
             $newYearsDay->modify('next monday');
         }
 
-        $this->addHoliday(new Holiday('newYearsDay', [], $newYearsDay, $this->locale, $type));
+        $this->addHoliday(new Holiday('newYearsDay', [], $newYearsDay, $type));
     }
 
     /**
@@ -122,7 +122,6 @@ class UnitedKingdom extends AbstractProvider
             'mayDayBankHoliday',
             ['en_GB' => 'May Day Bank Holiday'],
             new DateTime("first monday of may $this->year", new DateTimeZone($this->timezone)),
-            $this->locale,
             Holiday::TYPE_BANK
         ));
     }
@@ -154,7 +153,6 @@ class UnitedKingdom extends AbstractProvider
             'springBankHoliday',
             ['en_GB' => 'Spring Bank Holiday'],
             new DateTime("last monday of may $this->year", new DateTimeZone($this->timezone)),
-            $this->locale,
             Holiday::TYPE_BANK
         ));
     }
@@ -186,7 +184,6 @@ class UnitedKingdom extends AbstractProvider
             'summerBankHoliday',
             ['en_GB' => 'Summer Bank Holiday'],
             new DateTime("last monday of august $this->year", new DateTimeZone($this->timezone)),
-            $this->locale,
             Holiday::TYPE_BANK
         ));
     }
@@ -218,8 +215,8 @@ class UnitedKingdom extends AbstractProvider
         $christmasDay = new DateTime("$this->year-12-25", new DateTimeZone($this->timezone));
         $boxingDay    = new DateTime("$this->year-12-26", new DateTimeZone($this->timezone));
 
-        $this->addHoliday(new Holiday('christmasDay', [], $christmasDay, $this->locale));
-        $this->addHoliday(new Holiday('secondChristmasDay', [], $boxingDay, $this->locale, Holiday::TYPE_BANK));
+        $this->addHoliday(new Holiday('christmasDay', [], $christmasDay));
+        $this->addHoliday(new Holiday('secondChristmasDay', [], $boxingDay, Holiday::TYPE_BANK));
 
         $substituteChristmasDay = clone $christmasDay;
         $substituteBoxingDay    = clone $boxingDay;
@@ -230,7 +227,6 @@ class UnitedKingdom extends AbstractProvider
                 'substituteHoliday:christmasDay',
                 [],
                 $substituteChristmasDay,
-                $this->locale,
                 Holiday::TYPE_BANK
             ));
         }
@@ -241,7 +237,6 @@ class UnitedKingdom extends AbstractProvider
                 'substituteHoliday:secondChristmasDay',
                 [],
                 $substituteBoxingDay,
-                $this->locale,
                 Holiday::TYPE_BANK
             ));
         }

--- a/tests/Base/HolidayTest.php
+++ b/tests/Base/HolidayTest.php
@@ -15,6 +15,7 @@ namespace Yasumi\tests\Base;
 use DateTime;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Yasumi\Yasumi;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiBase;
 use Yasumi\TranslationsInterface;
@@ -28,6 +29,11 @@ class HolidayTest extends TestCase
 {
     use YasumiBase;
 
+    protected function tearDown()
+    {
+        Yasumi::setDefaultLocale('en_US');
+    }
+
     /**
      * Tests that an InvalidArgumentException is thrown in case an blank short name is given.
      *
@@ -40,23 +46,12 @@ class HolidayTest extends TestCase
     }
 
     /**
-     * Tests that an Yasumi\Exception\UnknownLocaleException is thrown in case an invalid locale is given.
-     *
-     * @expectedException \Yasumi\Exception\UnknownLocaleException
-     * @throws \Exception
-     */
-    public function testCreateHolidayUnknownLocaleException(): void
-    {
-        new Holiday('testHoliday', [], new DateTime(), 'wx-YZ');
-    }
-
-    /**
      * Tests that a Yasumi holiday instance can be serialized to a JSON object.
      * @throws \Exception
      */
     public function testHolidayIsJsonSerializable(): void
     {
-        $holiday  = new Holiday('testHoliday', [], new DateTime(), 'en_US');
+        $holiday  = new Holiday('testHoliday', [], new DateTime());
         $json     = \json_encode($holiday);
         $instance = \json_decode($json, true);
 
@@ -73,12 +68,12 @@ class HolidayTest extends TestCase
     public function testHolidayWithDateTimeInterface(): void
     {
         // Assert with DateTime instance
-        $holiday = new Holiday('testHoliday', [], new \DateTime(), 'en_US');
+        $holiday = new Holiday('testHoliday', [], new \DateTime());
         $this->assertNotNull($holiday);
         $this->assertInstanceOf(Holiday::class, $holiday);
 
         // Assert with DateTimeImmutable instance
-        $holiday = new Holiday('testHoliday', [], new \DateTimeImmutable(), 'en_US');
+        $holiday = new Holiday('testHoliday', [], new \DateTimeImmutable());
         $this->assertNotNull($holiday);
         $this->assertInstanceOf(Holiday::class, $holiday);
     }
@@ -90,7 +85,7 @@ class HolidayTest extends TestCase
     public function testHolidayGetNameWithNoTranslations(): void
     {
         $name    = 'testHoliday';
-        $holiday = new Holiday($name, [], new DateTime(), 'en_US');
+        $holiday = new Holiday($name, [], new DateTime());
 
         $this->assertIsString($holiday->getName());
         $this->assertEquals($name, $holiday->getName());
@@ -104,8 +99,10 @@ class HolidayTest extends TestCase
     {
         $name        = 'testHoliday';
         $translation = 'My Holiday';
-        $locale      = 'en_US';
-        $holiday     = new Holiday($name, [$locale => $translation], new DateTime(), $locale);
+        $locale      = 'en_NZ';
+        $holiday     = new Holiday($name, [$locale => $translation], new DateTime());
+
+        Yasumi::setDefaultLocale($locale);
 
         $this->assertIsString($holiday->getName());
         $this->assertEquals($translation, $holiday->getName());
@@ -120,11 +117,12 @@ class HolidayTest extends TestCase
     {
         $name        = 'testHoliday';
         $translation = 'My Holiday';
-        $holiday     = new Holiday($name, ['en_US' => $translation], new DateTime(), 'nl_NL');
+        $locale      = 'nl_NL';
+        $holiday     = new Holiday($name, [$locale => $translation], new DateTime());
 
-        $this->assertNotNull($holiday->getName());
-        $this->assertIsString($holiday->getName());
-        $this->assertEquals($translation, $holiday->getName());
+        $this->assertNotNull($holiday->getName($locale));
+        $this->assertIsString($holiday->getName($locale));
+        $this->assertEquals($translation, $holiday->getName($locale));
     }
 
     /**
@@ -145,12 +143,12 @@ class HolidayTest extends TestCase
 
         $locale = 'pl_PL';
 
-        $holiday = new Holiday('newYearsDay', [], new DateTime('2015-01-01'), $locale);
+        $holiday = new Holiday('newYearsDay', [], new DateTime('2015-01-01'));
         $holiday->mergeGlobalTranslations($translationsStub);
 
-        $this->assertNotNull($holiday->getName());
-        $this->assertIsString($holiday->getName());
-        $this->assertEquals($translations[$locale], $holiday->getName());
+        $this->assertNotNull($holiday->getName($locale));
+        $this->assertIsString($holiday->getName($locale));
+        $this->assertEquals($translations[$locale], $holiday->getName($locale));
     }
 
     /**
@@ -175,14 +173,13 @@ class HolidayTest extends TestCase
         $holiday = new Holiday(
             'newYearsDay',
             [$customLocale => $customTranslation],
-            new DateTime('2015-01-01'),
-            $customLocale
+            new DateTime('2015-01-01')
         );
         $holiday->mergeGlobalTranslations($translationsStub);
 
-        $this->assertNotNull($holiday->getName());
-        $this->assertIsString($holiday->getName());
-        $this->assertEquals($customTranslation, $holiday->getName());
+        $this->assertNotNull($holiday->getName($customLocale));
+        $this->assertIsString($holiday->getName($customLocale));
+        $this->assertEquals($customTranslation, $holiday->getName($customLocale));
     }
 
     /**
@@ -207,13 +204,12 @@ class HolidayTest extends TestCase
         $holiday = new Holiday(
             'newYearsDay',
             [$customLocale => $customTranslation],
-            new DateTime('2014-01-01'),
-            $customLocale
+            new DateTime('2014-01-01')
         );
         $holiday->mergeGlobalTranslations($translationsStub);
 
-        $this->assertNotNull($holiday->getName());
-        $this->assertIsString($holiday->getName());
-        $this->assertEquals($customTranslation, $holiday->getName());
+        $this->assertNotNull($holiday->getName($customLocale));
+        $this->assertIsString($holiday->getName($customLocale));
+        $this->assertEquals($customTranslation, $holiday->getName($customLocale));
     }
 }

--- a/tests/Base/YasumiTest.php
+++ b/tests/Base/YasumiTest.php
@@ -37,6 +37,33 @@ class YasumiTest extends TestCase
      */
     public const YEAR_UPPER_BOUND = 9999;
 
+    protected function tearDown()
+    {
+        Yasumi::setDefaultLocale('en_US');
+    }
+
+    /**
+     * Tests that default locale can be set and retrieved.
+     */
+    public function testDefaultLocale(): void
+    {
+        $this->assertEquals('en_US', Yasumi::getDefaultLocale());
+
+        Yasumi::setDefaultLocale('it_IT');
+        $this->assertEquals('it_IT', Yasumi::getDefaultLocale());
+    }
+
+    /**
+     * Tests that an Yasumi\Exception\UnknownLocaleException is thrown in case an invalid locale is given.
+     *
+     * @expectedException \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function testSetDefaultLocaleUnknownLocaleException(): void
+    {
+        Yasumi::setDefaultLocale('wx_YZ');
+    }
+
     /**
      * Tests that an InvalidArgumentException is thrown in case an invalid year is given.
      *
@@ -93,21 +120,6 @@ class YasumiTest extends TestCase
             Factory::create()->numberBetween(self::YEAR_LOWER_BOUND, self::YEAR_UPPER_BOUND)
         );
         $this->assertInstanceOf($class, $instance);
-    }
-
-    /**
-     * Tests that an Yasumi\Exception\UnknownLocaleException is thrown in case an invalid locale is given.
-     *
-     * @expectedException \Yasumi\Exception\UnknownLocaleException
-     * @throws \ReflectionException
-     */
-    public function testCreateWithInvalidLocale(): void
-    {
-        Yasumi::create(
-            'Japan',
-            Factory::create()->numberBetween(self::YEAR_LOWER_BOUND, self::YEAR_UPPER_BOUND),
-            'wx_YZ'
-        );
     }
 
     /**


### PR DESCRIPTION
I suggest removing the locale from `Holiday` and `Provider` instances. The locale is not used by these entities themselves except when generating a name.

Instead I suggest adding a configurable global locale, and the possibility to override this in calls to `Holiday::getName()`.

This approach is used e.g. by the [PHP intl extension](http://php.net/manual/en/locale.setdefault.php), the [Symfony Translator](https://api.symfony.com/2.7/Symfony/Component/Translation/Translator.html), [Drupal's t() function](https://api.drupal.org/api/drupal/core%21includes%21bootstrap.inc/function/t/8.4.x) and the [Punic](https://punic.github.io/#Data-class) library.

This will make a clearer separation of concerns as well as reduce the amount of boilerplate code in all the providers.

The change is not backwards compatible, so this is 3.x material.

I have not implemented this for all providers yet. I'd appreciate some feedback on this PR before I proceed with fixing the remaining 9904 failing tests :-)

My reason for suggesting this is to pave the way for another PR that will allow custom locale fallbacks instead of the hardcoded fallback to English. E.g. if you are displaying a Swedish calendar with a Danish locale, not all Swedish holidays may have a Danish translation, but because the two languages are so closely related, you would rather want to fall back to Swedish than English. This change will be much easier if both locale and fallback locales wont have to be passed through all the providers.