### PR TITLE
Typos in Easter Monday and Republic Day for it_IT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Fixed spelling issues in the Danish translation for Second Christmas Day. [\#167](https://github.com/azuyalabs/yasumi/pull/167)
 - Corpus Christi is official in Poland [\#168](https://github.com/azuyalabs/yasumi/pull/168) ([c960657](https://github.com/c960657))
 - Liberation Day is official in the Netherlands [\#169](https://github.com/azuyalabs/yasumi/pull/169) ([c960657](https://github.com/c960657))
+- Typos in Easter Monday and Republic Day for the 'it_IT' locale [\#171](https://github.com/azuyalabs/yasumi/pull/171) ([c960657](https://github.com/c960657))
 
 
 ### Removed

--- a/src/Yasumi/Provider/Italy.php
+++ b/src/Yasumi/Provider/Italy.php
@@ -110,7 +110,7 @@ class Italy extends AbstractProvider
         if ($this->year >= 1946) {
             $this->addHoliday(new Holiday(
                 'republicDay',
-                ['it_IT' => 'Festa della Republica'],
+                ['it_IT' => 'Festa della Repubblica'],
                 new DateTime("$this->year-6-2", new DateTimeZone($this->timezone)),
                 $this->locale
             ));

--- a/src/Yasumi/data/translations/easterMonday.php
+++ b/src/Yasumi/data/translations/easterMonday.php
@@ -33,7 +33,7 @@ return [
     'hr_HR' => 'Uskršnji ponedjeljak',
     'hu_HU' => 'Húsvéthétfő',
     'it_CH' => 'Lunedi di Pasqua',
-    'it_IT' => 'Lunedi` dell\'Angelo',
+    'it_IT' => 'Lunedì dell\'Angelo',
     'lt_LT' => 'Antroji Velykų diena',
     'lv_LV' => 'Otrās Lieldienas',
     'nb_NO' => 'Andre påskedag',

--- a/tests/Italy/EasterMondayTest.php
+++ b/tests/Italy/EasterMondayTest.php
@@ -53,7 +53,7 @@ class EasterMondayTest extends ItalyBaseTestCase implements YasumiTestCaseInterf
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(),
-            [self::LOCALE => 'Lunedi` dell\'Angelo']
+            [self::LOCALE => "Lunedì dell'Angelo"]
         );
     }
 

--- a/tests/Italy/RepublicDayTest.php
+++ b/tests/Italy/RepublicDayTest.php
@@ -78,7 +78,7 @@ class RepublicDayTest extends ItalyBaseTestCase implements YasumiTestCaseInterfa
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            [self::LOCALE => 'Festa della Republica']
+            [self::LOCALE => 'Festa della Repubblica']
         );
     }
 


### PR DESCRIPTION
Two typos for it_IT:
- Missing _b_ in [Festa della Repubblica Italiana](https://it.wikipedia.org/wiki/Festa_della_Repubblica_Italiana).
- A misplaced grave accent in [Lunedì dell'Angelo](https://it.wikipedia.org/wiki/Luned%C3%AC_dell%27Angelo).
