### PR TITLE
Remove duplicate definition of newYearsDay

### DIFF
--- a/src/Yasumi/Provider/Germany.php
+++ b/src/Yasumi/Provider/Germany.php
@@ -50,7 +50,6 @@ class Germany extends AbstractProvider
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
 


### PR DESCRIPTION
`$this->newYearsDay()` is called twice from `Yasumi\Provider\Germany::initialize()`.