### PR TITLE
Revert "Fix composer warning [...]should not contain uppercase characters[...]"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.14",
     "fzaninotto/faker": "~1.8",
-    "mikey179/vfsstream": "~1.6",
+    "mikey179/vfsStream": "~1.6",
     "phpunit/phpunit": "~7.5"
   },
   "autoload": {


### PR DESCRIPTION
Reverts azuyalabs/yasumi#135
Work should be done in the 'develop' branch not 'master'.