### PR TITLE
Good Friday is not an official holiday in Brazil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Liberation Day is official in the Netherlands [\#169](https://github.com/azuyalabs/yasumi/pull/169) ([c960657](https://github.com/c960657))
 - Typos in Easter Monday and Republic Day for the 'it_IT' locale [\#171](https://github.com/azuyalabs/yasumi/pull/171) ([c960657](https://github.com/c960657))
 - Corrected the name of the Emperors Birthday function and variable.
+- Good Friday is not official in Brazil [\#174](https://github.com/azuyalabs/yasumi/pull/174) ([c960657](https://github.com/c960657))
 
 ### Removed
 - Unused constants.

--- a/src/Yasumi/Provider/Brazil.php
+++ b/src/Yasumi/Provider/Brazil.php
@@ -52,7 +52,7 @@ class Brazil extends AbstractProvider
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
         $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
         $this->addHoliday($this->ashWednesday($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
 
         /**

--- a/tests/Brazil/BrazilTest.php
+++ b/tests/Brazil/BrazilTest.php
@@ -33,7 +33,6 @@ class BrazilTest extends BrazilBaseTestCase
     {
         $this->assertDefinedHolidays([
             'newYearsDay',
-            'goodFriday',
             'tiradentesDay',
             'internationalWorkersDay',
             'independenceDay',
@@ -53,6 +52,7 @@ class BrazilTest extends BrazilBaseTestCase
         $this->assertDefinedHolidays([
             'carnavalMonday',
             'carnavalTuesday',
+            'goodFriday',
             'easter',
             'corpusChristi',
             'ashWednesday'

--- a/tests/Brazil/GoodFridayTest.php
+++ b/tests/Brazil/GoodFridayTest.php
@@ -68,6 +68,6 @@ class GoodFridayTest extends BrazilBaseTestCase implements YasumiTestCaseInterfa
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
     }
 }


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Public_holidays_in_Brazil), Good Friday is not an official holiday in Brazil.