### PR TITLE
Check all USA holidays for substitutions

### DIFF
--- a/src/Yasumi/Provider/USA.php
+++ b/src/Yasumi/Provider/USA.php
@@ -270,33 +270,25 @@ class USA extends AbstractProvider
 
         // Loop through all defined holidays
         while ($datesIterator->valid()) {
-
-            // Only process New Year's Day, Independence Day, or Christmas Day
-            if (\in_array(
-                $datesIterator->current()->shortName,
-                ['newYearsDay', 'independenceDay', 'christmasDay'],
-                true
-            )) {
-
-                // Substitute holiday is on a Monday in case the holiday falls on a Sunday
-                if (0 === (int)$datesIterator->current()->format('w')) {
-                    $substituteHoliday = clone $datesIterator->current();
-                    $substituteHoliday->add(new DateInterval('P1D'));
-                }
-
-                // Substitute holiday is on a Friday in case the holiday falls on a Saturday
-                if (6 === (int)$datesIterator->current()->format('w')) {
-                    $substituteHoliday = clone $datesIterator->current();
-                    $substituteHoliday->sub(new DateInterval('P1D'));
-                }
-
-                // Add substitute holiday
-                if (null !== $substituteHoliday) {
-                    $this->addHoliday(new Holiday('substituteHoliday:' . $substituteHoliday->shortName, [
-                        'en_US' => $substituteHoliday->getName() . ' observed',
-                    ], $substituteHoliday, $this->locale));
-                }
+            // Substitute holiday is on a Monday in case the holiday falls on a Sunday
+            if (0 === (int)$datesIterator->current()->format('w')) {
+                $substituteHoliday = clone $datesIterator->current();
+                $substituteHoliday->add(new DateInterval('P1D'));
             }
+
+            // Substitute holiday is on a Friday in case the holiday falls on a Saturday
+            if (6 === (int)$datesIterator->current()->format('w')) {
+                $substituteHoliday = clone $datesIterator->current();
+                $substituteHoliday->sub(new DateInterval('P1D'));
+            }
+
+            // Add substitute holiday
+            if (null !== $substituteHoliday) {
+                $this->addHoliday(new Holiday('substituteHoliday:' . $substituteHoliday->shortName, [
+                    'en_US' => $substituteHoliday->getName() . ' observed',
+                ], $substituteHoliday, $this->locale));
+            }
+
             $datesIterator->next();
         }
     }

--- a/tests/USA/VeteransDayTest.php
+++ b/tests/USA/VeteransDayTest.php
@@ -50,6 +50,38 @@ class VeteransDayTest extends USABaseTestCase implements YasumiTestCaseInterface
     }
 
     /**
+     * Tests Veterans Day on or after 1919 when substituted on Monday (when Veterans Day falls on Sunday)
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testVeteransDayOnAfter1919SubstitutedMonday()
+    {
+        $year = 2018;
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:veteransDay',
+            $year,
+            new DateTime("$year-11-12", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests Veterans Day on or after 1919 when substituted on Friday (when Veterans Day falls on Saturday)
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testVeteransDayOnAfter1919SubstitutedFriday()
+    {
+        $year = 2017;
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:veteransDay',
+            $year,
+            new DateTime("$year-11-10", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
      * Tests Veterans Day before 1919. Veterans Day was established in 1919 on November 11.
      * @throws \ReflectionException
      */


### PR DESCRIPTION
For USA holidays, per [Section 3(a) of Executive Order 11582 of Feb. 11, 1971](https://www.archives.gov/federal-register/codification/executive-order/11582.html) and [5 U.S.C. 6103(b)](https://www.govinfo.gov/content/pkg/USCODE-2011-title5/html/USCODE-2011-title5-partIII-subpartE-chap61-subchapI-sec6103.htm), **any** holiday that falls on a Sunday is moved to Monday and **any** holiday that falls on a Saturday is moved to Sunday. 

This PR changes the USA Provider to check all holidays for potential substitute holidays, not just New Year's Day, Independence Day, and Christmas Day

This addresses issue #91 regarding Veteran's Day that typically falls on November 11, but in 2018 it was [observed on 2018-11-12](https://www.opm.gov/policy-data-oversight/snow-dismissal-procedures/federal-holidays/#url=2018)
