### PR TITLE
Adjust Summer Bank Holiday prior to 1970

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Holiday Provider for South Korea. [\#156](https://github.com/azuyalabs/yasumi/pull/156) ([blood72](https://github.com/blood72))
 - Translation for the Easter holiday for the 'fr_FR' locale [\#146](https://github.com/azuyalabs/yasumi/pull/146) ([pioc92](https://github.com/pioc92))
 - Translation for the Pentecoste holiday for the 'fr_FR' locale [\#145](https://github.com/azuyalabs/yasumi/pull/145) ([pioc92](https://github.com/pioc92))
+- Late Summer Bank Holiday in United Kingdom prior to 1965 [\#161](https://github.com/azuyalabs/yasumi/pull/161) ([c960657](https://github.com/c960657))
 
 ### Changed
 - Replaced the standard 'InvalidArgumentException' when an invalid year or holiday provider are given by a new exception for each of these two situations separately ('InvalidYearException' and 'ProviderNotFoundException'). This allows you to better distinguish which exception may occur when instantiating the Yasumi class. [\#95](https://github.com/azuyalabs/yasumi/pull/95) ([qneyrat](https://github.com/qneyrat))
@@ -18,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Updated the translation for the Assumption of Mary holiday for the 'fr_FR' locale [\#155](https://github.com/azuyalabs/yasumi/pull/155) ([pioc92](https://github.com/pioc92))
 
 ### Fixed
+- Late Summer Bank Holiday in 1968 and 1969 in United Kingdom [\#161](https://github.com/azuyalabs/yasumi/pull/161) ([c960657](https://github.com/c960657))
 
 ### Removed
 

--- a/src/Yasumi/Provider/UnitedKingdom.php
+++ b/src/Yasumi/Provider/UnitedKingdom.php
@@ -162,7 +162,7 @@ class UnitedKingdom extends AbstractProvider
     /**
      * The Summer Bank holiday, also known as the Late Summer bank holiday, is a time for people in the United Kingdom
      * to have a day off work or school. It falls on the last Monday of August replacing the first Monday in August
-     * (formerly commonly known as "August Bank Holiday".
+     * (formerly commonly known as "August Bank Holiday").
      *
      * Many organizations, businesses and schools are closed. Stores may be open or closed, according to local custom.
      * Public transport systems often run to a holiday timetable.
@@ -177,8 +177,34 @@ class UnitedKingdom extends AbstractProvider
      */
     private function calculateSummerBankHoliday(): void
     {
-        // Statutory bank holiday from 1971, following a trial period from 1965 to 1970.
+        if ($this->year < 1871) {
+            return;
+        }
+
         if ($this->year < 1965) {
+            $this->addHoliday(new Holiday(
+                'summerBankHoliday',
+                ['en_GB' => 'August Bank Holiday'],
+                new DateTime("first monday of august $this->year", new DateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_BANK
+            ));
+
+            return;
+        }
+
+        // Statutory bank holiday from 1971, following a trial period from 1965 to 1970.
+        // During the trial period, the definition was different than today, causing exceptions
+        // in 1968 and 1969.
+        if ($this->year == 1968 || $this->year == 1969) {
+            $this->addHoliday(new Holiday(
+                'summerBankHoliday',
+                ['en_GB' => 'Summer Bank Holiday'],
+                new DateTime("first monday of september $this->year", new DateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_BANK
+            ));
+
             return;
         }
 

--- a/tests/UnitedKingdom/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/SummerBankHolidayTest.php
@@ -30,7 +30,7 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
     /**
      * The year in which the holiday was first established
      */
-    public const ESTABLISHMENT_YEAR = 1965;
+    public const ESTABLISHMENT_YEAR = 1871;
 
     /**
      * Tests the holiday defined in this test.
@@ -39,12 +39,71 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
      */
     public function testHoliday()
     {
-        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $year = $this->generateRandomYear(1970);
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
             new DateTime("last monday of august $year", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday exception in 2020.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBefore1965()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, 1967);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("first monday of august $year", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday during trial period in 1965-1970.
+     * @throws \ReflectionException
+     */
+    public function testHolidayTrialPeriod()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1965,
+            new DateTime("1965-8-30", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1966,
+            new DateTime("1966-8-29", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1967,
+            new DateTime("1967-8-28", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1968,
+            new DateTime("1968-9-2", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1969,
+            new DateTime("1969-9-1", new DateTimeZone(self::TIMEZONE))
+        );
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1970,
+            new DateTime("1970-8-31", new DateTimeZone(self::TIMEZONE))
         );
     }
 


### PR DESCRIPTION
Prior to 1965, the Summer Bank Holiday aka August Bank Holiday was on the first day of August.

In 1968–69 the new “August” bank holiday fell in September. This was as a result of the decision to move the holiday to the end of the month, and the nearest Monday being taken. The current definition was introduced in 1971.

Source: https://en.wikipedia.org/wiki/Public_holidays_in_the_United_Kingdom#England,_Northern_Ireland_and_Wales