### PR TITLE
Add England, Wales, Scotland, Northern Ireland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Added additional code style fixers and aligning StyleCI settings with PHP-CS.
 - Included extra requirement for some PHP Extensions in the composer file.
 - Holiday providers for England, Wales, Scotland and Northern Ireland [\#165](https://github.com/azuyalabs/yasumi/pull/165) ([c960657](https://github.com/c960657))
+- Holiday providers for England, Wales, Scotland and Northern Ireland [\#166](https://github.com/azuyalabs/yasumi/pull/166) ([c960657](https://github.com/c960657))
 
 ### Changed
 - Updated the translation for the All Saints holiday for the 'fr_FR' locale [\#152](https://github.com/azuyalabs/yasumi/pull/152) ([pioc92](https://github.com/pioc92))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Observance holidays for Sweden [\#172](https://github.com/azuyalabs/yasumi/pull/172) ([c960657](https://github.com/c960657))
 - Added additional code style fixers and aligning StyleCI settings with PHP-CS.
 - Included extra requirement for some PHP Extensions in the composer file.
+- Holiday providers for England, Wales, Scotland and Northern Ireland [\#165](https://github.com/azuyalabs/yasumi/pull/165) ([c960657](https://github.com/c960657))
 
 ### Changed
 - Updated the translation for the All Saints holiday for the 'fr_FR' locale [\#152](https://github.com/azuyalabs/yasumi/pull/152) ([pioc92](https://github.com/pioc92))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Observance holidays for Sweden [\#172](https://github.com/azuyalabs/yasumi/pull/172) ([c960657](https://github.com/c960657))
 - Added additional code style fixers and aligning StyleCI settings with PHP-CS.
 - Included extra requirement for some PHP Extensions in the composer file.
-- Holiday providers for England, Wales, Scotland and Northern Ireland [\#165](https://github.com/azuyalabs/yasumi/pull/165) ([c960657](https://github.com/c960657))
 - Holiday providers for England, Wales, Scotland and Northern Ireland [\#166](https://github.com/azuyalabs/yasumi/pull/166) ([c960657](https://github.com/c960657))
 
 ### Changed

--- a/src/Yasumi/Provider/Romania.php
+++ b/src/Yasumi/Provider/Romania.php
@@ -135,10 +135,12 @@ class Romania extends AbstractProvider
     private function calculateStAndrewDay(): void
     {
         if ($this->year >= 2012) {
-            $this->addHoliday(new Holiday('stAndrewDay', [
-                'en_US' => 'Saint Andrew\'s Day',
-                'ro_RO' => 'Sfântul Andrei'
-            ], new DateTime($this->year . '-11-30', new DateTimeZone($this->timezone)), $this->locale));
+            $this->addHoliday(new Holiday(
+                'stAndrewsDay',
+                [],
+                new DateTime($this->year . '-11-30', new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
         }
     }
 

--- a/src/Yasumi/Provider/UnitedKingdom.php
+++ b/src/Yasumi/Provider/UnitedKingdom.php
@@ -33,6 +33,8 @@ class UnitedKingdom extends AbstractProvider
      */
     public const ID = 'GB';
 
+    public $timezone = 'Europe/London';
+
     /**
      * Initialize holidays for the United Kingdom.
      *
@@ -43,8 +45,6 @@ class UnitedKingdom extends AbstractProvider
      */
     public function initialize(): void
     {
-        $this->timezone = 'Europe/London';
-
         // Add common holidays
         $this->calculateNewYearsDay();
         $this->calculateMayDayBankHoliday();
@@ -74,7 +74,7 @@ class UnitedKingdom extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNewYearsDay(): void
+    protected function calculateNewYearsDay(): void
     {
         // Before 1871 it was not an observed or statutory holiday
         if ($this->year < 1871) {
@@ -113,7 +113,7 @@ class UnitedKingdom extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateMayDayBankHoliday(): void
+    protected function calculateMayDayBankHoliday(): void
     {
         // From 1978, by Royal Proclamation annually
         if ($this->year < 1978) {
@@ -158,7 +158,7 @@ class UnitedKingdom extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSpringBankHoliday(): void
+    protected function calculateSpringBankHoliday(): void
     {
         // Statutory bank holiday from 1971, following a trial period from 1965 to 1970.
         if ($this->year < 1965) {
@@ -204,7 +204,7 @@ class UnitedKingdom extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSummerBankHoliday(): void
+    protected function calculateSummerBankHoliday(): void
     {
         if ($this->year < 1871) {
             return;
@@ -268,12 +268,12 @@ class UnitedKingdom extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateChristmasHolidays(): void
+    protected function calculateChristmasHolidays($type = Holiday::TYPE_OFFICIAL): void
     {
         $christmasDay = new DateTime("$this->year-12-25", new DateTimeZone($this->timezone));
         $boxingDay = new DateTime("$this->year-12-26", new DateTimeZone($this->timezone));
 
-        $this->addHoliday(new Holiday('christmasDay', [], $christmasDay, $this->locale));
+        $this->addHoliday(new Holiday('christmasDay', [], $christmasDay, $this->locale, $type));
         $this->addHoliday(new Holiday('secondChristmasDay', [], $boxingDay, $this->locale, Holiday::TYPE_BANK));
 
         $substituteChristmasDay = clone $christmasDay;

--- a/src/Yasumi/Provider/UnitedKingdom/England.php
+++ b/src/Yasumi/Provider/UnitedKingdom/England.php
@@ -12,8 +12,6 @@
 
 namespace Yasumi\Provider\UnitedKingdom;
 
-use DateTime;
-use DateTimeZone;
 use Yasumi\Holiday;
 use Yasumi\Provider\UnitedKingdom;
 

--- a/src/Yasumi/Provider/UnitedKingdom/England.php
+++ b/src/Yasumi/Provider/UnitedKingdom/England.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\Provider\UnitedKingdom;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\UnitedKingdom;
+
+/**
+ * Provider for all holidays in England (United Kingdom).
+ *
+ * England is a country that is part of the United Kingdom. It covers an area of 130,279 square kilometres
+ * (50,301 sq mi), and has a population of 5,619,400. London, England's capital, is also the capital of
+ * and the largest city in the United Kingdom.
+ *
+ * @link https://en.wikipedia.org/wiki/England
+ */
+class England extends UnitedKingdom
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    public const ID = 'GB-ENG';
+}

--- a/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
@@ -15,8 +15,8 @@ namespace Yasumi\Provider\UnitedKingdom;
 use DateTime;
 use DateTimeZone;
 use Yasumi\Holiday;
-use Yasumi\SubstituteHoliday;
 use Yasumi\Provider\UnitedKingdom;
+use Yasumi\SubstituteHoliday;
 
 /**
  * Provider for all holidays in Northern Ireland (United Kingdom).

--- a/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\Provider\UnitedKingdom;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\UnitedKingdom;
+
+/**
+ * Provider for all holidays in Northern Ireland (United Kingdom).
+ *
+ * Northern Ireland is a country that is part of the United Kingdom. It covers an area of 14,130 square kilometres
+ * (5,460 sq mi), and has a population of 1,885,400. Belfast, Northern Ireland's capital and largest city,
+ * is the 12th largest city in the United Kingdom.
+ *
+ * @link https://en.wikipedia.org/wiki/Northern_Ireland
+ */
+class NorthernIreland extends UnitedKingdom
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    public const ID = 'GB-NIR';
+
+    public $timezone = 'Europe/Belfast';
+
+    /**
+     * Initialize holidays for Northern Ireland (United Kingdom).
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize(): void
+    {
+        parent::initialize();
+
+        $this->calculateStPatricksDay();
+        $this->calculateBattleOfTheBoyne();
+    }
+
+    /**
+     * St. Patrick's Day.
+     *
+     * Saint Patrick's Day, or the Feast of Saint Patrick (Irish: Lá Fhéile Pádraig, "the Day of the Festival of
+     * Patrick"), is a cultural and religious celebration held on 17 March, the traditional death date of Saint Patrick
+     * (c. AD 385–461), the foremost patron saint of Ireland. Saint Patrick's Day is a public holiday in the Republic
+     * of Ireland, Northern Ireland, the Canadian province of Newfoundland and Labrador, and the British Overseas
+     * Territory of Montserrat.
+     *
+     * @link https://en.wikipedia.org/wiki/Saint_Patrick%27s_Day
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     * @throws \Exception
+     */
+    private function calculateStPatricksDay(): void
+    {
+        $holiday = new Holiday(
+            'stPatricksDay',
+            ['en_GB' => 'St. Patrick\'s Day'],
+            new DateTime($this->year . '-3-17', new DateTimeZone($this->timezone)),
+            $this->locale,
+            Holiday::TYPE_BANK
+        );
+
+        $this->addHoliday($holiday);
+
+        // Substitute holiday is on the next available weekday if a holiday falls on a Saturday or Sunday
+        if (\in_array((int)$holiday->format('w'), [0, 6], true)) {
+            $substituteHoliday = clone $holiday;
+            $substituteHoliday->modify('next monday');
+
+            $this->addHoliday(new Holiday(
+                'substituteHoliday:' . $substituteHoliday->shortName,
+                ['en_GB' => $substituteHoliday->getName() . ' (substitute day)'],
+                $substituteHoliday,
+                $this->locale,
+                Holiday::TYPE_BANK));
+        }
+    }
+
+    /**
+     * Battle of the Boyne.
+     *
+     * Orangemen's Day, also called The Twelfth or Glorious Twelfth) celebrates the Glorious Revolution (1688)
+     * and victory of Protestant King William of Orange over Catholic king James II at the Battle of the
+     * Boyne (1690), which began the Protestant Ascendancy in Ireland.
+     *
+     * @link https://en.wikipedia.org/wiki/The_Twelfth
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     * @throws \Exception
+     */
+    private function calculateBattleOfTheBoyne(): void
+    {
+        $holiday = new Holiday(
+            'battleOfTheBoyne',
+            ['en_GB' => 'Battle of the Boyne'],
+            new DateTime($this->year . '-7-12', new DateTimeZone($this->timezone)),
+            $this->locale,
+            Holiday::TYPE_BANK
+        );
+
+        $this->addHoliday($holiday);
+
+        // Substitute holiday is on the next available weekday if a holiday falls on a Saturday or Sunday
+        if (\in_array((int)$holiday->format('w'), [0, 6], true)) {
+            $substituteHoliday = clone $holiday;
+            $substituteHoliday->modify('next monday');
+
+            $this->addHoliday(new Holiday(
+                'substituteHoliday:' . $substituteHoliday->shortName,
+                ['en_GB' => $substituteHoliday->getName() . ' (substitute day)'],
+                $substituteHoliday,
+                $this->locale,
+                Holiday::TYPE_BANK
+            ));
+        }
+    }
+}

--- a/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
@@ -15,6 +15,7 @@ namespace Yasumi\Provider\UnitedKingdom;
 use DateTime;
 use DateTimeZone;
 use Yasumi\Holiday;
+use Yasumi\SubstituteHoliday;
 use Yasumi\Provider\UnitedKingdom;
 
 /**
@@ -87,13 +88,13 @@ class NorthernIreland extends UnitedKingdom
 
         // Substitute holiday is on the next available weekday if a holiday falls on a Saturday or Sunday
         if (\in_array((int)$holiday->format('w'), [0, 6], true)) {
-            $substituteHoliday = clone $holiday;
-            $substituteHoliday->modify('next monday');
+            $date = clone $holiday;
+            $date->modify('next monday');
 
-            $this->addHoliday(new Holiday(
-                'substituteHoliday:' . $substituteHoliday->shortName,
-                ['en_GB' => $substituteHoliday->getName() . ' (substitute day)'],
-                $substituteHoliday,
+            $this->addHoliday(new SubstituteHoliday(
+                $holiday,
+                [],
+                $date,
                 $this->locale,
                 Holiday::TYPE_BANK
             ));
@@ -133,13 +134,13 @@ class NorthernIreland extends UnitedKingdom
 
         // Substitute holiday is on the next available weekday if a holiday falls on a Saturday or Sunday
         if (\in_array((int)$holiday->format('w'), [0, 6], true)) {
-            $substituteHoliday = clone $holiday;
-            $substituteHoliday->modify('next monday');
+            $date = clone $holiday;
+            $date->modify('next monday');
 
-            $this->addHoliday(new Holiday(
-                'substituteHoliday:' . $substituteHoliday->shortName,
-                ['en_GB' => $substituteHoliday->getName() . ' (substitute day)'],
-                $substituteHoliday,
+            $this->addHoliday(new SubstituteHoliday(
+                $holiday,
+                [],
+                $date,
                 $this->locale,
                 Holiday::TYPE_BANK
             ));

--- a/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
@@ -71,6 +71,10 @@ class NorthernIreland extends UnitedKingdom
      */
     private function calculateStPatricksDay(): void
     {
+        if ($this->year < 1971) {
+            return;
+        }
+
         $holiday = new Holiday(
             'stPatricksDay',
             ['en_GB' => 'St. Patrick\'s Day'],
@@ -113,6 +117,10 @@ class NorthernIreland extends UnitedKingdom
      */
     private function calculateBattleOfTheBoyne(): void
     {
+        if ($this->year < 1926) {
+            return;
+        }
+
         $holiday = new Holiday(
             'battleOfTheBoyne',
             ['en_GB' => 'Battle of the Boyne'],

--- a/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
@@ -91,7 +91,8 @@ class NorthernIreland extends UnitedKingdom
                 ['en_GB' => $substituteHoliday->getName() . ' (substitute day)'],
                 $substituteHoliday,
                 $this->locale,
-                Holiday::TYPE_BANK));
+                Holiday::TYPE_BANK
+            ));
         }
     }
 

--- a/src/Yasumi/Provider/UnitedKingdom/Scotland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/Scotland.php
@@ -16,8 +16,8 @@ use DateInterval;
 use DateTime;
 use DateTimeZone;
 use Yasumi\Holiday;
-use Yasumi\SubstituteHoliday;
 use Yasumi\Provider\UnitedKingdom;
+use Yasumi\SubstituteHoliday;
 
 /**
  * Provider for all holidays in Scotland (United Kingdom).

--- a/src/Yasumi/Provider/UnitedKingdom/Scotland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/Scotland.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\Provider\UnitedKingdom;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\UnitedKingdom;
+
+/**
+ * Provider for all holidays in Scotland (United Kingdom).
+ *
+ * Scotland is a country that is part of the United Kingdom. It covers an area of 77,933 square kilometres
+ * (30,090 sq mi), and has a population of 5,424,800. The capital is Edinburgh. Glasgow, Scotland's
+ * largest city, is the fifth largest city in the United Kingdom.
+ *
+ * Bank and public holidays in Scotland are determined under the Banking and Financial Dealings Act 1971
+ * and the St Andrew's Day Bank Holiday (Scotland) Act 2007. Unlike the rest of United Kingdom, most bank
+ * holidays are not recognised as statutory public holidays in Scotland, as most public holidays are
+ * determined by local authorities across Scotland.
+ *
+ * @link https://en.wikipedia.org/wiki/Scotland
+ */
+class Scotland extends UnitedKingdom
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    public const ID = 'GB-SCT';
+
+    public $timezone = 'Europe/London';
+
+    /**
+     * Initialize holidays for the United Kingdom.
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize(): void
+    {
+        // Add common holidays
+        $this->calculateNewYearsHolidays();
+        $this->calculateMayDayBankHoliday();
+        $this->calculateSpringBankHoliday();
+        $this->calculateSummerBankHoliday();
+
+        // Add common Christian holidays
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale, Holiday::TYPE_BANK));
+        $this->calculateStAndrewsDay();
+        $this->calculateChristmasHolidays(Holiday::TYPE_BANK);
+    }
+
+    /**
+     * New Year's Day is a public holiday in the United Kingdom on January 1 each year. It marks
+     * the start of the New Year in the Gregorian calendar. For many people have a quiet day on
+     * January 1, which marks the end of the Christmas break before they return to work.
+     *
+     * In Scotland, January 2 is also a bank holiday. If January 2 falls on a Saturday, the following Monday is a bank holiday.
+     * If New Years Day falls on a Saturday, the following Monday and Tuesday are bank holidays.
+     *
+     * @link https://en.wikipedia.org/wiki/Public_holidays_in_Scotland
+     * @link http://www.timeanddate.com/holidays/uk/new-year-day
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    protected function calculateNewYearsHolidays(): void
+    {
+        // Before 1871 it was not an observed or statutory holiday
+        if ($this->year < 1871) {
+            return;
+        }
+
+        if ($this->year <= 1974) {
+            $type = Holiday::TYPE_OBSERVANCE;
+        } else {
+            $type = Holiday::TYPE_BANK;
+        }
+
+        $christmasDay = new DateTime("$this->year-1-1", new DateTimeZone($this->timezone));
+        $boxingDay    = new DateTime("$this->year-1-2", new DateTimeZone($this->timezone));
+
+        $this->addHoliday(new Holiday('newYearsDay', [], $christmasDay, $this->locale, $type));
+        $this->addHoliday(new Holiday('secondNewYearsDay', [], $boxingDay, $this->locale, $type));
+
+        $substituteChristmasDay = clone $christmasDay;
+        $substituteBoxingDay    = clone $boxingDay;
+
+        if (\in_array((int)$christmasDay->format('w'), [0, 6], true)) {
+            $substituteChristmasDay->add(new DateInterval('P2D'));
+            $this->addHoliday(new Holiday(
+                'substituteHoliday:newYearsDay',
+                [],
+                $substituteChristmasDay,
+                $this->locale,
+                $type
+            ));
+        }
+
+        if (\in_array((int)$boxingDay->format('w'), [0, 6], true)) {
+            $substituteBoxingDay->add(new DateInterval('P2D'));
+            $this->addHoliday(new Holiday(
+                'substituteHoliday:secondNewYearsDay',
+                [],
+                $substituteBoxingDay,
+                $this->locale,
+                $type
+            ));
+        }
+    }
+
+    /**
+     * The Summer Bank holiday, also known as the Late Summer bank holiday, is a time for people in the United Kingdom
+     * to have a day off work or school. In Scotland it falls on the first Monday of August.
+     *
+     * @link https://www.timeanddate.com/holidays/uk/summer-bank-holiday
+     * @link https://en.wikipedia.org/wiki/Public_holidays_in_Scotland
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     */
+    protected function calculateSummerBankHoliday(): void
+    {
+        if ($this->year < 1871) {
+            return;
+        }
+
+        $this->addHoliday(new Holiday(
+            'summerBankHoliday',
+            ['en_GB' => 'August Bank Holiday'],
+            new DateTime("first monday of august $this->year", new DateTimeZone($this->timezone)),
+            $this->locale,
+            Holiday::TYPE_BANK
+        ));
+    }
+
+    /**
+     * St. Andrew's Day.
+     *
+     * Saint Andrew's Day is Scotland's national day, celebrated on 30 November.
+     *
+     * @link https://en.wikipedia.org/wiki/Saint_Andrew%27s_Day
+     *
+     * @throws \Yasumi\Exception\InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws \Yasumi\Exception\UnknownLocaleException
+     * @throws \Exception
+     * @throws \Exception
+     */
+    private function calculateStAndrewsDay(): void
+    {
+        if ($this->year < 2007) {
+            return;
+        }
+        $holiday = new Holiday(
+            'stAndrewsDay',
+            [],
+            new DateTime($this->year . '-11-30', new DateTimeZone($this->timezone)),
+            $this->locale,
+            Holiday::TYPE_BANK
+        );
+
+        $this->addHoliday($holiday);
+
+        // Substitute holiday is on the next available weekday if a holiday falls on a Saturday or Sunday
+        if (\in_array((int)$holiday->format('w'), [0, 6], true)) {
+            $substituteHoliday = clone $holiday;
+            $substituteHoliday->modify('next monday');
+
+            $this->addHoliday(new Holiday(
+                'substituteHoliday:' . $substituteHoliday->shortName,
+                ['en_GB' => $substituteHoliday->getName() . ' (substitute day)'],
+                $substituteHoliday,
+                $this->locale,
+                Holiday::TYPE_BANK
+            ));
+        }
+    }
+}

--- a/src/Yasumi/Provider/UnitedKingdom/Wales.php
+++ b/src/Yasumi/Provider/UnitedKingdom/Wales.php
@@ -22,7 +22,7 @@ use Yasumi\Provider\UnitedKingdom;
  * (8,023 sq mi), and has a population of 3,125,000. Cardiff, Wales's capital and largest city, is the
  * eleventh largest city in the United Kingdom.
  *
- * @link https://en.wikipedia.org/wiki/England
+ * @link https://en.wikipedia.org/wiki/Wales
  */
 class Wales extends UnitedKingdom
 {

--- a/src/Yasumi/Provider/UnitedKingdom/Wales.php
+++ b/src/Yasumi/Provider/UnitedKingdom/Wales.php
@@ -12,8 +12,6 @@
 
 namespace Yasumi\Provider\UnitedKingdom;
 
-use DateTime;
-use DateTimeZone;
 use Yasumi\Holiday;
 use Yasumi\Provider\UnitedKingdom;
 

--- a/src/Yasumi/Provider/UnitedKingdom/Wales.php
+++ b/src/Yasumi/Provider/UnitedKingdom/Wales.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\Provider\UnitedKingdom;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\Provider\UnitedKingdom;
+
+/**
+ * Provider for all holidays in Wales (United Kingdom).
+ *
+ * Wales is a country that is part of the United Kingdom. It covers an area of 20,779 square kilometres
+ * (8,023 sq mi), and has a population of 3,125,000. Cardiff, Wales's capital and largest city, is the
+ * eleventh largest city in the United Kingdom.
+ *
+ * @link https://en.wikipedia.org/wiki/England
+ */
+class Wales extends UnitedKingdom
+{
+    /**
+     * Code to identify this Holiday Provider. Typically this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    public const ID = 'GB-WLS';
+}

--- a/src/Yasumi/data/translations/secondNewYearsDay.php
+++ b/src/Yasumi/data/translations/secondNewYearsDay.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+// Translations for New Year's Day
+return [
+    'da_DK' => '2. nytårsdag',
+    'en_GB' => '2nd January',
+];

--- a/src/Yasumi/data/translations/stAndrewsDay.php
+++ b/src/Yasumi/data/translations/stAndrewsDay.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+// Translations for St. Andrew's Day
+return [
+    'en_US' => 'St. Andrew\'s Day',
+    'en_GB' => 'St. Andrew\'s Day',
+    'ro_RO' => 'Sfântul Andrei',
+];

--- a/tests/Romania/RomaniaTest.php
+++ b/tests/Romania/RomaniaTest.php
@@ -43,7 +43,7 @@ class RomaniaTest extends RomaniaBaseTestCase
             'pentecost',
             'pentecostMonday',
             'assumptionOfMary',
-            'stAndrewDay',
+            'stAndrewsDay',
             'nationalDay',
             'christmasDay',
             'secondChristmasDay'

--- a/tests/Romania/StAndrewsDayTest.php
+++ b/tests/Romania/StAndrewsDayTest.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\Romania;
+
+use DateTime;
+use DateTimeZone;
+use Exception;
+use ReflectionException;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Saint Andrew Day in Romania.
+ */
+class StAndrewsDayTest extends RomaniaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'stAndrewsDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 2012;
+
+    /**
+     * Tests Saint Andrew Day on or after 2012.
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function testStAndrewDayOnAfter2012()
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-11-30", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests Saint Andrew before 2012.
+     * @throws ReflectionException
+     */
+    public function testStAndrewDayBefore2012()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Sfântul Andrei']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/UnitedKingdom/England/BoxingDayTest.php
+++ b/tests/UnitedKingdom/England/BoxingDayTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\England;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Boxing Day in England.
+ */
+class BoxingDayTest extends EnglandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'secondChristmasDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->add(new DateInterval('P2D'));
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
+        }
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year = $this->generateRandomYear();
+            $date = new DateTime("$year-12-26", new DateTimeZone(self::TIMEZONE));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Boxing Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_BANK);
+    }
+}

--- a/tests/UnitedKingdom/England/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/England/ChristmasDayTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\England;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Christmas Day in England.
+ */
+class ChristmasDayTest extends EnglandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'christmasDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->add(new DateInterval('P2D'));
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
+        }
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year = $this->generateRandomYear();
+            $date = new DateTime("$year-12-25", new DateTimeZone(self::TIMEZONE));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Christmas Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/UnitedKingdom/England/EasterMondayTest.php
+++ b/tests/UnitedKingdom/England/EasterMondayTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\England;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Monday in England.
+ */
+class EasterMondayTest extends EnglandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'easterMonday';
+
+    /**
+     * Tests Easter Monday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, self::TIMEZONE);
+            $date->add(new DateInterval('P1D'));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Monday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_BANK);
+    }
+}

--- a/tests/UnitedKingdom/England/EnglandBaseTestCase.php
+++ b/tests/UnitedKingdom/England/EnglandBaseTestCase.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\England;
+
+use Yasumi\tests\UnitedKingdom\UnitedKingdomBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the England holiday provider.
+ */
+abstract class EnglandBaseTestCase extends UnitedKingdomBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public const REGION = 'UnitedKingdom\England';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public const TIMEZONE = 'Europe/London';
+
+    /**
+     * Locale that is considered common for this provider
+     */
+    public const LOCALE = 'en_GB';
+
+    /**
+     * Number of iterations to be used for the various unit tests of this provider
+     */
+    public const TEST_ITERATIONS = 50;
+}

--- a/tests/UnitedKingdom/England/EnglandTest.php
+++ b/tests/UnitedKingdom/England/EnglandTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\England;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in England.
+ */
+class EnglandTest extends EnglandBaseTestCase
+{
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in England are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testOfficialHolidays(): void
+    {
+        $this->assertDefinedHolidays([
+            'goodFriday',
+            'christmasDay',
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Tests if all observed holidays in England are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testObservedHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+    }
+
+    /**
+     * Tests if all seasonal holidays in England are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testSeasonalHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_SEASON);
+    }
+
+    /**
+     * Tests if all bank holidays in England are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testBankHolidays(): void
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'easterMonday',
+            'mayDayBankHoliday',
+            'springBankHoliday',
+            'secondChristmasDay'
+        ], self::REGION, $this->year, Holiday::TYPE_BANK);
+    }
+
+    /**
+     * Tests if all other holidays in England are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testOtherHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1978);
+    }
+}

--- a/tests/UnitedKingdom/England/EnglandTest.php
+++ b/tests/UnitedKingdom/England/EnglandTest.php
@@ -81,7 +81,7 @@ class EnglandTest extends EnglandBaseTestCase
     /**
      * Initial setup of this Test Case
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->year = $this->generateRandomYear(1978);
     }

--- a/tests/UnitedKingdom/England/GoodFridayTest.php
+++ b/tests/UnitedKingdom/England/GoodFridayTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\England;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class containing tests for Good Friday in England.
+ */
+class GoodFridayTest extends EnglandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'goodFriday';
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 1866;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-3-30", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Good Friday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/UnitedKingdom/England/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/MayDayBankHolidayTest.php
@@ -58,14 +58,14 @@ class MayDayBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
             self::REGION,
             self::HOLIDAY,
             1995,
-            new DateTime("1995-5-8", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1995-5-8', new DateTimeZone(self::TIMEZONE))
         );
 
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             2020,
-            new DateTime("2020-5-8", new DateTimeZone(self::TIMEZONE))
+            new DateTime('2020-5-8', new DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/UnitedKingdom/England/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/MayDayBankHolidayTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\England;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the May Day Bank Holiday in England.
+ */
+class MayDayBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'mayDayBankHoliday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1978;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 2101;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-5-2", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday exception in 1995 and 2020.
+     * @throws \ReflectionException
+     */
+    public function testHolidayExceptions()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1995,
+            new DateTime("1995-5-8", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2020,
+            new DateTime("2020-5-8", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'May Day Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/England/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/England/NewYearsDayTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\England;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing New Years Day in England.
+ */
+class NewYearsDayTest extends EnglandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1871;
+
+    /**
+     * The year in which the holiday was adjusted
+     */
+    public const ADJUSTMENT_YEAR = 1974;
+
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'newYearsDay';
+
+    /**
+     * Tests the holiday defined in this test on or after establishment.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHolidayOnAfterEstablishment($year, $expected)
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests that the holiday defined in this test is of the type 'observance' before the year it was changed.
+     * @throws \ReflectionException
+     */
+    public function testHolidayIsObservedTypeBeforeChange()
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ADJUSTMENT_YEAR - 1),
+            Holiday::TYPE_OBSERVANCE
+        );
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        return $this->generateRandomDatesWithHolidayMovedToMonday(01, 01, self::TIMEZONE, 10, self::ESTABLISHMENT_YEAR);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'New Year\'s Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ADJUSTMENT_YEAR + 1),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/England/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/SpringBankHolidayTest.php
@@ -58,14 +58,14 @@ class SpringBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
             self::REGION,
             self::HOLIDAY,
             2002,
-            new DateTime("2002-6-4", new DateTimeZone(self::TIMEZONE))
+            new DateTime('2002-6-4', new DateTimeZone(self::TIMEZONE))
         );
 
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             2012,
-            new DateTime("2012-6-4", new DateTimeZone(self::TIMEZONE))
+            new DateTime('2012-6-4', new DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/UnitedKingdom/England/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/SpringBankHolidayTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\England;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the Spring Bank Holiday in England.
+ */
+class SpringBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'springBankHoliday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1965;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 1988;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-5-30", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday exceptions in 2002 and 2012.
+     * @throws \ReflectionException
+     */
+    public function testHolidayException()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2002,
+            new DateTime("2002-6-4", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2012,
+            new DateTime("2012-6-4", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Spring Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/England/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/SummerBankHolidayTest.php
@@ -73,37 +73,37 @@ class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
             self::REGION,
             self::HOLIDAY,
             1965,
-            new DateTime("1965-8-30", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1965-8-30', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1966,
-            new DateTime("1966-8-29", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1966-8-29', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1967,
-            new DateTime("1967-8-28", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1967-8-28', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1968,
-            new DateTime("1968-9-2", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1968-9-2', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1969,
-            new DateTime("1969-9-1", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1969-9-1', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1970,
-            new DateTime("1970-8-31", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1970-8-31', new DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/UnitedKingdom/England/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/SummerBankHolidayTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * This file is part of the Yasumi package.
  *
@@ -10,19 +10,17 @@
  * @author Sacha Telgenhof <me@sachatelgenhof.com>
  */
 
-namespace Yasumi\tests\UnitedKingdom;
+namespace Yasumi\tests\UnitedKingdom\England;
 
 use DateTime;
 use DateTimeZone;
-use Exception;
-use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing the Summer Bank Holiday in the United Kingdom.
+ * Class for testing the Summer Bank Holiday England.
  */
-class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiTestCaseInterface
+class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday
@@ -35,14 +33,9 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
     public const ESTABLISHMENT_YEAR = 1871;
 
     /**
-     * The year in which the holiday was renamed from August Bank Holiday to Summer Bank Holiday.
-     */
-    public const RENAME_YEAR = 1965;
-
-    /**
      * Tests the holiday defined in this test.
-     * @throws Exception
-     * @throws ReflectionException
+     * @throws \Exception
+     * @throws \ReflectionException
      */
     public function testHoliday()
     {
@@ -57,8 +50,7 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the holiday exception in 2020.
-     * @throws ReflectionException
-     * @throws Exception
+     * @throws \ReflectionException
      */
     public function testHolidayBefore1965()
     {
@@ -73,13 +65,7 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the holiday during trial period in 1965-1970.
-     * @throws ReflectionException
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
+     * @throws \ReflectionException
      */
     public function testHolidayTrialPeriod()
     {
@@ -87,43 +73,43 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
             self::REGION,
             self::HOLIDAY,
             1965,
-            new DateTime('1965-8-30', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1965-8-30", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1966,
-            new DateTime('1966-8-29', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1966-8-29", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1967,
-            new DateTime('1967-8-28', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1967-8-28", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1968,
-            new DateTime('1968-9-2', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1968-9-2", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1969,
-            new DateTime('1969-9-1', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1969-9-1", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1970,
-            new DateTime('1970-8-31', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1970-8-31", new DateTimeZone(self::TIMEZONE))
         );
     }
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -136,21 +122,21 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testTranslation(): void
     {
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::RENAME_YEAR),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
             [self::LOCALE => 'Summer Bank Holiday']
         );
     }
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/BattleOfTheBoyneTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/BattleOfTheBoyneTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Batthe of the Boyne in Northern Ireland.
+ */
+class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'battleOfTheBoyne';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int       $year     the year for which the holiday defined in this test needs to be tested
+     * @param \DateTime $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->modify('next monday');
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+        }
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year   = $this->generateRandomYear();
+            $date   = new DateTime("$year-7-12", new DateTimeZone(self::TIMEZONE));
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     *
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Battle of the Boyne']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/BattleOfTheBoyneTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/BattleOfTheBoyneTest.php
@@ -96,7 +96,7 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Yasumi
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
             [self::LOCALE => 'Battle of the Boyne']
         );
     }
@@ -110,7 +110,7 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Yasumi
         $this->assertHolidayType(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
             Holiday::TYPE_BANK
         );
     }

--- a/tests/UnitedKingdom/NorthernIreland/BattleOfTheBoyneTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/BattleOfTheBoyneTest.php
@@ -28,6 +28,11 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Yasumi
     public const HOLIDAY = 'battleOfTheBoyne';
 
     /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1926;
+
+    /**
      * Tests the holiday defined in this test.
      *
      * @dataProvider HolidayDataProvider
@@ -50,6 +55,19 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Yasumi
     }
 
     /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
      * Returns a list of random test dates used for assertion of the holiday defined in this test
      *
      * @return array list of test dates for the holiday defined in this test
@@ -60,7 +78,7 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Yasumi
         $data = [];
 
         for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
-            $year   = $this->generateRandomYear();
+            $year   = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
             $date   = new DateTime("$year-7-12", new DateTimeZone(self::TIMEZONE));
             $data[] = [$year, $date->format('Y-m-d')];
         }

--- a/tests/UnitedKingdom/NorthernIreland/BoxingDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/BoxingDayTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Boxing Day in Northern Ireland.
+ */
+class BoxingDayTest extends NorthernIrelandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'secondChristmasDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->add(new DateInterval('P2D'));
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
+        }
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year = $this->generateRandomYear();
+            $date = new DateTime("$year-12-26", new DateTimeZone(self::TIMEZONE));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Boxing Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_BANK);
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/ChristmasDayTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Christmas Day in Northern Ireland.
+ */
+class ChristmasDayTest extends NorthernIrelandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'christmasDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->add(new DateInterval('P2D'));
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
+        }
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year = $this->generateRandomYear();
+            $date = new DateTime("$year-12-25", new DateTimeZone(self::TIMEZONE));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Christmas Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/EasterMondayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/EasterMondayTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Monday in Northern Ireland.
+ */
+class EasterMondayTest extends NorthernIrelandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'easterMonday';
+
+    /**
+     * Tests Easter Monday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, self::TIMEZONE);
+            $date->add(new DateInterval('P1D'));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Monday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_BANK);
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/GoodFridayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/GoodFridayTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class containing tests for Good Friday in Northern Ireland.
+ */
+class GoodFridayTest extends NorthernIrelandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'goodFriday';
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 1866;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-3-30", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Good Friday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/MayDayBankHolidayTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the May Day Bank Holiday in Northern Ireland.
+ */
+class MayDayBankHolidayTest extends NorthernIrelandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'mayDayBankHoliday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1978;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 2101;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-5-2", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday exception in 1995 and 2020.
+     * @throws \ReflectionException
+     */
+    public function testHolidayExceptions()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1995,
+            new DateTime("1995-5-8", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2020,
+            new DateTime("2020-5-8", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'May Day Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/MayDayBankHolidayTest.php
@@ -58,14 +58,14 @@ class MayDayBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
             self::REGION,
             self::HOLIDAY,
             1995,
-            new DateTime("1995-5-8", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1995-5-8', new DateTimeZone(self::TIMEZONE))
         );
 
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             2020,
-            new DateTime("2020-5-8", new DateTimeZone(self::TIMEZONE))
+            new DateTime('2020-5-8', new DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/UnitedKingdom/NorthernIreland/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/NewYearsDayTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing New Years Day in Northern Ireland.
+ */
+class NewYearsDayTest extends NorthernIrelandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1871;
+
+    /**
+     * The year in which the holiday was adjusted
+     */
+    public const ADJUSTMENT_YEAR = 1974;
+
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'newYearsDay';
+
+    /**
+     * Tests the holiday defined in this test on or after establishment.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHolidayOnAfterEstablishment($year, $expected)
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests that the holiday defined in this test is of the type 'observance' before the year it was changed.
+     * @throws \ReflectionException
+     */
+    public function testHolidayIsObservedTypeBeforeChange()
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ADJUSTMENT_YEAR - 1),
+            Holiday::TYPE_OBSERVANCE
+        );
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        return $this->generateRandomDatesWithHolidayMovedToMonday(01, 01, self::TIMEZONE, 10, self::ESTABLISHMENT_YEAR);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'New Year\'s Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ADJUSTMENT_YEAR + 1),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/NorthernIrelandBaseTestCase.php
+++ b/tests/UnitedKingdom/NorthernIreland/NorthernIrelandBaseTestCase.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use Yasumi\tests\UnitedKingdom\UnitedKingdomBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the Northern Ireland holiday provider.
+ */
+abstract class NorthernIrelandBaseTestCase extends UnitedKingdomBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public const REGION = 'UnitedKingdom\NorthernIreland';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public const TIMEZONE = 'Europe/Belfast';
+
+    /**
+     * Locale that is considered common for this provider
+     */
+    public const LOCALE = 'en_GB';
+
+    /**
+     * Number of iterations to be used for the various unit tests of this provider
+     */
+    public const TEST_ITERATIONS = 50;
+}

--- a/tests/UnitedKingdom/NorthernIreland/NorthernIrelandTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/NorthernIrelandTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in Northern Ireland.
+ */
+class NorthernIrelandTest extends NorthernIrelandBaseTestCase
+{
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in Northern Ireland are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testOfficialHolidays(): void
+    {
+        $this->assertDefinedHolidays([
+            'goodFriday',
+            'christmasDay',
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Tests if all observed holidays in Northern Ireland are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testObservedHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+    }
+
+    /**
+     * Tests if all seasonal holidays in Northern Ireland are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testSeasonalHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_SEASON);
+    }
+
+    /**
+     * Tests if all bank holidays in Northern Ireland are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testBankHolidays(): void
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'easterMonday',
+            'mayDayBankHoliday',
+            'springBankHoliday',
+            'battleOfTheBoyne',
+            'secondChristmasDay'
+        ], self::REGION, $this->year, Holiday::TYPE_BANK);
+    }
+
+    /**
+     * Tests if all other holidays in Northern Ireland are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testOtherHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1978);
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/NorthernIrelandTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/NorthernIrelandTest.php
@@ -82,7 +82,7 @@ class NorthernIrelandTest extends NorthernIrelandBaseTestCase
     /**
      * Initial setup of this Test Case
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->year = $this->generateRandomYear(1978);
     }

--- a/tests/UnitedKingdom/NorthernIreland/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/SpringBankHolidayTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the Spring Bank Holiday in Northern Ireland.
+ */
+class SpringBankHolidayTest extends NorthernIrelandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'springBankHoliday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1965;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 1988;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-5-30", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Spring Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/StPatricksDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/StPatricksDayTest.php
@@ -96,7 +96,7 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTes
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
             [self::LOCALE => 'St. Patrick\'s Day']
         );
     }
@@ -110,7 +110,7 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTes
         $this->assertHolidayType(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
             Holiday::TYPE_BANK
         );
     }

--- a/tests/UnitedKingdom/NorthernIreland/StPatricksDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/StPatricksDayTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing St. Patrick's Day in Northern Ireland.
+ */
+class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'stPatricksDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int       $year     the year for which the holiday defined in this test needs to be tested
+     * @param \DateTime $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->modify('next monday');
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+        }
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year   = $this->generateRandomYear();
+            $date   = new DateTime("$year-3-17", new DateTimeZone(self::TIMEZONE));
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     *
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'St. Patrick\'s Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/StPatricksDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/StPatricksDayTest.php
@@ -28,6 +28,11 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTes
     public const HOLIDAY = 'stPatricksDay';
 
     /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1971;
+
+    /**
      * Tests the holiday defined in this test.
      *
      * @dataProvider HolidayDataProvider
@@ -50,6 +55,19 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTes
     }
 
     /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
      * Returns a list of random test dates used for assertion of the holiday defined in this test
      *
      * @return array list of test dates for the holiday defined in this test
@@ -60,7 +78,7 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTes
         $data = [];
 
         for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
-            $year   = $this->generateRandomYear();
+            $year   = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
             $date   = new DateTime("$year-3-17", new DateTimeZone(self::TIMEZONE));
             $data[] = [$year, $date->format('Y-m-d')];
         }

--- a/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
@@ -73,37 +73,37 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
             self::REGION,
             self::HOLIDAY,
             1965,
-            new DateTime("1965-8-30", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1965-8-30', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1966,
-            new DateTime("1966-8-29", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1966-8-29', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1967,
-            new DateTime("1967-8-28", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1967-8-28', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1968,
-            new DateTime("1968-9-2", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1968-9-2', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1969,
-            new DateTime("1969-9-1", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1969-9-1', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1970,
-            new DateTime("1970-8-31", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1970-8-31', new DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * This file is part of the Yasumi package.
  *
@@ -10,19 +10,17 @@
  * @author Sacha Telgenhof <me@sachatelgenhof.com>
  */
 
-namespace Yasumi\tests\UnitedKingdom;
+namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 
 use DateTime;
 use DateTimeZone;
-use Exception;
-use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing the Summer Bank Holiday in the United Kingdom.
+ * Class for testing the Summer Bank Holiday in Northern Ireland.
  */
-class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiTestCaseInterface
+class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday
@@ -35,14 +33,9 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
     public const ESTABLISHMENT_YEAR = 1871;
 
     /**
-     * The year in which the holiday was renamed from August Bank Holiday to Summer Bank Holiday.
-     */
-    public const RENAME_YEAR = 1965;
-
-    /**
      * Tests the holiday defined in this test.
-     * @throws Exception
-     * @throws ReflectionException
+     * @throws \Exception
+     * @throws \ReflectionException
      */
     public function testHoliday()
     {
@@ -57,8 +50,7 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the holiday exception in 2020.
-     * @throws ReflectionException
-     * @throws Exception
+     * @throws \ReflectionException
      */
     public function testHolidayBefore1965()
     {
@@ -73,13 +65,7 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the holiday during trial period in 1965-1970.
-     * @throws ReflectionException
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
+     * @throws \ReflectionException
      */
     public function testHolidayTrialPeriod()
     {
@@ -87,43 +73,43 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
             self::REGION,
             self::HOLIDAY,
             1965,
-            new DateTime('1965-8-30', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1965-8-30", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1966,
-            new DateTime('1966-8-29', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1966-8-29", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1967,
-            new DateTime('1967-8-28', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1967-8-28", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1968,
-            new DateTime('1968-9-2', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1968-9-2", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1969,
-            new DateTime('1969-9-1', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1969-9-1", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1970,
-            new DateTime('1970-8-31', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1970-8-31", new DateTimeZone(self::TIMEZONE))
         );
     }
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -136,21 +122,21 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testTranslation(): void
     {
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::RENAME_YEAR),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
             [self::LOCALE => 'Summer Bank Holiday']
         );
     }
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Scotland/BoxingDayTest.php
+++ b/tests/UnitedKingdom/Scotland/BoxingDayTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Boxing Day in Scotland.
+ */
+class BoxingDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'secondChristmasDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->add(new DateInterval('P2D'));
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
+        }
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year = $this->generateRandomYear();
+            $date = new DateTime("$year-12-26", new DateTimeZone(self::TIMEZONE));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Boxing Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_BANK);
+    }
+}

--- a/tests/UnitedKingdom/Scotland/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/Scotland/ChristmasDayTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Christmas Day in Scotland.
+ */
+class ChristmasDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'christmasDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->add(new DateInterval('P2D'));
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
+        }
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year = $this->generateRandomYear();
+            $date = new DateTime("$year-12-25", new DateTimeZone(self::TIMEZONE));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Christmas Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_BANK);
+    }
+}

--- a/tests/UnitedKingdom/Scotland/GoodFridayTest.php
+++ b/tests/UnitedKingdom/Scotland/GoodFridayTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class containing tests for Good Friday in Scotland.
+ */
+class GoodFridayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'goodFriday';
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 1866;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-3-30", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Good Friday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_BANK);
+    }
+}

--- a/tests/UnitedKingdom/Scotland/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/Scotland/MayDayBankHolidayTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the May Day Bank Holiday in Scotland.
+ */
+class MayDayBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'mayDayBankHoliday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1978;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 2101;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-5-2", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday exception in 1995 and 2020.
+     * @throws \ReflectionException
+     */
+    public function testHolidayExceptions()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1995,
+            new DateTime("1995-5-8", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2020,
+            new DateTime("2020-5-8", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'May Day Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/Scotland/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/Scotland/MayDayBankHolidayTest.php
@@ -58,14 +58,14 @@ class MayDayBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
             self::REGION,
             self::HOLIDAY,
             1995,
-            new DateTime("1995-5-8", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1995-5-8', new DateTimeZone(self::TIMEZONE))
         );
 
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             2020,
-            new DateTime("2020-5-8", new DateTimeZone(self::TIMEZONE))
+            new DateTime('2020-5-8', new DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/UnitedKingdom/Scotland/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/Scotland/NewYearsDayTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing New Years Day in Scotland.
+ */
+class NewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1871;
+
+    /**
+     * The year in which the holiday was adjusted
+     */
+    public const ADJUSTMENT_YEAR = 1974;
+
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'newYearsDay';
+
+    /**
+     * Tests the holiday defined in this test on or after establishment.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHolidayOnAfterEstablishment($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->add(new DateInterval('P2D'));
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+        }
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests that the holiday defined in this test is of the type 'observance' before the year it was changed.
+     * @throws \ReflectionException
+     */
+    public function testHolidayIsObservedTypeBeforeChange()
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ADJUSTMENT_YEAR - 1),
+            Holiday::TYPE_OBSERVANCE
+        );
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year   = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+            $date   = new DateTime("$year-1-1", new DateTimeZone(self::TIMEZONE));
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'New Year\'s Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ADJUSTMENT_YEAR + 1),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/Scotland/ScotlandBaseTestCase.php
+++ b/tests/UnitedKingdom/Scotland/ScotlandBaseTestCase.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use Yasumi\tests\UnitedKingdom\UnitedKingdomBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the Scotland holiday provider.
+ */
+abstract class ScotlandBaseTestCase extends UnitedKingdomBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public const REGION = 'UnitedKingdom\Scotland';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public const TIMEZONE = 'Europe/London';
+
+    /**
+     * Locale that is considered common for this provider
+     */
+    public const LOCALE = 'en_GB';
+
+    /**
+     * Number of iterations to be used for the various unit tests of this provider
+     */
+    public const TEST_ITERATIONS = 50;
+}

--- a/tests/UnitedKingdom/Scotland/ScotlandTest.php
+++ b/tests/UnitedKingdom/Scotland/ScotlandTest.php
@@ -80,7 +80,7 @@ class ScotlandTest extends ScotlandBaseTestCase
     /**
      * Initial setup of this Test Case
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->year = $this->generateRandomYear(1978);
     }

--- a/tests/UnitedKingdom/Scotland/ScotlandTest.php
+++ b/tests/UnitedKingdom/Scotland/ScotlandTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in Scotland.
+ */
+class ScotlandTest extends ScotlandBaseTestCase
+{
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in Scotland are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testOfficialHolidays(): void
+    {
+        $this->assertDefinedHolidays([
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Tests if all observed holidays in Scotland are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testObservedHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+    }
+
+    /**
+     * Tests if all seasonal holidays in Scotland are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testSeasonalHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_SEASON);
+    }
+
+    /**
+     * Tests if all bank holidays in Scotland are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testBankHolidays(): void
+    {
+        $this->assertDefinedHolidays([
+            'goodFriday',
+            'mayDayBankHoliday',
+            'springBankHoliday',
+            'christmasDay',
+            'secondChristmasDay',
+            'newYearsDay',
+        ], self::REGION, $this->year, Holiday::TYPE_BANK);
+    }
+
+    /**
+     * Tests if all other holidays in Scotland are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testOtherHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1978);
+    }
+}

--- a/tests/UnitedKingdom/Scotland/SecondNewYearsDayTest.php
+++ b/tests/UnitedKingdom/Scotland/SecondNewYearsDayTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing New Years Day in Scotland.
+ */
+class SecondNewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1871;
+
+    /**
+     * The year in which the holiday was adjusted
+     */
+    public const ADJUSTMENT_YEAR = 1974;
+
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'secondNewYearsDay';
+
+    /**
+     * Tests the holiday defined in this test on or after establishment.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHolidayOnAfterEstablishment($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->add(new DateInterval('P2D'));
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+        }
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests that the holiday defined in this test is of the type 'observance' before the year it was changed.
+     * @throws \ReflectionException
+     */
+    public function testHolidayIsObservedTypeBeforeChange()
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ADJUSTMENT_YEAR - 1),
+            Holiday::TYPE_OBSERVANCE
+        );
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year   = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+            $date   = new DateTime("$year-1-2", new DateTimeZone(self::TIMEZONE));
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => '2nd January']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ADJUSTMENT_YEAR + 1),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/Scotland/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/Scotland/SpringBankHolidayTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the Spring Bank Holiday in Scotland.
+ */
+class SpringBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'springBankHoliday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1965;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 1988;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-5-30", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Spring Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/Scotland/StAndrewsDayTest.php
+++ b/tests/UnitedKingdom/Scotland/StAndrewsDayTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing St. Patrick's Day in Scotland.
+ */
+class StAndrewsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'stAndrewsDay';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 2007;
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int       $year     the year for which the holiday defined in this test needs to be tested
+     * @param \DateTime $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->modify('next monday');
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+        }
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year   = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+            $date   = new DateTime("$year-11-30", new DateTimeZone(self::TIMEZONE));
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     *
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'St. Andrew\'s Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/Scotland/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/Scotland/SummerBankHolidayTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Scotland;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the August Bank Holiday in Scotland.
+ */
+class SummerBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'summerBankHoliday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1871;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(1970);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("first monday of august $year", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'August Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/Wales/BoxingDayTest.php
+++ b/tests/UnitedKingdom/Wales/BoxingDayTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Wales;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Boxing Day in Wales.
+ */
+class BoxingDayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'secondChristmasDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->add(new DateInterval('P2D'));
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
+        }
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year = $this->generateRandomYear();
+            $date = new DateTime("$year-12-26", new DateTimeZone(self::TIMEZONE));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Boxing Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_BANK);
+    }
+}

--- a/tests/UnitedKingdom/Wales/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/Wales/ChristmasDayTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Wales;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Christmas Day in Wales.
+ */
+class ChristmasDayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'christmasDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $date = new DateTime($expected, new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
+
+        if (\in_array((int)$date->format('w'), [0, 6], true)) {
+            $date->add(new DateInterval('P2D'));
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
+        }
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; $y++) {
+            $year = $this->generateRandomYear();
+            $date = new DateTime("$year-12-25", new DateTimeZone(self::TIMEZONE));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Christmas Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/UnitedKingdom/Wales/EasterMondayTest.php
+++ b/tests/UnitedKingdom/Wales/EasterMondayTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Wales;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Easter Monday in Wales.
+ */
+class EasterMondayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'easterMonday';
+
+    /**
+     * Tests Easter Monday
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Returns a list of test dates
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < 50; $y++) {
+            $year = $this->generateRandomYear();
+            $date = $this->calculateEaster($year, self::TIMEZONE);
+            $date->add(new DateInterval('P1D'));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Easter Monday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_BANK);
+    }
+}

--- a/tests/UnitedKingdom/Wales/GoodFridayTest.php
+++ b/tests/UnitedKingdom/Wales/GoodFridayTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Wales;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class containing tests for Good Friday in Wales.
+ */
+class GoodFridayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'goodFriday';
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 1866;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-3-30", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Good Friday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/UnitedKingdom/Wales/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/MayDayBankHolidayTest.php
@@ -58,14 +58,14 @@ class MayDayBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             1995,
-            new DateTime("1995-5-8", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1995-5-8', new DateTimeZone(self::TIMEZONE))
         );
 
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             2020,
-            new DateTime("2020-5-8", new DateTimeZone(self::TIMEZONE))
+            new DateTime('2020-5-8', new DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/UnitedKingdom/Wales/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/MayDayBankHolidayTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * This file is part of the Yasumi package.
  *
@@ -10,51 +10,70 @@
  * @author Sacha Telgenhof <me@sachatelgenhof.com>
  */
 
-namespace Yasumi\tests\Romania;
+namespace Yasumi\tests\UnitedKingdom\Wales;
 
 use DateTime;
 use DateTimeZone;
-use Exception;
-use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing Saint Andrew Day in Romania.
+ * Class for testing the May Day Bank Holiday in Wales.
  */
-class StAndrewDayTest extends RomaniaBaseTestCase implements YasumiTestCaseInterface
+class MayDayBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
 {
     /**
-     * The name of the holiday to be tested
+     * The name of the holiday
      */
-    public const HOLIDAY = 'stAndrewDay';
+    public const HOLIDAY = 'mayDayBankHoliday';
 
     /**
      * The year in which the holiday was first established
      */
-    public const ESTABLISHMENT_YEAR = 2012;
+    public const ESTABLISHMENT_YEAR = 1978;
 
     /**
-     * Tests Saint Andrew Day on or after 2012.
-     * @throws Exception
-     * @throws ReflectionException
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
      */
-    public function testStAndrewDayOnAfter2012()
+    public function testHoliday()
     {
-        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $year = 2101;
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
-            new DateTime("$year-11-30", new DateTimeZone(self::TIMEZONE))
+            new DateTime("$year-5-2", new DateTimeZone(self::TIMEZONE))
         );
     }
 
     /**
-     * Tests Saint Andrew before 2012.
-     * @throws ReflectionException
+     * Tests the holiday exception in 1995 and 2020.
+     * @throws \ReflectionException
      */
-    public function testStAndrewDayBefore2012()
+    public function testHolidayExceptions()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1995,
+            new DateTime("1995-5-8", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2020,
+            new DateTime("2020-5-8", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
     {
         $this->assertNotHoliday(
             self::REGION,
@@ -65,7 +84,7 @@ class StAndrewDayTest extends RomaniaBaseTestCase implements YasumiTestCaseInter
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testTranslation(): void
     {
@@ -73,13 +92,13 @@ class StAndrewDayTest extends RomaniaBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            [self::LOCALE => 'Sfântul Andrei']
+            [self::LOCALE => 'May Day Bank Holiday']
         );
     }
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testHolidayType(): void
     {
@@ -87,7 +106,7 @@ class StAndrewDayTest extends RomaniaBaseTestCase implements YasumiTestCaseInter
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_OFFICIAL
+            Holiday::TYPE_BANK
         );
     }
 }

--- a/tests/UnitedKingdom/Wales/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/Wales/NewYearsDayTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Wales;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing New Years Day in Wales.
+ */
+class NewYearsDayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1871;
+
+    /**
+     * The year in which the holiday was adjusted
+     */
+    public const ADJUSTMENT_YEAR = 1974;
+
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'newYearsDay';
+
+    /**
+     * Tests the holiday defined in this test on or after establishment.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testHolidayOnAfterEstablishment($year, $expected)
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expected, new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests that the holiday defined in this test is of the type 'observance' before the year it was changed.
+     * @throws \ReflectionException
+     */
+    public function testHolidayIsObservedTypeBeforeChange()
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ADJUSTMENT_YEAR - 1),
+            Holiday::TYPE_OBSERVANCE
+        );
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        return $this->generateRandomDatesWithHolidayMovedToMonday(01, 01, self::TIMEZONE, 10, self::ESTABLISHMENT_YEAR);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'New Year\'s Day']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ADJUSTMENT_YEAR + 1),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/Wales/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/SpringBankHolidayTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Wales;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the Spring Bank Holiday in Wales.
+ */
+class SpringBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday
+     */
+    public const HOLIDAY = 'springBankHoliday';
+
+    /**
+     * The year in which the holiday was first established
+     */
+    public const ESTABLISHMENT_YEAR = 1965;
+
+    /**
+     * Tests the holiday defined in this test.
+     * @throws \Exception
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = 1988;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-5-30", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday exceptions in 2002 and 2012.
+     * @throws \ReflectionException
+     */
+    public function testHolidayException()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2002,
+            new DateTime("2002-6-4", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2012,
+            new DateTime("2012-6-4", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     * @throws \ReflectionException
+     */
+    public function testHolidayBeforeEstablishment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Spring Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/Wales/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/SpringBankHolidayTest.php
@@ -58,14 +58,14 @@ class SpringBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             2002,
-            new DateTime("2002-6-4", new DateTimeZone(self::TIMEZONE))
+            new DateTime('2002-6-4', new DateTimeZone(self::TIMEZONE))
         );
 
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             2012,
-            new DateTime("2012-6-4", new DateTimeZone(self::TIMEZONE))
+            new DateTime('2012-6-4', new DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/UnitedKingdom/Wales/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/SummerBankHolidayTest.php
@@ -73,37 +73,37 @@ class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
             self::REGION,
             self::HOLIDAY,
             1965,
-            new DateTime("1965-8-30", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1965-8-30', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1966,
-            new DateTime("1966-8-29", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1966-8-29', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1967,
-            new DateTime("1967-8-28", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1967-8-28', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1968,
-            new DateTime("1968-9-2", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1968-9-2', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1969,
-            new DateTime("1969-9-1", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1969-9-1', new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1970,
-            new DateTime("1970-8-31", new DateTimeZone(self::TIMEZONE))
+            new DateTime('1970-8-31', new DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/UnitedKingdom/Wales/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/SummerBankHolidayTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * This file is part of the Yasumi package.
  *
@@ -10,19 +10,17 @@
  * @author Sacha Telgenhof <me@sachatelgenhof.com>
  */
 
-namespace Yasumi\tests\UnitedKingdom;
+namespace Yasumi\tests\UnitedKingdom\Wales;
 
 use DateTime;
 use DateTimeZone;
-use Exception;
-use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing the Summer Bank Holiday in the United Kingdom.
+ * Class for testing the Summer Bank Holiday in Wales.
  */
-class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiTestCaseInterface
+class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday
@@ -35,14 +33,9 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
     public const ESTABLISHMENT_YEAR = 1871;
 
     /**
-     * The year in which the holiday was renamed from August Bank Holiday to Summer Bank Holiday.
-     */
-    public const RENAME_YEAR = 1965;
-
-    /**
      * Tests the holiday defined in this test.
-     * @throws Exception
-     * @throws ReflectionException
+     * @throws \Exception
+     * @throws \ReflectionException
      */
     public function testHoliday()
     {
@@ -57,8 +50,7 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the holiday exception in 2020.
-     * @throws ReflectionException
-     * @throws Exception
+     * @throws \ReflectionException
      */
     public function testHolidayBefore1965()
     {
@@ -73,13 +65,7 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the holiday during trial period in 1965-1970.
-     * @throws ReflectionException
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
+     * @throws \ReflectionException
      */
     public function testHolidayTrialPeriod()
     {
@@ -87,43 +73,43 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
             self::REGION,
             self::HOLIDAY,
             1965,
-            new DateTime('1965-8-30', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1965-8-30", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1966,
-            new DateTime('1966-8-29', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1966-8-29", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1967,
-            new DateTime('1967-8-28', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1967-8-28", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1968,
-            new DateTime('1968-9-2', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1968-9-2", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1969,
-            new DateTime('1969-9-1', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1969-9-1", new DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             1970,
-            new DateTime('1970-8-31', new DateTimeZone(self::TIMEZONE))
+            new DateTime("1970-8-31", new DateTimeZone(self::TIMEZONE))
         );
     }
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -136,21 +122,21 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testTranslation(): void
     {
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::RENAME_YEAR),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
             [self::LOCALE => 'Summer Bank Holiday']
         );
     }
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Wales/WalesBaseTestCase.php
+++ b/tests/UnitedKingdom/Wales/WalesBaseTestCase.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Wales;
+
+use Yasumi\tests\UnitedKingdom\UnitedKingdomBaseTestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for test cases of the Wales holiday provider.
+ */
+abstract class WalesBaseTestCase extends UnitedKingdomBaseTestCase
+{
+    use YasumiBase;
+
+    /**
+     * Name of the region (e.g. country / state) to be tested
+     */
+    public const REGION = 'UnitedKingdom\Wales';
+
+    /**
+     * Timezone in which this provider has holidays defined
+     */
+    public const TIMEZONE = 'Europe/London';
+
+    /**
+     * Locale that is considered common for this provider
+     */
+    public const LOCALE = 'en_GB';
+
+    /**
+     * Number of iterations to be used for the various unit tests of this provider
+     */
+    public const TEST_ITERATIONS = 50;
+}

--- a/tests/UnitedKingdom/Wales/WalesTest.php
+++ b/tests/UnitedKingdom/Wales/WalesTest.php
@@ -81,7 +81,7 @@ class WalesTest extends WalesBaseTestCase
     /**
      * Initial setup of this Test Case
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->year = $this->generateRandomYear(1978);
     }

--- a/tests/UnitedKingdom/Wales/WalesTest.php
+++ b/tests/UnitedKingdom/Wales/WalesTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom\Wales;
+
+use Yasumi\Holiday;
+
+/**
+ * Class for testing holidays in Wales.
+ */
+class WalesTest extends WalesBaseTestCase
+{
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected $year;
+
+    /**
+     * Tests if all official holidays in Wales are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testOfficialHolidays(): void
+    {
+        $this->assertDefinedHolidays([
+            'goodFriday',
+            'christmasDay',
+        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Tests if all observed holidays in Wales are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testObservedHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+    }
+
+    /**
+     * Tests if all seasonal holidays in Wales are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testSeasonalHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_SEASON);
+    }
+
+    /**
+     * Tests if all bank holidays in Wales are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testBankHolidays(): void
+    {
+        $this->assertDefinedHolidays([
+            'newYearsDay',
+            'easterMonday',
+            'mayDayBankHoliday',
+            'springBankHoliday',
+            'secondChristmasDay'
+        ], self::REGION, $this->year, Holiday::TYPE_BANK);
+    }
+
+    /**
+     * Tests if all other holidays in Wales are defined by the provider class
+     * @throws \ReflectionException
+     */
+    public function testOtherHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+    }
+
+    /**
+     * Initial setup of this Test Case
+     */
+    protected function setUp()
+    {
+        $this->year = $this->generateRandomYear(1978);
+    }
+}


### PR DESCRIPTION
Public holidays are defined differently in England, Wales, Northern Ireland and particularly Scotland.

I have tried to implement providers for each of these countries based on Wikipedia ([UK](https://en.wikipedia.org/wiki/Public_holidays_in_the_United_Kingdom) and [Scotland](https://en.wikipedia.org/wiki/Public_and_bank_holidays_in_Scotland)), official sources ([1](https://www.gov.scot/publications/bank-holidays/), [2](https://www.gov.uk/bank-holidays), [3](http://www.legislation.gov.uk/ukpga/1971/80)), newspaper articles ([4](https://www.independent.co.uk/life-style/uk-bank-holidays-2019-what-days-off-get-how-many-easter-christmas-national-public-dates-a7533036.html), [5](https://www.independent.co.uk/life-style/uk-bank-holidays-2020-what-days-off-get-how-many-easter-christmas-national-public-dates-a8952166.html)) and other online sources ([6](https://www.hrlocker.com/hr-software/blog/uk-republic-northern-ireland-scotland-public-bank-holidays-2018-2019/), [7](http://researchbriefings.files.parliament.uk/documents/SN06170/SN06170.pdf)).

The providers for England and Wales are identical to the existing United Kingdom provider, including the unit tests. The provider for Northern Ireland is nearly identical except that it adds to holidays. The provider for Scotland is completely different (it does not call `parent::initialize()`.

Northern Ireland did not exist as a country prior to 1921 (neither did the Republic of Ireland), but I haven't added special handling of this. I assume that the territory that is currently Northern Ireland followed the same rules as England and Wales prior to then.

Like the United Kingdom provider, these providers miss translations for substitute holidays. This issue has been addressed in PR #162.