### PR TITLE
Provider for holidays in South Korea

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -173,6 +173,11 @@
                 <directory suffix="Test.php">./tests/SouthAfrica</directory>
             </testsuite>
 
+            <!-- Test Suite for holidays in South Korea -->
+            <testsuite name="SouthKorea">
+                <directory suffix="Test.php">./tests/SouthKorea</directory>
+            </testsuite>
+
             <!-- Test Suite for holidays in Spain -->
             <testsuite name="Spain">
                 <directory suffix="Test.php">./tests/Spain</directory>

--- a/src/Yasumi/Provider/SouthKorea.php
+++ b/src/Yasumi/Provider/SouthKorea.php
@@ -1,0 +1,518 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\Provider;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+
+/**
+ * Provider for all holidays in the South Korea except for election day and temporary public holiday.
+ *
+ * @link https://en.wikipedia.org/wiki/Public_holidays_in_South_Korea
+ */
+class SouthKorea extends AbstractProvider
+{
+    use CommonHolidays, ChristianHolidays;
+
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    public const ID = 'KR';
+
+    /**
+     * Dates in Gregorian calendar of Seollal, Buddha's Birthday, and Chuseok (~ 2050)
+     *
+     * The Korean calendar is derived from the Chinese calendar. Although not being an official calendar, the
+     * traditional Korean calendar is still maintained by the government. The current version is based on China's
+     * Shixian calendar, which was in turn developed by Jesuit scholars. However, because the Korean calendar is now
+     * based on the moon's shape seen from Korea, occasionally the calendar diverges from the traditional Chinese
+     * calendar by one day, even though the underlying rule is the same.
+     * @link https://en.wikipedia.org/wiki/Korean_calendar
+     *
+     * To convert from lunar calendar to Gregorian calendar, lunar observation is necessary.
+     * There is no perfect formula, and as it moves away from the current date, the error becomes bigger.
+     * Korea Astronomy and Space Science Institute (KASI) is supporting the converter until 2050.
+     * For more information, please refer to the paper below.
+     * 박한얼, 민병희, 안영숙,(2017).한국 음력의 운용과 계산법 연구.천문학논총,32(3),407-420.
+     * @link https://www.kasi.re.kr/kor/research/paper/20170259 - Korea Astronomy and Space Science Institute
+     */
+    public const LUNAR_HOLIDAY = [
+        'seollal' => [
+            1985 => '1985-2-20', 1986 => '1986-2-9',  1987 => '1987-1-29', 1988 => '1988-2-18', 1989 => '1989-2-6',
+            1990 => '1990-1-27', 1991 => '1991-2-15', 1992 => '1992-2-4',  1993 => '1993-1-23', 1994 => '1994-2-10',
+            1995 => '1995-1-31', 1996 => '1996-2-19', 1997 => '1997-2-8',  1998 => '1998-1-28', 1999 => '1999-2-16',
+            2000 => '2000-2-5',  2001 => '2001-1-24', 2002 => '2002-2-12', 2003 => '2003-2-1',  2004 => '2004-1-22',
+            2005 => '2005-2-9',  2006 => '2006-1-29', 2007 => '2007-2-18', 2008 => '2008-2-7',  2009 => '2009-1-26',
+            2010 => '2010-2-14', 2011 => '2011-2-3',  2012 => '2012-1-23', 2013 => '2013-2-10', 2014 => '2014-1-31',
+            2015 => '2015-2-19', 2016 => '2016-2-8',  2017 => '2017-1-28', 2018 => '2018-2-16', 2019 => '2019-2-5',
+            2020 => '2020-1-25', 2021 => '2021-2-12', 2022 => '2022-2-1',  2023 => '2023-1-22', 2024 => '2024-2-10',
+            2025 => '2025-1-29', 2026 => '2026-2-17', 2027 => '2027-2-7',  2028 => '2028-1-27', 2029 => '2029-2-13',
+            2030 => '2030-2-3',  2031 => '2031-1-23', 2032 => '2032-2-11', 2033 => '2033-1-31', 2034 => '2034-2-19',
+            2035 => '2035-2-8',  2036 => '2036-1-28', 2037 => '2037-2-15', 2038 => '2038-2-4',  2039 => '2037-1-24',
+            2040 => '2040-2-12', 2041 => '2041-2-1',  2042 => '2042-1-22', 2043 => '2043-2-10', 2044 => '2044-1-30',
+            2045 => '2045-2-17', 2046 => '2046-2-6',  2047 => '2047-1-26', 2048 => '2048-2-14', 2049 => '2049-2-2',
+            2050 => '2050-1-23',
+        ],
+        'buddhasBirthday' => [
+            1975 => '1975-5-18', 1976 => '1976-5-6',  1977 => '1977-5-25', 1978 => '1978-5-14', 1979 => '1979-5-3',
+            1980 => '1980-5-21', 1981 => '1981-5-11', 1982 => '1982-5-1',  1983 => '1983-5-20', 1984 => '1984-5-8',
+            1985 => '1985-5-27', 1986 => '1986-5-16', 1987 => '1987-5-5',  1988 => '1988-5-23', 1989 => '1989-5-12',
+            1990 => '1990-5-2',  1991 => '1991-5-21', 1992 => '1992-5-10', 1993 => '1993-5-28', 1994 => '1994-5-18',
+            1995 => '1995-5-7',  1996 => '1996-5-24', 1997 => '1997-5-14', 1998 => '1998-5-3',  1999 => '1999-5-22',
+            2000 => '2000-5-11', 2001 => '2001-4-30', 2002 => '2002-5-19', 2003 => '2003-5-8',  2004 => '2004-5-26',
+            2005 => '2005-5-15', 2006 => '2006-5-5',  2007 => '2007-5-24', 2008 => '2008-5-12', 2009 => '2009-5-2',
+            2010 => '2010-5-21', 2011 => '2011-5-10', 2012 => '2012-5-28', 2013 => '2013-5-17', 2014 => '2014-5-6',
+            2015 => '2015-5-25', 2016 => '2016-5-14', 2017 => '2017-5-3',  2018 => '2018-5-22', 2019 => '2019-5-12',
+            2020 => '2020-4-30', 2021 => '2021-5-19', 2022 => '2022-5-8',  2023 => '2023-5-27', 2024 => '2024-5-15',
+            2025 => '2025-5-5',  2026 => '2026-5-24', 2027 => '2027-5-13', 2028 => '2028-5-2',  2029 => '2029-5-20',
+            2030 => '2030-5-9',  2031 => '2031-5-28', 2032 => '2032-5-16', 2033 => '2033-5-6',  2034 => '2034-5-25',
+            2035 => '2035-5-15', 2036 => '2036-5-3',  2037 => '2037-5-22', 2038 => '2038-5-11', 2039 => '2039-4-30',
+            2040 => '2040-5-18', 2041 => '2041-5-7',  2042 => '2042-5-26', 2043 => '2043-5-16', 2044 => '2044-5-5',
+            2045 => '2045-5-24', 2046 => '2046-5-13', 2047 => '2047-5-2',  2048 => '2048-5-20', 2049 => '2049-5-9',
+            2050 => '2050-5-28',
+        ],
+        'chuseok' => [
+            1949 => '1949-10-6', 1950 => '1950-9-26', 1951 => '1951-9-15', 1952 => '1952-10-3', 1953 => '1953-9-22',
+            1954 => '1954-9-11', 1955 => '1955-9-30', 1956 => '1956-9-19', 1957 => '1957-9-8',  1958 => '1958-9-27',
+            1959 => '1959-9-17', 1960 => '1960-10-5', 1961 => '1961-9-24', 1962 => '1962-9-13', 1963 => '1963-10-2',
+            1964 => '1964-9-20', 1965 => '1965-9-10', 1966 => '1966-9-29', 1967 => '1967-9-18', 1968 => '1968-10-6',
+            1969 => '1969-9-26', 1970 => '1970-9-15', 1971 => '1971-10-3', 1972 => '1972-9-22', 1973 => '1973-9-11',
+            1974 => '1974-9-30', 1975 => '1975-9-20', 1976 => '1976-9-8',  1977 => '1977-9-27', 1978 => '1978-9-17',
+            1979 => '1979-10-5', 1980 => '1980-9-23', 1981 => '1981-9-12', 1982 => '1982-10-1', 1983 => '1983-9-21',
+            1984 => '1984-9-10', 1985 => '1985-9-29', 1986 => '1986-9-18', 1987 => '1987-10-7', 1988 => '1988-9-25',
+            1989 => '1989-9-14', 1990 => '1990-10-3', 1991 => '1991-9-22', 1992 => '1992-9-11', 1993 => '1993-9-30',
+            1994 => '1994-9-20', 1995 => '1950-9-9',  1996 => '1996-9-27', 1997 => '1997-9-16', 1998 => '1998-10-5',
+            1999 => '1999-9-24', 2000 => '2000-9-12', 2001 => '2001-10-1', 2002 => '2002-9-21', 2003 => '2003-9-11',
+            2004 => '2004-9-28', 2005 => '2005-9-18', 2006 => '2006-10-6', 2007 => '2007-9-25', 2008 => '2008-9-14',
+            2009 => '2009-10-3', 2010 => '2010-9-22', 2011 => '2011-9-12', 2012 => '2012-9-30', 2013 => '2013-9-19',
+            2014 => '2014-9-8',  2015 => '2015-9-27', 2016 => '2016-9-15', 2017 => '2017-10-4', 2018 => '2018-9-24',
+            2019 => '2019-9-13', 2020 => '2020-10-1', 2021 => '2021-9-21', 2022 => '2022-9-10', 2023 => '2023-9-29',
+            2024 => '2024-9-17', 2025 => '2025-10-6', 2026 => '2026-9-25', 2027 => '2027-9-15', 2028 => '2028-10-3',
+            2029 => '2029-9-22', 2030 => '2030-9-12', 2031 => '2031-10-1', 2032 => '2032-9-19', 2033 => '2033-9-8',
+            2034 => '2034-9-27', 2035 => '2035-9-16', 2036 => '2036-10-4', 2037 => '2037-9-24', 2038 => '2038-9-13',
+            2039 => '2039-10-2', 2040 => '2040-9-21', 2041 => '2041-9-10', 2042 => '2042-9-28', 2043 => '2043-9-17',
+            2044 => '2044-10-5', 2045 => '2045-9-25', 2046 => '2046-9-15', 2047 => '2047-10-4', 2048 => '2048-9-22',
+            2049 => '2049-9-11', 2050 => '2050-9-30',
+        ],
+    ];
+
+    /**
+     * Initialize holidays for South Korea.
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize(): void
+    {
+        $this->timezone = 'Asia/Seoul';
+
+        // Add common holidays
+        $this->calculateNewYearsDay();
+        if ($this->year >= 1949) {
+            $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
+        }
+
+        // Calculate lunar holidays
+        $this->calculateSeollal();
+        $this->calculateBuddhasBirthday();
+        $this->calculateChuseok();
+
+        // Calculate other holidays
+        $this->calculateIndependenceMovementDay();
+        $this->calculateArborDay();
+        $this->calculateChildrensDay();
+        $this->calculateMemorialDay();
+        $this->calculateConstitutionDay();
+        $this->calculateLiberationDay();
+        $this->calculateArmedForcesDay();
+        $this->calculateNationalFoundationDay();
+        $this->calculateHangulDay();
+        $this->calculateSubstituteHolidays();
+    }
+
+    /**
+     * New Year's Day. New Year's Day is held on January 1st and established since 1950.
+     * From the enactment of the First Law to 1998, there was a two or three-day break in the New Year.
+     *
+     * @link https://en.wikipedia.org/wiki/New_Year%27s_Day#East_Asian
+     *
+     * @throws \Exception
+     */
+    public function calculateNewYearsDay(): void
+    {
+        if ($this->year >= 1950) {
+            $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+            if ($this->year <= 1998) {
+                $this->addHoliday(new Holiday(
+                    'dayAfterNewYearsDay',
+                    [],
+                    new DateTime("$this->year-1-2", new DateTimeZone($this->timezone)),
+                    $this->locale
+                ));
+            }
+            if ($this->year <= 1990) {
+                $this->addHoliday(new Holiday(
+                    'twoDaysLaterNewYearsDay',
+                    ['en_US' => 'Two Days Later New Year\'s Day', 'ko_KR' => '새해 연휴'],
+                    new DateTime("$this->year-1-3", new DateTimeZone($this->timezone)),
+                    $this->locale
+                ));
+            }
+        }
+    }
+
+    /**
+     * Seollal (Korean New Year's Day).
+     * Seollal is held on the 1st day of the 1st lunar month and was established from 1985.
+     *
+     * @link https://en.wikipedia.org/wiki/Korean_New_Year
+     *
+     * @throws \Exception
+     */
+    public function calculateSeollal()
+    {
+        if ($this->year >= 1985 and isset(self::LUNAR_HOLIDAY['seollal'][$this->year])) {
+            $seollal = new DateTime(self::LUNAR_HOLIDAY['seollal'][$this->year], new DateTimeZone($this->timezone));
+            $this->addHoliday(new Holiday(
+                'seollal',
+                ['en_US' => 'Seollal', 'ko_KR' => '설날'],
+                $seollal,
+                $this->locale
+            ));
+            if ($this->year > 1989) {
+                $dayBeforeSeollal = clone $seollal;
+                $dayBeforeSeollal->sub(new DateInterval('P1D'));
+                $this->addHoliday(new Holiday(
+                    'dayBeforeSeollal',
+                    ['en_US' => 'Day before Seollal', 'ko_KR' => '설날 연휴'],
+                    $dayBeforeSeollal,
+                    $this->locale
+                ));
+                $dayAfterSeollal = clone $seollal;
+                $dayAfterSeollal->add(new DateInterval('P1D'));
+                $this->addHoliday(new Holiday(
+                    'dayAfterSeollal',
+                    ['en_US' => 'Day after Seollal', 'ko_KR' => '설날 연휴'],
+                    $dayAfterSeollal,
+                    $this->locale
+                ));
+            }
+        }
+    }
+
+    /**
+     * Independence Movement Day. Independence Movement Day is held on March 1st and was established from 1949.
+     *
+     * @link https://en.wikipedia.org/wiki/Independence_Movement_Day
+     *
+     * @throws \Exception
+     */
+    public function calculateIndependenceMovementDay()
+    {
+        if ($this->year >= 1949) {
+            $this->addHoliday(new Holiday(
+                'independenceMovementDay',
+                ['en_US' => 'Independence Movement Day', 'ko_KR' => '삼일절'],
+                new DateTime("$this->year-3-1", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Sikmogil (Arbor Day). Sikmogil is held on May 5th and established since 1949.
+     *
+     * @link https://en.wikipedia.org/wiki/Sikmogil
+     *
+     * @throws \Exception
+     */
+    public function calculateArborDay(): void
+    {
+        if ($this->year >= 1949 && $this->year < 1960 || $this->year > 1960 && $this->year < 2006) {
+            $this->addHoliday(new Holiday(
+                'arborDay',
+                ['en_US' => 'Arbor Day', 'ko_KR' => '식목일'],
+                new DateTime("$this->year-4-5", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Children's Day. Children's Day is held on May 5th and established since 1970.
+     *
+     * @link https://en.wikipedia.org/wiki/Children%27s_Day#South_Korea
+     *
+     * @throws \Exception
+     */
+    public function calculateChildrensDay(): void
+    {
+        if ($this->year >= 1970) {
+            $this->addHoliday(new Holiday(
+                'childrensDay',
+                ['en_US' => 'Children\'s Day', 'ko_KR' => '어린이날'],
+                new DateTime("$this->year-5-5", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Buddha's Birthday is held on the 8th day of the 4th lunar month and was established since 1975.
+     *
+     * @link https://en.wikipedia.org/wiki/Buddha%27s_Birthday
+     *
+     * @throws \Exception
+     */
+    public function calculateBuddhasBirthday()
+    {
+        if ($this->year >= 1975 and isset(self::LUNAR_HOLIDAY['buddhasBirthday'][$this->year])) {
+            $this->addHoliday(new Holiday(
+                'buddhasBirthday',
+                ['en_US' => 'Buddha\'s Birthday', 'ko_KR' => '부처님오신날'],
+                new DateTime(self::LUNAR_HOLIDAY['buddhasBirthday'][$this->year], new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Memorial Day. Memorial Day is held on June 6th and established since 1956.
+     *
+     * @link https://en.wikipedia.org/wiki/Memorial_Day_(South_Korea)
+     *
+     * @throws \Exception
+     */
+    public function calculateMemorialDay(): void
+    {
+        if ($this->year >= 1966) {
+            $this->addHoliday(new Holiday(
+                'memorialDay',
+                ['en_US' => 'Memorial Day', 'ko_KR' => '현충일'],
+                new DateTime("$this->year-6-6", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Constitution Day.
+     *
+     * Constitution Day is held on July 17th and established since 1949.
+     * Officially, it is a strict national holiday, but government offices and banks work normally after 2008.
+     *
+     * @link https://en.wikipedia.org/wiki/Constitution_Day_(South_Korea)
+     *
+     * @throws \Exception
+     */
+    public function calculateConstitutionDay(): void
+    {
+        if ($this->year >= 1949 && $this->year < 2008) {
+            $this->addHoliday(new Holiday(
+                'constitutionDay',
+                ['en_US' => 'Constitution Day', 'ko_KR' => '제헌절'],
+                new DateTime("$this->year-7-17", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Liberation Day. Liberation Day is held on August 15th and established since 1949.
+     *
+     * @link https://en.wikipedia.org/wiki/National_Liberation_Day_of_Korea
+     *
+     * @throws \Exception
+     */
+    public function calculateLiberationDay(): void
+    {
+        if ($this->year >= 1949) {
+            $this->addHoliday(new Holiday(
+                'liberationDay',
+                ['en_US' => 'Liberation Day', 'ko_KR' => '광복절'],
+                new DateTime("$this->year-8-15", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Chuseok (Korean Thanksgiving Day).
+     *
+     * Chuseok, one of the biggest holidays in Korea, is a major harvest festival and a three-day holiday celebrated on
+     * the 15th day of the 8th month of the lunar calendar on the full moon.
+     *
+     * @link https://en.wikipedia.org/wiki/Chuseok
+     *
+     * @throws \Exception
+     */
+    public function calculateChuseok()
+    {
+        if ($this->year >= 1949 and isset(self::LUNAR_HOLIDAY['chuseok'][$this->year])) {
+            // Chuseok
+            $chuseok = new Holiday(
+                'chuseok',
+                ['en_US' => 'Chuseok', 'ko_KR' => '추석'],
+                new DateTime(self::LUNAR_HOLIDAY['chuseok'][$this->year], new DateTimeZone($this->timezone)),
+                $this->locale
+            );
+            $this->addHoliday($chuseok);
+
+            // Day after Chuseok
+            if ($this->year >= 1986) {
+                $this->addHoliday(new Holiday(
+                    'dayAfterChuseok',
+                    ['en_US' => 'Day after Chuseok', 'ko_KR' => '추석 연휴'],
+                    (clone $chuseok)->add(new DateInterval('P1D')),
+                    $this->locale
+                ));
+            }
+
+            // Day before Chuseok
+            if ($this->year >= 1989) {
+                $this->addHoliday(new Holiday(
+                    'dayBeforeChuseok',
+                    ['en_US' => 'Day before Chuseok', 'ko_KR' => '추석 연휴'],
+                    (clone $chuseok)->sub(new DateInterval('P1D')),
+                    $this->locale
+                ));
+            }
+        }
+    }
+
+    /**
+     * Armed Forces Day. Armed Forces Day is held on October 1st and established since 1956.
+     *
+     * @link https://en.wikipedia.org/wiki/Armed_Forces_Day_(South_Korea)
+     *
+     * @throws \Exception
+     */
+    public function calculateArmedForcesDay(): void
+    {
+        if ($this->year >= 1956 && $this->year <= 1990) {
+            $this->addHoliday(new Holiday(
+                'armedForcesDay',
+                ['en_US' => 'Armed Forces Day', 'ko_KR' => '국군의 날'],
+                new DateTime("$this->year-10-1", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Gaecheonjeol (National Foundation Day). Gaecheonjeol is held on October 3rd and established since 1949.
+     *
+     * @link https://en.wikipedia.org/wiki/Gaecheonjeol
+     *
+     * @throws \Exception
+     */
+    public function calculateNationalFoundationDay(): void
+    {
+        if ($this->year >= 1949) {
+            $this->addHoliday(new Holiday(
+                'nationalFoundationDay',
+                ['en_US' => 'National Foundation Day', 'ko_KR' => '개천절'],
+                new DateTime("$this->year-10-3", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Hangul Day. Hangul Day is held on October 9th and established since 1949.
+     *
+     * @link https://en.wikipedia.org/wiki/Hangul_Day
+     *
+     * @throws \Exception
+     */
+    public function calculateHangulDay(): void
+    {
+        if ($this->year >= 1949 && $this->year <= 1990 || $this->year > 2012) {
+            $this->addHoliday(new Holiday(
+                'hangulDay',
+                ['en_US' => 'Hangul Day', 'ko_KR' => '한글날'],
+                new DateTime("$this->year-10-9", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Substitute Holidays.
+     * related statutes: Article 3 Alternative Statutory Holidays of the Regulations on Holidays of Government Offices
+     *
+     * Since 2014, it has been applied only on Seollal, Chuseok and Children's Day.
+     * Due to the lunar calendar, public holidays can overlap even if it's not a Sunday.
+     * When public holidays fall each other, the first non-public holiday after the holiday become as a public holiday.
+     * As an exception, Children's Day also applies on Saturday.
+     *
+     * @throws \Exception
+     */
+    public function calculateSubstituteHolidays(): void
+    {
+        if ($this->year > 2013) {
+            // Initialize holidays variable
+            $holidays = $this->getHolidays();
+            $acceptedHolidays = [
+                'dayBeforeSeollal', 'seollal', 'dayAfterSeollal',
+                'dayBeforeChuseok', 'chuseok', 'dayAfterChuseok',
+                'childrensDay',
+            ];
+
+            // Loop through all holidays
+            foreach ($holidays as $shortName => $date) {
+                // Get list of holiday dates except this
+                $holidayDates = \array_map(function ($holiday) use ($shortName) {
+                    return $holiday->shortName === $shortName ? false : (string)$holiday;
+                }, $holidays);
+
+                // Only process accepted holidays and conditions
+                if (\in_array($shortName, $acceptedHolidays, true)
+                    && (
+                        0 === (int)$date->format('w')
+                        || \in_array($date, $holidayDates, false)
+                        || 6 === (int)$date->format('w') && $shortName === 'childrensDay'
+                    )
+                ) {
+                    $substitute = clone $date;
+
+                    // Find next week day (not being another holiday)
+                    while (0 === (int)$substitute->format('w')
+                        || 6 === (int)$substitute->format('w') && $shortName === 'childrensDay'
+                        || \in_array($substitute, $holidayDates, false)) {
+                        $substitute->add(new DateInterval('P1D'));
+                        continue;
+                    }
+
+                    // Add a new holiday that is substituting the original holiday
+                    $holiday = new Holiday("substituteHoliday:$substitute->shortName", [
+                        'en_US' => $substitute->translations['en_US'] . ' Observed',
+                        'ko_KR' => '대체공휴일',
+                    ], $substitute, $this->locale);
+
+                    // Add a new holiday that is substituting the original holiday
+                    $this->addHoliday($holiday);
+
+                    // Add substitute holiday to the list
+                    $holidays[] = $holiday;
+                }
+            }
+        }
+    }
+}

--- a/src/Yasumi/data/translations/christmasDay.php
+++ b/src/Yasumi/data/translations/christmasDay.php
@@ -35,6 +35,7 @@ return [
     'hu_HU' => 'Karácsony',
     'it_CH' => 'Natale',
     'it_IT' => 'Natale',
+    'ko_KR' => '기독탄신일',
     'lt_LT' => 'Šv. Kalėdos',
     'lv_LV' => 'Ziemassvētki',
     'nb_NO' => 'Første juledag',

--- a/src/Yasumi/data/translations/christmasEve.php
+++ b/src/Yasumi/data/translations/christmasEve.php
@@ -21,6 +21,7 @@ return [
     'fr_BE' => 'Réveillon de Noël',
     'fr_CH' => 'Réveillon de Noël',
     'it_CH' => 'Vigilia di Natale',
+    'ko_KR' => '크리스마스 이브',
     'lt_LT' => 'Šv. Kūčios',
     'lv_LV' => 'Ziemassvētku vakars',
     'pt_PT' => 'Véspera de Natal',

--- a/src/Yasumi/data/translations/dayAfterNewYearsDay.php
+++ b/src/Yasumi/data/translations/dayAfterNewYearsDay.php
@@ -14,4 +14,5 @@
 return [
     'en_NZ' => 'Day after New Year\'s Day',
     'en_US' => 'Day after New Year\'s Day',
+    'ko_KR' => '새해 연휴',
 ];

--- a/src/Yasumi/data/translations/internationalWomensDay.php
+++ b/src/Yasumi/data/translations/internationalWomensDay.php
@@ -14,6 +14,7 @@
 return [
     'de_DE' => 'Internationaler Frauentag',
     'en_US' => 'International Women\'s Day',
+    'ko_KR' => '국제 여성의 날',
     'ru_RU' => 'Международный женский день',
     'uk_UA' => 'Міжнародний жіночий день',
     'ru_UA' => 'Международный женский день',

--- a/src/Yasumi/data/translations/internationalWorkersDay.php
+++ b/src/Yasumi/data/translations/internationalWorkersDay.php
@@ -32,6 +32,7 @@ return [
     'it_CH' => 'Festa dei lavoratori',
     'it_IT' => 'Festa del Lavoro',
     'ja_JP' => '労働の日',
+    'ko_KR' => '노동절',
     'lt_LT' => 'Tarptautinė darbo diena',
     'lv_LV' => 'Darba svētki',
     'nb_NO' => 'Arbeidernes dag',

--- a/src/Yasumi/data/translations/labourDay.php
+++ b/src/Yasumi/data/translations/labourDay.php
@@ -16,6 +16,7 @@ return [
     'en_NZ' => 'Labour Day',
     'en_US' => 'Labour Day',
     'ja_JP' => '労働の日',
+    'ko_KR' => '노동절',
     'nl_BE' => 'Dag van de arbeid',
     'nl_NL' => 'Dag van de arbeid',
     'sk_SK' => 'Sviatok práce',

--- a/src/Yasumi/data/translations/newYearsDay.php
+++ b/src/Yasumi/data/translations/newYearsDay.php
@@ -38,6 +38,7 @@ return [
     'it_CH' => 'Capodanno',
     'it_IT' => 'Capodanno',
     'ja_JP' => '元日',
+    'ko_KR' => '새해',
     'lt_LT' => 'Naujųjų metų diena',
     'lv_LV' => 'Jaunais Gads',
     'nb_NO' => 'Første nyttårsdag',

--- a/src/Yasumi/data/translations/newYearsEve.php
+++ b/src/Yasumi/data/translations/newYearsEve.php
@@ -14,5 +14,6 @@
 return [
     'da_DK' => 'Nytårsaften',
     'en_US' => 'New Year\'s Eve',
+    'ko_KR' => '신년전야',
     'lv_LV' => 'Vecgada vakars',
 ];

--- a/src/Yasumi/data/translations/secondChristmasDay.php
+++ b/src/Yasumi/data/translations/secondChristmasDay.php
@@ -25,6 +25,7 @@ return [
     'et_EE' => 'Teine Jõulupüha',
     'fi_FI' => '2. joulupäivä',
     'hu_HU' => 'Karácsony másnapja',
+    'ko_KR' => '성탄절 연휴',
     'lt_LT' => 'Kalėdos (antra diena)',
     'lv_LV' => 'Otrie Ziemassvētki',
     'nb_NO' => 'Andre juledag',

--- a/src/Yasumi/data/translations/summerTime.php
+++ b/src/Yasumi/data/translations/summerTime.php
@@ -14,5 +14,6 @@
 return [
     'da_DK' => 'Sommertid starter',
     'en_US' => 'Summertime',
+    'ko_KR' => '서머타임',
     'nl_NL' => 'Zomertijd',
 ];

--- a/src/Yasumi/data/translations/valentinesDay.php
+++ b/src/Yasumi/data/translations/valentinesDay.php
@@ -20,6 +20,7 @@ return [
     'fr_CH' => 'Saint-Valentin',
     'it_CH' => 'San Valentino',
     'ja_JP' => 'バレンタイン·デー',
+    'ko_KR' => '발렌타인 데이',
     'nl_BE' => 'Valentijnsdag',
     'nl_NL' => 'Valentijnsdag',
     'pl_PL' => 'Walentynki',

--- a/tests/SouthKorea/ArborDayTest.php
+++ b/tests/SouthKorea/ArborDayTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing day after Arbor Day in South Korea.
+ */
+class ArborDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'arborDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1949;
+
+    /**
+     * The year in which the holiday was removed
+     */
+    public const REMOVED_YEAR = 2005;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::REMOVED_YEAR);
+        if ($year === 1960) {
+            $this->assertNotHoliday(
+                self::REGION,
+                self::HOLIDAY,
+                $year
+            );
+        } else {
+            $this->assertHoliday(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                new DateTime("$year-4-5", new DateTimeZone(self::TIMEZONE))
+            );
+        }
+    }
+
+    /**
+     * Tests the holiday defined in this test after removal.
+     * @throws \ReflectionException
+     */
+    public function testHolidayAfterRemoval()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::REMOVED_YEAR + 1)
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::REMOVED_YEAR);
+        if ($year !== 1960) {
+            $this->assertTranslatedHolidayName(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                [self::LOCALE => '식목일']
+            );
+        }
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::REMOVED_YEAR);
+        if ($year !== 1960) {
+            $this->assertHolidayType(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                Holiday::TYPE_OFFICIAL
+            );
+        }
+    }
+}

--- a/tests/SouthKorea/ArmedForcesDayTest.php
+++ b/tests/SouthKorea/ArmedForcesDayTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing day after Armed Forces Day in South Korea.
+ */
+class ArmedForcesDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'armedForcesDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1956;
+
+    /**
+     * The year in which the holiday was removed
+     */
+    public const REMOVED_YEAR = 1990;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::REMOVED_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-10-1", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test after removal.
+     * @throws \ReflectionException
+     */
+    public function testHolidayAfterRemoval()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::REMOVED_YEAR + 1)
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::REMOVED_YEAR),
+            [self::LOCALE => '국군의 날']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::REMOVED_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/SouthKorea/BuddhasBirthdayTest.php
+++ b/tests/SouthKorea/BuddhasBirthdayTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\SouthKorea;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Buddha's Birthday in South Korea.
+ */
+class BuddhasBirthdayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'buddhasBirthday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1975;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2050);
+        if (isset(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year])) {
+            $this->assertHoliday(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                new DateTime(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year], new DateTimeZone(self::TIMEZONE))
+            );
+        }
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2050);
+        if (isset(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year])) {
+            $this->assertTranslatedHolidayName(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                [self::LOCALE => '부처님오신날']
+            );
+        }
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2050);
+        if (isset(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year])) {
+            $this->assertHolidayType(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                Holiday::TYPE_OFFICIAL
+            );
+        }
+    }
+}

--- a/tests/SouthKorea/ChildrensDayTest.php
+++ b/tests/SouthKorea/ChildrensDayTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Children's Day in South Korea.
+ */
+class ChildrensDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'childrensDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1970;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testMainHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-5-5", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the substitute holiday defined in this test (conflict with Buddha's Birthday).
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testSubstituteHolidayByBuddhasBirthday()
+    {
+        foreach ([2025, 2044] as $year) {
+            $this->assertHoliday(
+                self::REGION,
+                'substituteHoliday:childrensDay',
+                $year,
+                new DateTime("$year-5-6", new DateTimeZone(self::TIMEZONE))
+            );
+        }
+    }
+
+    /**
+     * Tests the substitute holiday defined in this test (conflict with Saturday).
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testSubstituteHolidayBySaturday()
+    {
+        $year = 2029;
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:childrensDay',
+            $year,
+            new DateTime("$year-5-7", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the substitute holiday defined in this test (conflict with Sunday).
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testSubstituteHolidayBySunday()
+    {
+        $year = 2019;
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:childrensDay',
+            $year,
+            new DateTime("$year-5-6", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => '어린이날']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/SouthKorea/ChristmasDayTest.php
+++ b/tests/SouthKorea/ChristmasDayTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Christmas Day in South Korea.
+ */
+class ChristmasDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'christmasDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1949;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-12-25", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => '기독탄신일']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/SouthKorea/ChuseokTest.php
+++ b/tests/SouthKorea/ChuseokTest.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\SouthKorea;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Chuseok in South Korea.
+ */
+class ChuseokTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'chuseok';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1949;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2050);
+        if (isset(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year])) {
+            $date = new DateTime(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year], new DateTimeZone(self::TIMEZONE));
+
+            // Chuseok
+            $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+            // Day after Chuseok
+            if ($year >= 1986) {
+                $this->assertHoliday(
+                    self::REGION,
+                    'dayAfterChuseok',
+                    $year,
+                    (clone $date)->add(new DateInterval('P1D'))
+                );
+            }
+
+            // Day before Chuseok
+            if ($year >= 1989) {
+                $this->assertHoliday(
+                    self::REGION,
+                    'dayBeforeChuseok',
+                    $year,
+                    (clone $date)->sub(new DateInterval('P1D'))
+                );
+            }
+        }
+    }
+
+    /**
+     * Tests the substitute holiday defined in this test (conflict with Gaecheonjeol).
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testSubstituteHolidayByGaecheonjeol()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:dayBeforeChuseok',
+            2017,
+            new DateTime("2017-10-6", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:chuseok',
+            2028,
+            new DateTime("2028-10-5", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:dayAfterChuseok',
+            2039,
+            new DateTime("2039-10-5", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the substitute holiday defined in this test (conflict with Sunday).
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testSubstituteHolidayBySunday()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:dayBeforeChuseok',
+            2014,
+            new DateTime("2014-9-10", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:chuseok',
+            2039,
+            new DateTime("2039-10-4", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:dayAfterChuseok',
+            2022,
+            new DateTime("2022-9-12", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2050);
+        if (isset(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year])) {
+            $this->assertTranslatedHolidayName(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                [self::LOCALE => '추석']
+            );
+            if ($year >= 1986) {
+                $this->assertTranslatedHolidayName(
+                    self::REGION,
+                    'dayAfterChuseok',
+                    $year,
+                    [self::LOCALE => '추석 연휴']
+                );
+            }
+            if ($year >= 1986) {
+                $this->assertTranslatedHolidayName(
+                    self::REGION,
+                    'dayBeforeChuseok',
+                    $year,
+                    [self::LOCALE => '추석 연휴']
+                );
+            }
+        }
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2050);
+        if (isset(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year])) {
+            $this->assertHolidayType(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                Holiday::TYPE_OFFICIAL
+            );
+            if ($year >= 1986) {
+                $this->assertHolidayType(
+                    self::REGION,
+                    'dayAfterChuseok',
+                    $year,
+                    Holiday::TYPE_OFFICIAL
+                );
+            }
+            if ($year >= 1989) {
+                $this->assertHolidayType(
+                    self::REGION,
+                    'dayBeforeChuseok',
+                    $year,
+                    Holiday::TYPE_OFFICIAL
+                );
+            }
+        }
+    }
+}

--- a/tests/SouthKorea/ConstitutionDayTest.php
+++ b/tests/SouthKorea/ConstitutionDayTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing day after Constitution Day in South Korea.
+ */
+class ConstitutionDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'constitutionDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1949;
+
+    /**
+     * The year in which the holiday was removed
+     */
+    public const REMOVED_YEAR = 2007;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::REMOVED_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-7-17", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test after removal.
+     * @throws \ReflectionException
+     */
+    public function testHolidayAfterRemoval()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::REMOVED_YEAR + 1)
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::REMOVED_YEAR),
+            [self::LOCALE => '제헌절']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::REMOVED_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/SouthKorea/GaecheonjeolTest.php
+++ b/tests/SouthKorea/GaecheonjeolTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Gaecheonjeol (National Foundation Day) in South Korea.
+ */
+class GaecheonjeolTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'nationalFoundationDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1949;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-10-3", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => '개천절']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/SouthKorea/HangulDayTest.php
+++ b/tests/SouthKorea/HangulDayTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Hangul Day in South Korea.
+ */
+class HangulDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'hangulDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1949;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        if ($year > 1990 && $year <= 2012) {
+            $this->assertNotHoliday(
+                self::REGION,
+                self::HOLIDAY,
+                $year
+            );
+        } else {
+            $this->assertHoliday(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                new DateTime("$year-10-9", new DateTimeZone(self::TIMEZONE))
+            );
+        }
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        if ($year <= 1990 && $year > 2012) {
+            $this->assertTranslatedHolidayName(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                [self::LOCALE => '한글날']
+            );
+        }
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        if ($year <= 1990 && $year > 2012) {
+            $this->assertHolidayType(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                Holiday::TYPE_OFFICIAL
+            );
+        }
+    }
+}

--- a/tests/SouthKorea/HangulDayTest.php
+++ b/tests/SouthKorea/HangulDayTest.php
@@ -77,7 +77,7 @@ class HangulDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInte
     public function testTranslation(): void
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        if ($year <= 1990 && $year > 2012) {
+        if ($year <= 1990 || $year > 2012) {
             $this->assertTranslatedHolidayName(
                 self::REGION,
                 self::HOLIDAY,
@@ -94,7 +94,7 @@ class HangulDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInte
     public function testHolidayType(): void
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        if ($year <= 1990 && $year > 2012) {
+        if ($year <= 1990 || $year > 2012) {
             $this->assertHolidayType(
                 self::REGION,
                 self::HOLIDAY,

--- a/tests/SouthKorea/IndependenceMovementDayTest.php
+++ b/tests/SouthKorea/IndependenceMovementDayTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Independence Movement Day in South Korea.
+ */
+class IndependenceMovementDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'independenceMovementDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1949;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-3-1", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => '삼일절']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/SouthKorea/LiberationDayTest.php
+++ b/tests/SouthKorea/LiberationDayTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Independence Movement Day in South Korea.
+ */
+class LiberationDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'liberationDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1949;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-8-15", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => '광복절']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/SouthKorea/MemorialDayTest.php
+++ b/tests/SouthKorea/MemorialDayTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Memorial Day in South Korea.
+ */
+class MemorialDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'memorialDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1966;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-6-6", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => '현충일']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/SouthKorea/NewYearsDayTest.php
+++ b/tests/SouthKorea/NewYearsDayTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing New Year's Day in South Korea.
+ */
+class NewYearsDayTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'newYearsDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1950;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $date = new DateTime("$year-1-1", new DateTimeZone(self::TIMEZONE));
+
+        // New Year's Day
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        // Day after New Year's Day
+        if ($year <= 1998) {
+            $this->assertHoliday(
+                self::REGION,
+                'dayAfterNewYearsDay',
+                $year,
+                (clone $date)->add(new DateInterval('P1D'))
+            );
+        }
+
+        // Two days later New Year's Day
+        if ($year <= 1990) {
+            $this->assertHoliday(
+                self::REGION,
+                'twoDaysLaterNewYearsDay',
+                $year,
+                (clone $date)->add(new DateInterval('P2D'))
+            );
+        }
+    }
+
+    /**
+     * Tests the holiday defined in this test after removal.
+     * @throws \ReflectionException
+     */
+    public function testHolidayAfterRemoval()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            'dayAfterNewYearsDay',
+            $this->generateRandomYear(1999)
+        );
+        $this->assertNotHoliday(
+            self::REGION,
+            'twoDaysLaterNewYearsDay',
+            $this->generateRandomYear(1991)
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => '새해']
+        );
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            'dayAfterNewYearsDay',
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 1998),
+            [self::LOCALE => '새해 연휴']
+        );
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            'twoDaysLaterNewYearsDay',
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 1990),
+            [self::LOCALE => '새해 연휴']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+        $this->assertHolidayType(
+            self::REGION,
+            'dayAfterNewYearsDay',
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 1998),
+            Holiday::TYPE_OFFICIAL
+        );
+        $this->assertHolidayType(
+            self::REGION,
+            'twoDaysLaterNewYearsDay',
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 1990),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/SouthKorea/SeollalTest.php
+++ b/tests/SouthKorea/SeollalTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\SouthKorea;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Seollal (Korean New Year's Day) in South Korea.
+ */
+class SeollalTest extends SouthKoreaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'seollal';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1985;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2050);
+        if (isset(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year])) {
+            $date = new DateTime(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year], new DateTimeZone(self::TIMEZONE));
+
+            // Seollal
+            $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+            if ($year >= 1990) {
+                // Day before Seollal
+                $this->assertHoliday(
+                    self::REGION,
+                    'dayBeforeSeollal',
+                    $year,
+                    (clone $date)->sub(new DateInterval('P1D'))
+                );
+
+                // Day after Seollal
+                $this->assertHoliday(
+                    self::REGION,
+                    'dayAfterSeollal',
+                    $year,
+                    (clone $date)->add(new DateInterval('P1D'))
+                );
+            }
+        }
+    }
+
+    /**
+     * Tests the substitute holiday defined in this test (conflict with Sunday).
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testSubstituteHolidayBySunday()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:dayBeforeSeollal',
+            2016,
+            new DateTime("2016-2-10", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:seollal',
+            2034,
+            new DateTime("2034-2-21", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            'substituteHoliday:dayAfterSeollal',
+            2024,
+            new DateTime("2024-2-12", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2050);
+        if (isset(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year])) {
+            $this->assertTranslatedHolidayName(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                [self::LOCALE => '설날']
+            );
+            if ($year >= 1990) {
+                $this->assertHolidayType(
+                    self::REGION,
+                    'dayBeforeSeollal',
+                    $year,
+                    Holiday::TYPE_OFFICIAL
+                );
+                $this->assertHolidayType(
+                    self::REGION,
+                    'dayAfterSeollal',
+                    $year,
+                    Holiday::TYPE_OFFICIAL
+                );
+            }
+        }
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 2050);
+        if (isset(SouthKorea::LUNAR_HOLIDAY[self::HOLIDAY][$year])) {
+            $this->assertHolidayType(
+                self::REGION,
+                self::HOLIDAY,
+                $year,
+                Holiday::TYPE_OFFICIAL
+            );
+            if ($year >= 1990) {
+                $this->assertHolidayType(
+                    self::REGION,
+                    'dayBeforeSeollal',
+                    $year,
+                    Holiday::TYPE_OFFICIAL
+                );
+                $this->assertHolidayType(
+                    self::REGION,
+                    'dayAfterSeollal',
+                    $year,
+                    Holiday::TYPE_OFFICIAL
+                );
+            }
+        }
+    }
+}

--- a/tests/SouthKorea/SouthKoreaBaseTestCase.php
+++ b/tests/SouthKorea/SouthKoreaBaseTestCase.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use PHPUnit\Framework\TestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the South Korea holiday provider.
+ */
+abstract class SouthKoreaBaseTestCase extends TestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public const REGION = 'SouthKorea';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public const TIMEZONE = 'Asia/Seoul';
+
+    /**
+     * Locale that is considered common for this provider
+     */
+    public const LOCALE = 'ko_KR';
+}

--- a/tests/SouthKorea/SouthKoreaTest.php
+++ b/tests/SouthKorea/SouthKoreaTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\SouthKorea;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\SouthKorea;
+
+/**
+ * Class for testing holidays in South Korea.
+ */
+class SouthKoreaTest extends SouthKoreaBaseTestCase
+{
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in South Korea are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testOfficialHolidays(): void
+    {
+        $officialHolidays = [];
+        if ($this->year >= 1949) {
+            $officialHolidays[] = 'independenceMovementDay';
+            $officialHolidays[] = 'liberationDay';
+            $officialHolidays[] = 'nationalFoundationDay';
+            $officialHolidays[] = 'christmasDay';
+            if ($this->year !== 1960 && $this->year < 2006) {
+                $officialHolidays[] = 'arborDay';
+            }
+            if ($this->year <= 1990 && $this->year > 2012) {
+                $officialHolidays[] = 'hangulDay';
+            }
+            if ($this->year < 2008) {
+                $officialHolidays[] = 'constitutionDay';
+            }
+        }
+        if ($this->year >= 1950) {
+            $officialHolidays[] = 'newYearsDay';
+            if ($this->year <= 1990) {
+                $officialHolidays[] = 'twoDaysLaterNewYearsDay';
+            }
+            if ($this->year <= 1998) {
+                $officialHolidays[] = 'dayAfterNewYearsDay';
+            }
+        }
+        if ($this->year >= 1956 && $this->year <= 1990) {
+            $officialHolidays[] = 'armedForcesDay';
+        }
+        if ($this->year >= 1966) {
+            $officialHolidays[] = 'memorialDay';
+        }
+
+        // specific cases (Seollal, Buddha's Birthday and Chuseok)
+        if ($this->year >= 1949 && isset(SouthKorea::LUNAR_HOLIDAY['chuseok'][$this->year])) {
+            $officialHolidays[] = 'chuseok';
+            if ($this->year >= 1986) {
+                $officialHolidays[] = 'dayAfterChuseok';
+            }
+            if ($this->year >= 1989) {
+                $officialHolidays[] = 'dayBeforeChuseok';
+            }
+        }
+        if ($this->year >= 1975 && isset(SouthKorea::LUNAR_HOLIDAY['buddhasBirthday'][$this->year])) {
+            $officialHolidays[] = 'buddhasBirthday';
+        }
+        if ($this->year >= 1985 && isset(SouthKorea::LUNAR_HOLIDAY['seollal'][$this->year])) {
+            $officialHolidays[] = 'seollal';
+            if ($this->year > 1989) {
+                $officialHolidays[] = 'dayBeforeSeollal';
+                $officialHolidays[] = 'dayAfterSeollal';
+            }
+        }
+
+        $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Tests if all observed holidays in South Korea are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testObservedHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+    }
+
+    /**
+     * Tests if all seasonal holidays in South Korea are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testSeasonalHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_SEASON);
+    }
+
+    /**
+     * Tests if all bank holidays in South Korea are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testBankHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_BANK);
+    }
+
+    /**
+     * Tests if all other holidays in South Korea are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testOtherHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1949, 2050);
+    }
+}

--- a/tests/SouthKorea/SouthKoreaTest.php
+++ b/tests/SouthKorea/SouthKoreaTest.php
@@ -41,7 +41,7 @@ class SouthKoreaTest extends SouthKoreaBaseTestCase
             if ($this->year !== 1960 && $this->year < 2006) {
                 $officialHolidays[] = 'arborDay';
             }
-            if ($this->year <= 1990 && $this->year > 2012) {
+            if ($this->year <= 1990 || $this->year > 2012) {
                 $officialHolidays[] = 'hangulDay';
             }
             if ($this->year < 2008) {


### PR DESCRIPTION
If there was an exact solar to lunar conversion formula, I wanted to implement it.
Korean developers are suffering from the lunar calendar.
Korea Astronomy & Space Science Institute (KASI) provides related data for the lunar calendar until 2050.
I did my best. If there's anything I can do to make up for it, let me know.