### PR TITLE
Suspended holidays in Portugal 2013-2015

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - Late Summer Bank Holiday in 1968 and 1969 in United Kingdom [\#161](https://github.com/azuyalabs/yasumi/pull/161) ([c960657](https://github.com/c960657))
 - Fixed one-off exceptions for May Day Bank Holiday in 1995 and 2020 and Spring Bank Holiday in 2002 and 2012 (United Kingdom) [\#160](https://github.com/azuyalabs/yasumi/pull/160) ([c960657](https://github.com/c960657))
+- Fixed revoked holidays in Portugal in 2013-2015 [\#163](https://github.com/azuyalabs/yasumi/pull/163) ([c960657](https://github.com/c960657))
 
 ### Removed
 

--- a/src/Yasumi/Provider/Brazil.php
+++ b/src/Yasumi/Provider/Brazil.php
@@ -71,7 +71,7 @@ class Brazil extends AbstractProvider
                 $carnavalMonday->sub(new DateInterval('P48D')),
                 $this->locale,
                 Holiday::TYPE_OBSERVANCE
-             ));
+            ));
 
             $carnavalTuesday = clone $easter;
             $this->addHoliday(new Holiday(
@@ -80,7 +80,7 @@ class Brazil extends AbstractProvider
                 $carnavalTuesday->sub(new DateInterval('P47D')),
                 $this->locale,
                 Holiday::TYPE_OBSERVANCE
-             ));
+            ));
         }
 
         /**

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -153,6 +153,8 @@ class Portugal extends AbstractProvider
      * presented itself as the only one that had a programme that was capable of returning to the country its lost
      * status and place Portugal on the way of progress.
      *
+     * The holiday was revoked in 2013 due to government deliberation. It was restored in 2016.
+     *
      * @link https://en.wikipedia.org/wiki/5_October_1910_revolution
      *
      * @throws \Yasumi\Exception\InvalidDateException
@@ -162,7 +164,7 @@ class Portugal extends AbstractProvider
      */
     private function calculatePortugueseRepublicDay(): void
     {
-        if ($this->year >= 1910) {
+        if ($this->year >= 1910 && $this->year <= 2012 || $this->year >= 2016) {
             $this->addHoliday(new Holiday(
                 'portugueseRepublic',
                 ['pt_PT' => 'Implantação da República Portuguesa'],

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -105,7 +105,7 @@ class Portugal extends AbstractProvider
      */
     private function calculateCorpusChristi(): void
     {
-        if ($this->year <= 2013 || $this->year >= 2016) {
+        if ($this->year <= 2012 || $this->year >= 2016) {
             $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
         }
     }
@@ -175,7 +175,7 @@ class Portugal extends AbstractProvider
     }
 
     /**
-     * In Portugal, between 2013 andd 2015 (inclusive) this holiday did not happen due to government deliberation.
+     * In Portugal, between 2013 and 2015 (inclusive) this holiday did not happen due to government deliberation.
      * It was restored in 2016.
      *
      * @throws \Yasumi\Exception\InvalidDateException
@@ -185,7 +185,7 @@ class Portugal extends AbstractProvider
      */
     private function calculateAllSaintsDay(): void
     {
-        if ($this->year <= 2013 || $this->year >= 2016) {
+        if ($this->year <= 2012 || $this->year >= 2016) {
             $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
         }
     }
@@ -207,6 +207,8 @@ class Portugal extends AbstractProvider
      * and elsewhere, as the Acclamation War. The war established the House of Braganza as Portugal's new ruling
      * dynasty, replacing the House of Habsburg. This ended the so-called Iberian Union.
      *
+     * The holiday was revoked in 2013 due to government deliberation. It was restored in 2016.
+     *
      * @link https://pt.wikipedia.org/wiki/Restauração_da_Independência (portuguese link)
      * @link https://pt.wikipedia.org/wiki/Guerra_da_Restauração (english link)
      *
@@ -218,7 +220,7 @@ class Portugal extends AbstractProvider
     private function calculateRestorationOfIndependenceDay(): void
     {
         // The Wikipedia article mentions that this has been a holiday since the second of half of the XIX century.
-        if (($this->year >= 1850 && $this->year <= 2013) || $this->year >= 2016) {
+        if (($this->year >= 1850 && $this->year <= 2012) || $this->year >= 2016) {
             $this->addHoliday(new Holiday(
                 'restorationOfIndependence',
                 ['pt_PT' => 'Restauração da Independência'],

--- a/tests/Portugal/AllSaintsDayTest.php
+++ b/tests/Portugal/AllSaintsDayTest.php
@@ -28,9 +28,9 @@ class AllSaintsDayTest extends PortugalBaseTestCase implements YasumiTestCaseInt
     public const HOLIDAY = 'allSaintsDay';
 
     /**
-     * Holiday was abolished by the portuguese government in 2014.
+     * Holiday was abolished by the portuguese government in 2013.
      */
-    public const HOLIDAY_YEAR_ABOLISHED = 2014;
+    public const HOLIDAY_YEAR_ABOLISHED = 2013;
 
     /**
      * Holiday was restored by the portuguese government in 2016.
@@ -50,18 +50,18 @@ class AllSaintsDayTest extends PortugalBaseTestCase implements YasumiTestCaseInt
         $expected = new DateTime("$year-11-01", new DateTimeZone(self::TIMEZONE));
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
 
-        $year     = 2013;
+        $year     = 2012;
         $expected = new DateTime("$year-11-01", new DateTimeZone(self::TIMEZONE));
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
     }
 
     /**
-     * Test that the holiday did not happen in 2014 and 2015.
+     * Test that the holiday did not happen in 2013-2015.
      * @throws \ReflectionException
      */
     public function testNotHoliday()
     {
-        $year = $this->generateRandomYear(2014, 2015);
+        $year = $this->generateRandomYear(2013, 2015);
         $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
     }
 

--- a/tests/Portugal/CorpusChristiTest.php
+++ b/tests/Portugal/CorpusChristiTest.php
@@ -30,7 +30,7 @@ class CorpusChristiTest extends PortugalBaseTestCase implements YasumiTestCaseIn
     /**
      * Holiday was abolished by the portuguese government in 2014.
      */
-    public const HOLIDAY_YEAR_ABOLISHED = 2014;
+    public const HOLIDAY_YEAR_ABOLISHED = 2013;
 
     /**
      * Holiday was restored by the portuguese government in 2016.
@@ -50,12 +50,12 @@ class CorpusChristiTest extends PortugalBaseTestCase implements YasumiTestCaseIn
     }
 
     /**
-     * Test that the holiday did not happen in 2014 and 2015.
+     * Test that the holiday did not happen in 2013-2015.
      * @throws \ReflectionException
      */
     public function testNotHoliday()
     {
-        $year = $this->generateRandomYear(2014, 2015);
+        $year = $this->generateRandomYear(2013, 2015);
         $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
     }
 

--- a/tests/Portugal/PortugalTest.php
+++ b/tests/Portugal/PortugalTest.php
@@ -81,7 +81,7 @@ class PortugalTest extends PortugalBaseTestCase
     {
         $holidays = [];
 
-        if ($this->year <= 2013 || $this->year >= 2016) {
+        if ($this->year <= 2012 || $this->year >= 2016) {
             $holidays[] = 'corpusChristi';
         }
 

--- a/tests/Portugal/PortugueseRepublicDayTest.php
+++ b/tests/Portugal/PortugueseRepublicDayTest.php
@@ -28,9 +28,49 @@ class PortugueseRepublicDayTest extends PortugalBaseTestCase implements YasumiTe
     public const ESTABLISHMENT_YEAR = 1910;
 
     /**
+     * Holiday was abolished by the portuguese government in 2013.
+     */
+    public const HOLIDAY_YEAR_ABOLISHED = 2013;
+
+    /**
+     * Holiday was restored by the portuguese government in 2016.
+     */
+    public const HOLIDAY_YEAR_RESTORED = 2016;
+
+    /**
      * The name of the holiday to be tested
      */
     public const HOLIDAY = 'portugueseRepublic';
+
+    /**
+     * Test that the holiday if in effect in 2016 and later dates.
+     * @throws \ReflectionException
+     * @throws \Exception
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHolidayOnAfterRestoration()
+    {
+        $year = self::HOLIDAY_YEAR_RESTORED;
+
+        $expected = new DateTime("$year-10-05", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+
+        $year = $this->generateRandomYear(self::HOLIDAY_YEAR_RESTORED);
+
+        $expected = new DateTime("$year-10-05", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Test that the holiday did not happen in 2013-2015.
+     * @throws \ReflectionException
+     */
+    public function testNotHolidayDuringAbolishment()
+    {
+        $year = $this->generateRandomYear(2013, 2015);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
+    }
 
     /**
      * Tests the holiday defined in this test on or after establishment.

--- a/tests/Portugal/RestorationOfIndependenceTest.php
+++ b/tests/Portugal/RestorationOfIndependenceTest.php
@@ -28,9 +28,9 @@ class RestorationOfIndependenceTest extends PortugalBaseTestCase implements Yasu
     public const ESTABLISHMENT_YEAR = 1850;
 
     /**
-     * Holiday was abolished by the portuguese government in 2014.
+     * Holiday was abolished by the portuguese government in 2013.
      */
-    public const HOLIDAY_YEAR_ABOLISHED = 2014;
+    public const HOLIDAY_YEAR_ABOLISHED = 2013;
 
     /**
      * Holiday was restored by the portuguese government in 2016.
@@ -56,7 +56,7 @@ class RestorationOfIndependenceTest extends PortugalBaseTestCase implements Yasu
         $expected = new DateTime("$year-12-01", new DateTimeZone(self::TIMEZONE));
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
 
-        $year     = 1850;
+        $year     = self::ESTABLISHMENT_YEAR;
         $expected = new DateTime("$year-12-01", new DateTimeZone(self::TIMEZONE));
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
     }
@@ -82,12 +82,12 @@ class RestorationOfIndependenceTest extends PortugalBaseTestCase implements Yasu
     }
 
     /**
-     * Test that the holiday did not happen in 2014 and 2015.
+     * Test that the holiday did not happen in 2013-2015.
      * @throws \ReflectionException
      */
     public function testNotHolidayDuringAbolishment()
     {
-        $year = $this->generateRandomYear(2014, 2015);
+        $year = $this->generateRandomYear(2013, 2015);
         $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
     }
 


### PR DESCRIPTION
According to Wikipedia, four holidays were cancelled in three years; 2013, 2014 and 2015. Yasumi currently reports only 2014 and 2015.

Also, Portuguese Republic Day was also among the holidays. This is not currently supported by Yasumi.

From https://en.wikipedia.org/wiki/Public_holidays_in_Portugal#Revoked_holidays_in_2013–2015:
> In 2012, the Coalition government of Pedro Passos Coelho controversially revoked four holidays — two civilian holidays (Republic Day and Restoration of Independence) and two religious ones (Corpus Christi and All Saints Day). The move was effective from 2013 onwards [...] The four holidays were eventually restored by the government of António Costa, in January 2016.