### PR TITLE
Add AFL Grand Final Day 2019

### DIFF
--- a/src/Yasumi/Provider/Australia/Victoria.php
+++ b/src/Yasumi/Provider/Australia/Victoria.php
@@ -95,6 +95,9 @@ class Victoria extends Australia
             case 2018:
                 $aflGrandFinalFriday = '2018-09-28';
                 break;
+            case 2019:
+                $aflGrandFinalFriday = '2018-09-27';
+                break;
             default:
                 return;
         }


### PR DESCRIPTION
https://publicholidays.com.au/afl-grand-final-holiday/