### PR TITLE
Fix comment about weekend days in India

### DIFF
--- a/src/Yasumi/Provider/AbstractProvider.php
+++ b/src/Yasumi/Provider/AbstractProvider.php
@@ -66,7 +66,7 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
         // Friday
         'IR' => [5], // Iran, Islamic Republic of
 
-        // Friday
+        // Sunday
         'IN' => [0], // India
     ];
 


### PR DESCRIPTION
Weekend in India is Sunday = 0. The code is right, the comment is wrong.