### PR TITLE
Liberation Day is official in the Netherlands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixed revoked holidays in Portugal in 2013-2015 [\#163](https://github.com/azuyalabs/yasumi/pull/163) ([c960657](https://github.com/c960657))
 - Fixed spelling issues in the Danish translation for Second Christmas Day. [\#167](https://github.com/azuyalabs/yasumi/pull/167)
 - Corpus Christi is official in Poland [\#168](https://github.com/azuyalabs/yasumi/pull/168) ([c960657](https://github.com/c960657))
+- Liberation Day is official in the Netherlands [\#169](https://github.com/azuyalabs/yasumi/pull/169) ([c960657](https://github.com/c960657))
 
 
 ### Removed

--- a/src/Yasumi/Provider/Netherlands.php
+++ b/src/Yasumi/Provider/Netherlands.php
@@ -107,7 +107,7 @@ class Netherlands extends AbstractProvider
                 ['en_US' => 'Liberation Day', 'nl_NL' => 'Bevrijdingsdag'],
                 new DateTime("$this->year-5-5", new DateTimeZone($this->timezone)),
                 $this->locale,
-                Holiday::TYPE_OBSERVANCE
+                Holiday::TYPE_OFFICIAL
             ));
         }
     }

--- a/tests/Netherlands/LiberationDayTest.php
+++ b/tests/Netherlands/LiberationDayTest.php
@@ -85,7 +85,7 @@ class LiberationDayTest extends NetherlandsBaseTestCase implements YasumiTestCas
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            Holiday::TYPE_OBSERVANCE
+            Holiday::TYPE_OFFICIAL
         );
     }
 }

--- a/tests/Netherlands/NetherlandsTest.php
+++ b/tests/Netherlands/NetherlandsTest.php
@@ -38,6 +38,7 @@ class NetherlandsTest extends NetherlandsBaseTestCase
             'ascensionDay',
             'pentecost',
             'pentecostMonday',
+            'liberationDay',
             'christmasDay',
             'secondChristmasDay'
         ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
@@ -54,7 +55,6 @@ class NetherlandsTest extends NetherlandsBaseTestCase
             'goodFriday',
             'ashWednesday',
             'commemorationDay',
-            'liberationDay',
             'halloween',
             'stNicholasDay',
             'carnivalDay',


### PR DESCRIPTION
Liberation Day in the Netherlands is a public holiday, according to [Wikipedia](https://en.wikipedia.org/wiki/Public_holidays_in_the_Netherlands) and [Dutch law](https://wetten.overheid.nl/BWBR0002448/2010-10-10#Artikel3) (not mentioned by named but referred to as _fifth of May_).