### PR TITLE
Adjust da spelling for Second Christmas Day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Late Summer Bank Holiday in 1968 and 1969 in United Kingdom [\#161](https://github.com/azuyalabs/yasumi/pull/161) ([c960657](https://github.com/c960657))
 - Fixed one-off exceptions for May Day Bank Holiday in 1995 and 2020 and Spring Bank Holiday in 2002 and 2012 (United Kingdom) [\#160](https://github.com/azuyalabs/yasumi/pull/160) ([c960657](https://github.com/c960657))
 - Fixed revoked holidays in Portugal in 2013-2015 [\#163](https://github.com/azuyalabs/yasumi/pull/163) ([c960657](https://github.com/c960657))
+- Fixed spelling issues in the Danish translation for Second Christmas Day. [\#167](https://github.com/azuyalabs/yasumi/pull/167)
 
 ### Removed
 

--- a/src/Yasumi/data/translations/secondChristmasDay.php
+++ b/src/Yasumi/data/translations/secondChristmasDay.php
@@ -13,7 +13,7 @@
 // Translations for Second Christmas Day
 return [
     'cs_CZ' => '2. svátek vánoční',
-    'da_DK' => '2. Juledag',
+    'da_DK' => '2. juledag',
     'de_AT' => 'Stefanitag',
     'de_DE' => '2. Weihnachtsfeiertag',
     'el_GR' => 'Σύναξις Υπεραγίας Θεοτόκου Μαρίας',

--- a/tests/Denmark/SecondChristmasDayTest.php
+++ b/tests/Denmark/SecondChristmasDayTest.php
@@ -62,7 +62,7 @@ class SecondChristmasDayTest extends DenmarkBaseTestCase implements YasumiTestCa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(),
-            [self::LOCALE => '2. Juledag']
+            [self::LOCALE => '2. juledag']
         );
     }
 


### PR DESCRIPTION
I somehow missed Second Christmas Day in #96.

Just like Easter Monday, _2. påskedag_ (literally: Second Easter Day), the second word should be lowercased.