### PR TITLE
Allow default locale to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Observance holidays for Sweden [\#172](https://github.com/azuyalabs/yasumi/pull/172) ([c960657](https://github.com/c960657))
 - Added additional code style fixers and aligning StyleCI settings with PHP-CS.
 - Included extra requirement for some PHP Extensions in the composer file.
+- Added `Yasumi::setDefaultLocale()` and `Yasumi::getDefaultLocale()`. [\#123](https://github.com/azuyalabs/yasumi/pull/123) ([c960657](https://github.com/c960657))
+- Added optional $argument for `Holiday::getName($locale)` for overriding the default locale. [\#123](https://github.com/azuyalabs/yasumi/pull/123) ([c960657](https://github.com/c960657))
 
 ### Changed
 - Updated the translation for the All Saints holiday for the 'fr_FR' locale [\#152](https://github.com/azuyalabs/yasumi/pull/152) ([pioc92](https://github.com/pioc92))
@@ -66,6 +68,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   
 ### Removed
 - Duplicate definition of newYearsDay [\#125](https://github.com/azuyalabs/yasumi/pull/125) ([c960657](https://github.com/c960657))
+
+### Deprecated
+- Deprecated the `$locale` argument for `Yasumi::create()` and  `Yasumi::createByISO3166_2()`. [\#123](https://github.com/azuyalabs/yasumi/pull/123) ([c960657](https://github.com/c960657))
+- Deprecated the constant `Yasumi::DEFAULT_LOCALE`. [\#123](https://github.com/azuyalabs/yasumi/pull/123) ([c960657](https://github.com/c960657))
 
 
 ## [2.0.0] - 2019-01-11

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -155,14 +155,21 @@ class Holiday extends DateTime implements JsonSerializable
      * Returns the name of this holiday.
      *
      * The name of this holiday is returned translated in the given locale. If for the given locale no translation is
-     * defined, the name in the default locale ('en_US') is returned. In case there is no translation at all, the short
+     * defined, the name in the default locale is returned. In case there is no translation at all, the short
      * internal name is returned.
+     *
+     * @param string $locale the locale to use
      */
-    public function getName(): string
+    public function getName(string $locale = null): string
     {
-        return $this->translations[$this->displayLocale] ?? $this->translations[self::DEFAULT_LOCALE] ?? $this->shortName;
-    }
+        if ($locale === null) {
+            $locale = $this->displayLocale;
+        }
 
+        return $this->translations[$locale]
+            ?? $this->translations[Yasumi::getDefaultLocale()]
+            ?? $this->shortName;
+    }
     /**
      * Merges local translations (preferred) with global translations.
      *

--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -31,8 +31,15 @@ class Yasumi
 {
     /**
      * Default locale.
+     *
+     * @deprecated Will be removed in Yasumi 3.0
      */
     public const DEFAULT_LOCALE = 'en_US';
+
+    /**
+     * @var string Default locale
+     */
+    private static $defaultLocale = self::DEFAULT_LOCALE;
 
     /**
      * @var array list of all defined locales
@@ -114,7 +121,7 @@ class Yasumi
      * @param string $class holiday provider name
      * @param int $year year for which the country provider needs to be created. Year needs to be a valid integer
      *                       between 1000 and 9999.
-     * @param string $locale The locale to use. If empty we'll use the default locale (en_US)
+     * @param string $locale The locale to use (deprecated). If empty we'll use the default locale
      *
      * @return AbstractProvider An instance of class $class is created and returned
      *
@@ -124,8 +131,14 @@ class Yasumi
      * @throws ProviderNotFoundException if the holiday provider for the given country does not exist
      * @throws \ReflectionException
      */
-    public static function create(string $class, int $year = 0, string $locale = self::DEFAULT_LOCALE): ProviderInterface
+    public static function create(string $class, int $year = 0, string $locale = null): ProviderInterface
     {
+        if ($locale === null) {
+            $locale = self::$defaultLocale;
+        } else {
+            @\trigger_error('The third argument, $locale, is deprecated and will be removed in Yasumi 3.0', E_USER_DEPRECATED);
+        }
+
         // Find and return holiday provider instance
         $providerClass = \sprintf('Yasumi\Provider\%s', \str_replace('/', '\\', $class));
 
@@ -172,6 +185,44 @@ class Yasumi
     }
 
     /**
+     * Returns the default locale.
+     *
+     * @return string The default locale
+     */
+    public static function getDefaultLocale(): string
+    {
+        return self::$defaultLocale;
+    }
+
+    /**
+     * Sets the default locale.
+     *
+     * @param string $locale The locale to use
+     */
+    public static function setDefaultLocale(string $locale): void
+    {
+        // Load internal locales variable
+        if (empty(self::$locales)) {
+            self::$locales = self::getAvailableLocales();
+        }
+
+        // Assert locale input
+        if (! \in_array($locale, self::$locales, true)) {
+            throw new UnknownLocaleException(\sprintf('Locale "%s" is not a valid locale.', $locale));
+        }
+
+        self::$defaultLocale = $locale;
+    }
+
+    /**
+     * Resets default locale and fallback locales.
+     */
+    public static function reset(): void
+    {
+        self::$defaultLocale = 'en_US';
+    }
+
+    /**
      * Create a new holiday provider instance.
      *
      * A new holiday provider instance can be created using this function. You can use one of the providers included
@@ -181,7 +232,7 @@ class Yasumi
      * @param string $iso3166_2 ISO3166-2 Coded region, holiday provider will be searched for
      * @param int $year year for which the country provider needs to be created. Year needs to be a valid
      *                          integer between 1000 and 9999.
-     * @param string $locale The locale to use. If empty we'll use the default locale (en_US)
+     * @param string $locale The locale to use (deprecated). If empty we'll use the default locale (en_US)
      *
      * @return AbstractProvider An instance of class $class is created and returned
      *
@@ -194,8 +245,14 @@ class Yasumi
     public static function createByISO3166_2(
         string $iso3166_2,
         int $year = 0,
-        string $locale = self::DEFAULT_LOCALE
+        string $locale = null
     ): AbstractProvider {
+        if ($locale === null) {
+            $locale = self::$defaultLocale;
+        } else {
+            @\trigger_error('The third argument, $locale, is deprecated and will be removed in Yasumi 3.0', E_USER_DEPRECATED);
+        }
+
         $availableProviders = self::getProviders();
 
         if (false === isset($availableProviders[$iso3166_2])) {

--- a/tests/Base/HolidayTest.php
+++ b/tests/Base/HolidayTest.php
@@ -21,6 +21,7 @@ use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiBase;
 use Yasumi\TranslationsInterface;
+use Yasumi\Yasumi;
 
 /**
  * Class HolidayTest.
@@ -94,11 +95,13 @@ class HolidayTest extends TestCase
      */
     public function testHolidayGetNameWithNoTranslations(): void
     {
-        $name = 'testHoliday';
-        $holiday = new Holiday($name, [], new DateTime(), 'en_US');
+        $name    = 'testHoliday';
+        $locale  = 'en_US';
+        $holiday = new Holiday($name, [], new DateTime(), $locale);
 
-        $this->assertIsString($holiday->getName());
         $this->assertEquals($name, $holiday->getName());
+        $this->assertEquals($name, $holiday->getName($locale));
+        $this->assertEquals($name, $holiday->getName('ja_JP'));
     }
 
     /**
@@ -109,11 +112,14 @@ class HolidayTest extends TestCase
     {
         $name = 'testHoliday';
         $translation = 'My Holiday';
-        $locale = 'en_US';
-        $holiday = new Holiday($name, [$locale => $translation], new DateTime(), $locale);
+        $locale      = 'it_IT';
+        $holiday     = new Holiday($name, [$locale => $translation], new DateTime(), $locale);
 
-        $this->assertIsString($holiday->getName());
+        Yasumi::setDefaultLocale($locale);
+
         $this->assertEquals($translation, $holiday->getName());
+        $this->assertEquals($translation, $holiday->getName($locale));
+        $this->assertEquals($translation, $holiday->getName('ja_JP'));
     }
 
     /**
@@ -125,11 +131,14 @@ class HolidayTest extends TestCase
     {
         $name = 'testHoliday';
         $translation = 'My Holiday';
-        $holiday = new Holiday($name, ['en_US' => $translation], new DateTime(), 'nl_NL');
+        $locale      = 'en_US';
+        $holiday     = new Holiday($name, [$locale => $translation], new DateTime(), 'nl_NL');
 
-        $this->assertNotNull($holiday->getName());
-        $this->assertIsString($holiday->getName());
+        Yasumi::setDefaultLocale($locale);
+
         $this->assertEquals($translation, $holiday->getName());
+        $this->assertEquals($translation, $holiday->getName($locale));
+        $this->assertEquals($translation, $holiday->getName('ja_JP'));
     }
 
     /**
@@ -153,9 +162,9 @@ class HolidayTest extends TestCase
         $holiday = new Holiday('newYearsDay', [], new DateTime('2015-01-01'), $locale);
         $holiday->mergeGlobalTranslations($translationsStub);
 
-        $this->assertNotNull($holiday->getName());
-        $this->assertIsString($holiday->getName());
         $this->assertEquals($translations[$locale], $holiday->getName());
+        $this->assertEquals($translations['en_US'], $holiday->getName('en_US'));
+        $this->assertEquals($translations['en_US'], $holiday->getName('it_IT'));
     }
 
     /**
@@ -185,9 +194,11 @@ class HolidayTest extends TestCase
         );
         $holiday->mergeGlobalTranslations($translationsStub);
 
-        $this->assertNotNull($holiday->getName());
-        $this->assertIsString($holiday->getName());
         $this->assertEquals($customTranslation, $holiday->getName());
+        $this->assertEquals($customTranslation, $holiday->getName($customLocale));
+        $this->assertEquals($translations['pl_PL'], $holiday->getName('pl_PL'));
+        $this->assertEquals($translations['en_US'], $holiday->getName('en_US'));
+        $this->assertEquals($translations['en_US'], $holiday->getName('it_IT'));
     }
 
     /**
@@ -217,8 +228,9 @@ class HolidayTest extends TestCase
         );
         $holiday->mergeGlobalTranslations($translationsStub);
 
-        $this->assertNotNull($holiday->getName());
-        $this->assertIsString($holiday->getName());
         $this->assertEquals($customTranslation, $holiday->getName());
+        $this->assertEquals($customTranslation, $holiday->getName($customLocale));
+        $this->assertEquals($translations['en_US'], $holiday->getName('en_US'));
+        $this->assertEquals($translations['en_US'], $holiday->getName('it_IT'));
     }
 }

--- a/tests/Base/YasumiExternalProvider.php
+++ b/tests/Base/YasumiExternalProvider.php
@@ -13,6 +13,7 @@
 namespace Yasumi\tests\Base;
 
 use Yasumi\ProviderInterface;
+use Yasumi\TranslationsInterface;
 
 /**
  * Class YasumiExternalProvider.
@@ -21,6 +22,17 @@ use Yasumi\ProviderInterface;
  */
 class YasumiExternalProvider implements ProviderInterface
 {
+    public $year;
+    public $locale;
+    public $globalTranslations;
+
+    public function __construct($year, $locale, TranslationsInterface $globalTranslations)
+    {
+        $this->year = $year;
+        $this->locale = $locale;
+        $this->globalTranslations = $globalTranslations;
+    }
+
     /**
      * Initialize country holidays.
      */

--- a/tests/Base/YasumiTest.php
+++ b/tests/Base/YasumiTest.php
@@ -47,6 +47,40 @@ class YasumiTest extends TestCase
      */
     public const YEAR_UPPER_BOUND = 9999;
 
+    protected function tearDown()
+    {
+        Yasumi::reset();
+    }
+
+    /**
+     * Tests the initial default locale.
+     */
+    public function testInitialDefaultLocale(): void
+    {
+        $this->assertEquals('en_US', Yasumi::getDefaultLocale());
+    }
+
+    /**
+     * Tests that default locale can be set and returned.
+     */
+    public function testSetDefaultLocale(): void
+    {
+        Yasumi::setDefaultLocale('it_IT');
+
+        $this->assertEquals('it_IT', Yasumi::getDefaultLocale());
+    }
+
+    /**
+     * Tests that an Yasumi\Exception\UnknownLocaleException is thrown in case an invalid locale is given.
+     *
+     * @expectedException \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function testSetDefaultLocaleUnknownLocaleException(): void
+    {
+        Yasumi::setDefaultLocale('wx_YZ');
+    }
+
     /**
      * Tests that an InvalidArgumentException is thrown in case an invalid year is given.
      *
@@ -68,7 +102,7 @@ class YasumiTest extends TestCase
     {
         $this->expectException(ProviderNotFoundException::class);
 
-        Yasumi::create('Mars');
+        Yasumi::create('Mars, 2000');
     }
 
     /**
@@ -80,7 +114,7 @@ class YasumiTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Yasumi::create('CommonHolidays');
+        Yasumi::create('CommonHolidays', 2000);
     }
 
     /**
@@ -92,21 +126,44 @@ class YasumiTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Yasumi::create('AbstractProvider');
+        Yasumi::create('AbstractProvider', 2000);
     }
 
     /**
      * Tests that Yasumi allows external classes that extend the ProviderInterface.
      * @throws ReflectionException
      */
-    public function testCreateWithAbstractExtension(): void
+    public function testCreateWithExternalProvider(): void
     {
-        $class = YasumiExternalProvider::class;
+        $class    = YasumiExternalProvider::class;
+        $locale   = 'en_AU';
+
+        $instance = Yasumi::create(
+            $class,
+            Factory::create()->numberBetween(self::YEAR_LOWER_BOUND, self::YEAR_UPPER_BOUND),
+            $locale
+        );
+        $this->assertInstanceOf($class, $instance);
+        $this->assertEquals($locale, $instance->locale);
+    }
+
+    /**
+     * Tests that Yasumi allows external classes that extend the ProviderInterface.
+     * @throws ReflectionException
+     */
+    public function testCreateWithDefaultLocale(): void
+    {
+        $class    = YasumiExternalProvider::class;
+        $locale   = 'en_GB';
+
+        Yasumi::setDefaultLocale($locale);
+
         $instance = Yasumi::create(
             $class,
             Factory::create()->numberBetween(self::YEAR_LOWER_BOUND, self::YEAR_UPPER_BOUND)
         );
         $this->assertInstanceOf($class, $instance);
+        $this->assertEquals($locale, $instance->locale);
     }
 
     /**

--- a/tests/Base/YasumiTest.php
+++ b/tests/Base/YasumiTest.php
@@ -47,7 +47,7 @@ class YasumiTest extends TestCase
      */
     public const YEAR_UPPER_BOUND = 9999;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Yasumi::reset();
     }
@@ -73,11 +73,12 @@ class YasumiTest extends TestCase
     /**
      * Tests that an Yasumi\Exception\UnknownLocaleException is thrown in case an invalid locale is given.
      *
-     * @expectedException \Yasumi\Exception\UnknownLocaleException
-     * @throws \Exception
+     * @throws Exception
      */
     public function testSetDefaultLocaleUnknownLocaleException(): void
     {
+        $this->expectException(UnknownLocaleException::class);
+
         Yasumi::setDefaultLocale('wx_YZ');
     }
 
@@ -102,7 +103,7 @@ class YasumiTest extends TestCase
     {
         $this->expectException(ProviderNotFoundException::class);
 
-        Yasumi::create('Mars, 2000');
+        Yasumi::create('Mars', 2000);
     }
 
     /**


### PR DESCRIPTION
In preparation for the removal of `$this->holiday` from `Holiday` and `Provider` #122, this adds the suggested default language setting in backwards compatible way.

Two new class methods are added, `Yasumi::setDefaultLocale($locale)` and `Yasumi::getDefaultLocale()`, and a new optional argument is added to `$holiday->getName($locale = null)` that allows overriding the default.

This approach is used e.g. by the [PHP intl extension](http://php.net/manual/en/locale.setdefault.php), ~the [Symfony Translator](https://api.symfony.com/2.7/Symfony/Component/Translation/Translator.html)~, [Laravel](https://laravel.com/docs/5.7/localization), [Drupal's t() function](https://api.drupal.org/api/drupal/core%21includes%21bootstrap.inc/function/t/8.4.x) and the [Punic](https://punic.github.io/#Data-class) library.

Passing a locale to `Yasumi::create()` or `Yasumi:: createByISO3166_2()` is now deprecated (but still works as before). People can already now migrate to the new behaviour suggested for Yasumi 3.0 in #122. A deprecation warning is triggered following the tradition in [Symfony](https://symfony.com/doc/current/contributing/code/conventions.html#deprecations).

This paves the way for a second PR (#124) that adds support for fallback locales. I made two PR's in order to make code review easier. I recommend merging both PR's before doing a new release to ensure that the dust has settled on the API.