### PR TITLE
Add exceptions for UK bank holidays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Updated the translation for the Assumption of Mary holiday for the 'fr_FR' locale [\#155](https://github.com/azuyalabs/yasumi/pull/155) ([pioc92](https://github.com/pioc92))
 
 ### Fixed
+- Fixed one-off exceptions for May Day Bank Holiday in 1995 and 2020 and Spring Bank Holiday in 2002 and 2012 (United Kingdom) [\#160](https://github.com/azuyalabs/yasumi/pull/160) ([c960657](https://github.com/c960657))
 
 ### Removed
 

--- a/src/Yasumi/Provider/UnitedKingdom.php
+++ b/src/Yasumi/Provider/UnitedKingdom.php
@@ -118,6 +118,19 @@ class UnitedKingdom extends AbstractProvider
             return;
         }
 
+        // Moved to 8 May to commemorate the 50th (1995) and 75th (2020) anniversary of VE Day.
+        if ($this->year == 1995 || $this->year == 2020) {
+            $this->addHoliday(new Holiday(
+                'mayDayBankHoliday',
+                ['en_GB' => 'May Day Bank Holiday'],
+                new DateTime("$this->year-5-8", new DateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_BANK
+            ));
+
+            return;
+        }
+
         $this->addHoliday(new Holiday(
             'mayDayBankHoliday',
             ['en_GB' => 'May Day Bank Holiday'],
@@ -147,6 +160,20 @@ class UnitedKingdom extends AbstractProvider
     {
         // Statutory bank holiday from 1971, following a trial period from 1965 to 1970.
         if ($this->year < 1965) {
+            return;
+        }
+
+        // Moved to 4 June for the celebration of the Golden (2002) and Diamond (2012) Jubilee
+        // of Elizabeth II.
+        if ($this->year == 2002 || $this->year == 2012) {
+            $this->addHoliday(new Holiday(
+                'springBankHoliday',
+                ['en_GB' => 'Spring Bank Holiday'],
+                new DateTime("$this->year-6-4", new DateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_BANK
+            ));
+
             return;
         }
 

--- a/tests/UnitedKingdom/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/MayDayBankHolidayTest.php
@@ -49,7 +49,7 @@ class MayDayBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
     }
 
     /**
-     * Tests the holiday exception in 2020.
+     * Tests the holiday exception in 1995 and 2020.
      * @throws \ReflectionException
      */
     public function testHolidayExceptions()

--- a/tests/UnitedKingdom/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/MayDayBankHolidayTest.php
@@ -49,6 +49,27 @@ class MayDayBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
     }
 
     /**
+     * Tests the holiday exception in 2020.
+     * @throws \ReflectionException
+     */
+    public function testHolidayExceptions()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1995,
+            new DateTime("1995-5-8", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2020,
+            new DateTime("2020-5-8", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
      * Tests the holiday defined in this test before establishment.
      * @throws \ReflectionException
      */

--- a/tests/UnitedKingdom/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/SpringBankHolidayTest.php
@@ -49,6 +49,27 @@ class SpringBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
     }
 
     /**
+     * Tests the holiday exceptions in 2002 and 2012.
+     * @throws \ReflectionException
+     */
+    public function testHolidayException()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2002,
+            new DateTime("2002-6-4", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2012,
+            new DateTime("2012-6-4", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
      * Tests the holiday defined in this test before establishment.
      * @throws \ReflectionException
      */


### PR DESCRIPTION
The May Day and Spring Bank Holidays in the UK were moved in specific years:

- May Day Bank Holiday was moved to 8 May to commemorate the 50th (1995) and 75th (2020) anniversary of VE Day.
- Spring Bank Holiday was moved to 4 June for the celebration of the Golden (2002) and Diamond (2012) Jubilee of Queen Elizabeth II.

Source: https://en.wikipedia.org/wiki/Public_holidays_in_the_United_Kingdom#England,_Northern_Ireland_and_Wales