### PR TITLE
Fix composer warning [...]should not contain uppercase characters[...]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.14",
     "fzaninotto/faker": "~1.8",
-    "mikey179/vfsStream": "~1.6",
+    "mikey179/vfsstream": "~1.6",
     "phpunit/phpunit": "~7.5"
   },
   "autoload": {


### PR DESCRIPTION
Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.