### PR TITLE
Separated czech and slovak independence day from New Year's Day

### DIFF
--- a/src/Yasumi/Provider/CzechRepublic.php
+++ b/src/Yasumi/Provider/CzechRepublic.php
@@ -45,6 +45,7 @@ class CzechRepublic extends AbstractProvider
         $this->timezone = 'Europe/Prague';
 
         $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->calculateRenewalOfCzechIndependenceDay();
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
@@ -57,6 +58,29 @@ class CzechRepublic extends AbstractProvider
         $this->addHoliday($this->christmasEve($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
+    }
+
+    /**
+     * Day of renewal of independent Czech state
+     *
+     * @see https://en.wikipedia.org/wiki/Public_holidays_in_the_Czech_Republic
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    private function calculateRenewalOfCzechIndependenceDay(): void
+    {
+        $this->addHoliday(new Holiday(
+            'czechRenewalOfIndependentStateDay',
+            [
+                'cs_CZ' => 'Den obnovy samostatného českého státu',
+                'en_US' => 'Day of renewal of the independent Czech state'
+            ],
+            new DateTime($this->year . '-01-01', new \DateTimeZone($this->timezone)),
+            $this->locale
+        ));
     }
 
     /**

--- a/src/Yasumi/Provider/Slovakia.php
+++ b/src/Yasumi/Provider/Slovakia.php
@@ -68,7 +68,7 @@ class Slovakia extends AbstractProvider
         $this->timezone = 'Europe/Bratislava';
 
         // 1.1.
-        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->calculateSlovakIndependenceDay();
         // 6.1.
         $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale, Holiday::TYPE_BANK));
         // 1.5.
@@ -102,6 +102,30 @@ class Slovakia extends AbstractProvider
         // variable holidays - easter
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale, Holiday::TYPE_BANK));
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale, Holiday::TYPE_BANK));
+    }
+
+
+    /**
+     * New Year's Day
+     *
+     * @see https://en.wikipedia.org/wiki/Public_holidays_in_Slovakia
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    private function calculateSlovakIndependenceDay(): void
+    {
+        $this->addHoliday(new Holiday(
+            'slovakIndependenceDay',
+            [
+                'sk_SK' => 'Deň vzniku Slovenskej republiky',
+                'en_US' => 'Day of the Establishment of the Slovak Republic'
+            ],
+            new DateTime($this->year . '-01-01', new \DateTimeZone($this->timezone)),
+            $this->locale
+        ));
     }
 
     /**

--- a/src/Yasumi/data/translations/newYearsDay.php
+++ b/src/Yasumi/data/translations/newYearsDay.php
@@ -13,7 +13,7 @@
 // Translations for New Year's Day
 return [
     'bs_Latn_BA' => 'Nova godina',
-    'cs_CZ' => 'Den obnovy samostatného českého státu a Nový rok',
+    'cs_CZ' => 'Nový rok',
     'cy_GB' => 'Dydd Calan',
     'da_DK' => 'Nytårsdag',
     'de_AT' => 'Neujahr',
@@ -50,7 +50,7 @@ return [
     'ro_RO' => 'Anul Nou',
     'ru_RU' => 'Новый год',
     'ru_UA' => 'Новый Год',
-    'sk_SK' => 'Deň vzniku Slovenskej republiky',
+    'sk_SK' => 'Nový rok',
     'sv_SE' => 'nyårsdagen',
     'uk_UA' => 'Новий Рік',
 ];

--- a/tests/CzechRepublic/CzechRepublicTest.php
+++ b/tests/CzechRepublic/CzechRepublicTest.php
@@ -36,6 +36,7 @@ class CzechRepublicTest extends CzechRepublicBaseTestCase
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
+            'czechRenewalOfIndependentStateDay',
             'victoryInEuropeDay',
             'goodFriday',
             'easterMonday',

--- a/tests/CzechRepublic/RenewalOfIndependentCzechStateDayTest.php
+++ b/tests/CzechRepublic/RenewalOfIndependentCzechStateDayTest.php
@@ -17,18 +17,19 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing New Years Day in the Czech Republic.
+ * Class for testing Day of renewal of independent czech state in Czechia.
  *
- * Class NewYearsDayTest
- * @package Yasumi\tests\CzechRepublic
- * @author  Dennis Fridrich <fridrich.dennis@gmail.com>
+ *
+ * @package Yasumi\tests\Slovakia
+ * @author  Andrej Rypak (dakujem) <xrypak@gmail.com>
+ * @author Jan Langer <mail@janlanger.cz>
  */
-class NewYearsDayTest extends CzechRepublicBaseTestCase implements YasumiTestCaseInterface
+class RenewalOfIndependentCzechStateDayTest extends CzechRepublicBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday to be tested
      */
-    public const HOLIDAY = 'newYearsDay';
+    public const HOLIDAY = 'czechRenewalOfIndependentStateDay';
 
     /**
      * Tests the holiday defined in this test.
@@ -66,7 +67,7 @@ class NewYearsDayTest extends CzechRepublicBaseTestCase implements YasumiTestCas
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(),
-            [self::LOCALE => 'Nový rok']
+            [self::LOCALE => 'Den obnovy samostatného českého státu']
         );
     }
 

--- a/tests/Slovakia/SlovakIndependeceDayTest.php
+++ b/tests/Slovakia/SlovakIndependeceDayTest.php
@@ -19,18 +19,19 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing New years day in Slovakia.
+ * Class for testing Slovak independence day in Slovakia.
  *
  *
  * @package Yasumi\tests\Slovakia
  * @author  Andrej Rypak (dakujem) <xrypak@gmail.com>
+ * @author Jan Langer <mail@janlanger.cz>
  */
-class NewYearsDayTest extends SlovakiaBaseTestCase implements YasumiTestCaseInterface
+class SlovakIndependeceDayTest extends SlovakiaBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday to be tested
      */
-    public const HOLIDAY = 'newYearsDay';
+    public const HOLIDAY = 'slovakIndependenceDay';
 
 
     /**

--- a/tests/Slovakia/SlovakiaTest.php
+++ b/tests/Slovakia/SlovakiaTest.php
@@ -38,7 +38,7 @@ class SlovakiaTest extends SlovakiaBaseTestCase
     public function testOfficialHolidays(): void
     {
         $this->assertDefinedHolidays([
-            'newYearsDay',
+            'slovakIndependenceDay',
             'slovakConstitutionDay',
             'slovakNationalUprisingDay',
             'saintsCyrilAndMethodiusDay',


### PR DESCRIPTION
As I understood the code, the translations in `data/translations` should be perfectly equivalent. In Czech republic and Slovakia there are two holidays celebrated on 1st of January - New Year's Day and Disolution of Czechoslovakia.

So I think Czech and Slovak holiday providers should not use newYears method, but have its own definition. Current code causes czech version "Day of renewal of the independent Czech state and New Year's Day" to be translated to "Day of the Establishment of the Slovak Republic" in slovak.