### PR TITLE
Corpus Christi is an official holiday in Poland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Late Summer Bank Holiday in 1968 and 1969 in United Kingdom [\#161](https://github.com/azuyalabs/yasumi/pull/161) ([c960657](https://github.com/c960657))
 - Fixed one-off exceptions for May Day Bank Holiday in 1995 and 2020 and Spring Bank Holiday in 2002 and 2012 (United Kingdom) [\#160](https://github.com/azuyalabs/yasumi/pull/160) ([c960657](https://github.com/c960657))
 - Fixed revoked holidays in Portugal in 2013-2015 [\#163](https://github.com/azuyalabs/yasumi/pull/163) ([c960657](https://github.com/c960657))
+- Corpus Christi is official in Poland [\#168](https://github.com/azuyalabs/yasumi/pull/168) ([c960657](https://github.com/c960657))
 
 ### Removed
 

--- a/src/Yasumi/Provider/Poland.php
+++ b/src/Yasumi/Provider/Poland.php
@@ -49,7 +49,7 @@ class Poland extends AbstractProvider
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale));

--- a/tests/Poland/CorpusChristiTest.php
+++ b/tests/Poland/CorpusChristiTest.php
@@ -63,6 +63,6 @@ class CorpusChristiTest extends PolandBaseTestCase implements YasumiTestCaseInte
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Poland/PolandTest.php
+++ b/tests/Poland/PolandTest.php
@@ -40,6 +40,7 @@ class PolandTest extends PolandBaseTestCase
             'easterMonday',
             'epiphany',
             'pentecost',
+            'corpusChristi',
             'secondChristmasDay',
             'constitutionDay',
             'independenceDay',
@@ -79,7 +80,7 @@ class PolandTest extends PolandBaseTestCase
      */
     public function testOtherHolidays(): void
     {
-        $this->assertDefinedHolidays(['corpusChristi'], self::REGION, $this->year, Holiday::TYPE_OTHER);
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
     }
 
     /**


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Public_holidays_in_Poland) and [Poland law](http://prawo.sejm.gov.pl/isap.nsf/DocDetails.xsp?id=WDU19510040028), Corpus Christi is an official holiday in Poland.