### PR TITLE
Summer bank holiday test

### DIFF
--- a/tests/UnitedKingdom/England/BoxingDayTest.php
+++ b/tests/UnitedKingdom/England/BoxingDayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\England;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class BoxingDayTest extends EnglandBaseTestCase implements YasumiTestCaseInterfa
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -55,7 +57,7 @@ class BoxingDayTest extends EnglandBaseTestCase implements YasumiTestCaseInterfa
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -73,7 +75,7 @@ class BoxingDayTest extends EnglandBaseTestCase implements YasumiTestCaseInterfa
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -87,7 +89,7 @@ class BoxingDayTest extends EnglandBaseTestCase implements YasumiTestCaseInterfa
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/England/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/England/ChristmasDayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\England;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class ChristmasDayTest extends EnglandBaseTestCase implements YasumiTestCaseInte
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -55,7 +57,7 @@ class ChristmasDayTest extends EnglandBaseTestCase implements YasumiTestCaseInte
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -73,7 +75,7 @@ class ChristmasDayTest extends EnglandBaseTestCase implements YasumiTestCaseInte
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -87,7 +89,7 @@ class ChristmasDayTest extends EnglandBaseTestCase implements YasumiTestCaseInte
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/England/EasterMondayTest.php
+++ b/tests/UnitedKingdom/England/EasterMondayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\England;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class EasterMondayTest extends EnglandBaseTestCase implements YasumiTestCaseInte
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -53,7 +55,7 @@ class EasterMondayTest extends EnglandBaseTestCase implements YasumiTestCaseInte
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -72,7 +74,7 @@ class EasterMondayTest extends EnglandBaseTestCase implements YasumiTestCaseInte
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -86,7 +88,7 @@ class EasterMondayTest extends EnglandBaseTestCase implements YasumiTestCaseInte
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/England/EnglandTest.php
+++ b/tests/UnitedKingdom/England/EnglandTest.php
@@ -12,6 +12,7 @@
 
 namespace Yasumi\tests\UnitedKingdom\England;
 
+use ReflectionException;
 use Yasumi\Holiday;
 
 /**
@@ -26,7 +27,7 @@ class EnglandTest extends EnglandBaseTestCase
 
     /**
      * Tests if all official holidays in England are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testOfficialHolidays(): void
     {
@@ -38,7 +39,7 @@ class EnglandTest extends EnglandBaseTestCase
 
     /**
      * Tests if all observed holidays in England are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testObservedHolidays(): void
     {
@@ -47,7 +48,7 @@ class EnglandTest extends EnglandBaseTestCase
 
     /**
      * Tests if all seasonal holidays in England are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testSeasonalHolidays(): void
     {
@@ -56,7 +57,7 @@ class EnglandTest extends EnglandBaseTestCase
 
     /**
      * Tests if all bank holidays in England are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testBankHolidays(): void
     {
@@ -71,7 +72,7 @@ class EnglandTest extends EnglandBaseTestCase
 
     /**
      * Tests if all other holidays in England are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testOtherHolidays(): void
     {

--- a/tests/UnitedKingdom/England/GoodFridayTest.php
+++ b/tests/UnitedKingdom/England/GoodFridayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\England;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -29,8 +31,8 @@ class GoodFridayTest extends EnglandBaseTestCase implements YasumiTestCaseInterf
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -45,7 +47,7 @@ class GoodFridayTest extends EnglandBaseTestCase implements YasumiTestCaseInterf
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -59,7 +61,7 @@ class GoodFridayTest extends EnglandBaseTestCase implements YasumiTestCaseInterf
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/England/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/MayDayBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\England;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -35,8 +37,8 @@ class MayDayBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
     /**
      * Tests the holiday defined in this test.
      *
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -52,8 +54,8 @@ class MayDayBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
     /**
      * Tests the holiday exception in 1995 and 2020.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayExceptions()
     {
@@ -74,7 +76,7 @@ class MayDayBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -87,7 +89,7 @@ class MayDayBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -101,7 +103,7 @@ class MayDayBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/England/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/England/NewYearsDayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\England;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -45,8 +47,8 @@ class NewYearsDayTest extends EnglandBaseTestCase implements YasumiTestCaseInter
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayOnAfterEstablishment($year, $expected)
     {
@@ -60,7 +62,7 @@ class NewYearsDayTest extends EnglandBaseTestCase implements YasumiTestCaseInter
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -73,7 +75,7 @@ class NewYearsDayTest extends EnglandBaseTestCase implements YasumiTestCaseInter
 
     /**
      * Tests that the holiday defined in this test is of the type 'observance' before the year it was changed.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayIsObservedTypeBeforeChange()
     {
@@ -89,7 +91,7 @@ class NewYearsDayTest extends EnglandBaseTestCase implements YasumiTestCaseInter
      * Returns a list of random test dates used for assertion of the holiday defined in this test
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -98,7 +100,7 @@ class NewYearsDayTest extends EnglandBaseTestCase implements YasumiTestCaseInter
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -112,7 +114,7 @@ class NewYearsDayTest extends EnglandBaseTestCase implements YasumiTestCaseInter
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/England/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/SpringBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\England;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -35,8 +37,8 @@ class SpringBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
     /**
      * Tests the holiday defined in this test.
      *
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -52,8 +54,8 @@ class SpringBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
     /**
      * Tests the holiday exceptions in 2002 and 2012.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayException()
     {
@@ -74,7 +76,7 @@ class SpringBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -87,7 +89,7 @@ class SpringBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -101,7 +103,7 @@ class SpringBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/England/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/SummerBankHolidayTest.php
@@ -39,8 +39,8 @@ class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -56,8 +56,8 @@ class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
     /**
      * Tests the holiday exception in 2020.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayBefore1965()
     {
@@ -73,8 +73,8 @@ class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
     /**
      * Tests the holiday during trial period in 1965-1970.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayTrialPeriod()
     {
@@ -118,7 +118,7 @@ class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -131,7 +131,7 @@ class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -145,7 +145,7 @@ class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslationBeforeRename(): void
     {
@@ -159,7 +159,7 @@ class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/England/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/SummerBankHolidayTest.php
@@ -33,6 +33,11 @@ class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
     public const ESTABLISHMENT_YEAR = 1871;
 
     /**
+     * The year in which the holiday was renamed from August Bank Holiday to Summer Bank Holiday.
+     */
+    public const RENAME_YEAR = 1965;
+
+    /**
      * Tests the holiday defined in this test.
      * @throws \Exception
      * @throws \ReflectionException
@@ -133,8 +138,22 @@ class SummerBankHolidayTest extends EnglandBaseTestCase implements YasumiTestCas
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            $this->generateRandomYear(self::RENAME_YEAR),
             [self::LOCALE => 'Summer Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslationBeforeRename(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::RENAME_YEAR - 1),
+            [self::LOCALE => 'August Bank Holiday']
         );
     }
 

--- a/tests/UnitedKingdom/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/MayDayBankHolidayTest.php
@@ -54,7 +54,6 @@ class MayDayBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
      * Tests the holiday exception in 1995 and 2020.
      * @throws ReflectionException
      * @throws Exception
-     * @throws Exception
      */
     public function testHolidayExceptions()
     {

--- a/tests/UnitedKingdom/NorthernIreland/BattleOfTheBoyneTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/BattleOfTheBoyneTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -40,8 +42,8 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Yasumi
      * @param int       $year     the year for which the holiday defined in this test needs to be tested
      * @param \DateTime $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -56,7 +58,7 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Yasumi
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -71,7 +73,7 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Yasumi
      * Returns a list of random test dates used for assertion of the holiday defined in this test
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -89,7 +91,7 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Yasumi
     /**
      * Tests the translated name of the holiday defined in this test.
      *
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -103,7 +105,7 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Yasumi
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/BoxingDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/BoxingDayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class BoxingDayTest extends NorthernIrelandBaseTestCase implements YasumiTestCas
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -55,7 +57,7 @@ class BoxingDayTest extends NorthernIrelandBaseTestCase implements YasumiTestCas
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -73,7 +75,7 @@ class BoxingDayTest extends NorthernIrelandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -87,7 +89,7 @@ class BoxingDayTest extends NorthernIrelandBaseTestCase implements YasumiTestCas
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/ChristmasDayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class ChristmasDayTest extends NorthernIrelandBaseTestCase implements YasumiTest
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -55,7 +57,7 @@ class ChristmasDayTest extends NorthernIrelandBaseTestCase implements YasumiTest
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -73,7 +75,7 @@ class ChristmasDayTest extends NorthernIrelandBaseTestCase implements YasumiTest
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -87,7 +89,7 @@ class ChristmasDayTest extends NorthernIrelandBaseTestCase implements YasumiTest
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/EasterMondayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/EasterMondayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class EasterMondayTest extends NorthernIrelandBaseTestCase implements YasumiTest
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -53,7 +55,7 @@ class EasterMondayTest extends NorthernIrelandBaseTestCase implements YasumiTest
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -72,7 +74,7 @@ class EasterMondayTest extends NorthernIrelandBaseTestCase implements YasumiTest
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -86,7 +88,7 @@ class EasterMondayTest extends NorthernIrelandBaseTestCase implements YasumiTest
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/GoodFridayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/GoodFridayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -29,8 +31,8 @@ class GoodFridayTest extends NorthernIrelandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -45,7 +47,7 @@ class GoodFridayTest extends NorthernIrelandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -59,7 +61,7 @@ class GoodFridayTest extends NorthernIrelandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/MayDayBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -34,8 +36,8 @@ class MayDayBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -51,8 +53,8 @@ class MayDayBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
     /**
      * Tests the holiday exception in 1995 and 2020.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayExceptions()
     {
@@ -73,7 +75,7 @@ class MayDayBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -86,7 +88,7 @@ class MayDayBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -100,7 +102,7 @@ class MayDayBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/NewYearsDayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -45,8 +47,8 @@ class NewYearsDayTest extends NorthernIrelandBaseTestCase implements YasumiTestC
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayOnAfterEstablishment($year, $expected)
     {
@@ -60,7 +62,7 @@ class NewYearsDayTest extends NorthernIrelandBaseTestCase implements YasumiTestC
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -73,7 +75,7 @@ class NewYearsDayTest extends NorthernIrelandBaseTestCase implements YasumiTestC
 
     /**
      * Tests that the holiday defined in this test is of the type 'observance' before the year it was changed.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayIsObservedTypeBeforeChange()
     {
@@ -89,7 +91,7 @@ class NewYearsDayTest extends NorthernIrelandBaseTestCase implements YasumiTestC
      * Returns a list of random test dates used for assertion of the holiday defined in this test
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -98,7 +100,7 @@ class NewYearsDayTest extends NorthernIrelandBaseTestCase implements YasumiTestC
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -112,7 +114,7 @@ class NewYearsDayTest extends NorthernIrelandBaseTestCase implements YasumiTestC
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/NorthernIrelandTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/NorthernIrelandTest.php
@@ -12,6 +12,7 @@
 
 namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 
+use ReflectionException;
 use Yasumi\Holiday;
 
 /**
@@ -26,7 +27,7 @@ class NorthernIrelandTest extends NorthernIrelandBaseTestCase
 
     /**
      * Tests if all official holidays in Northern Ireland are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testOfficialHolidays(): void
     {
@@ -38,7 +39,7 @@ class NorthernIrelandTest extends NorthernIrelandBaseTestCase
 
     /**
      * Tests if all observed holidays in Northern Ireland are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testObservedHolidays(): void
     {
@@ -47,7 +48,7 @@ class NorthernIrelandTest extends NorthernIrelandBaseTestCase
 
     /**
      * Tests if all seasonal holidays in Northern Ireland are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testSeasonalHolidays(): void
     {
@@ -56,7 +57,7 @@ class NorthernIrelandTest extends NorthernIrelandBaseTestCase
 
     /**
      * Tests if all bank holidays in Northern Ireland are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testBankHolidays(): void
     {
@@ -72,7 +73,7 @@ class NorthernIrelandTest extends NorthernIrelandBaseTestCase
 
     /**
      * Tests if all other holidays in Northern Ireland are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testOtherHolidays(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/SpringBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -34,8 +36,8 @@ class SpringBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -50,7 +52,7 @@ class SpringBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -63,7 +65,7 @@ class SpringBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -77,7 +79,7 @@ class SpringBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/StPatricksDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/StPatricksDayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -40,8 +42,8 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTes
      * @param int       $year     the year for which the holiday defined in this test needs to be tested
      * @param \DateTime $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -56,7 +58,7 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTes
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -71,7 +73,7 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTes
      * Returns a list of random test dates used for assertion of the holiday defined in this test
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -89,7 +91,7 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTes
     /**
      * Tests the translated name of the holiday defined in this test.
      *
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -103,7 +105,7 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements YasumiTes
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\NorthernIreland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -39,8 +41,8 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -56,8 +58,8 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
     /**
      * Tests the holiday exception in 2020.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayBefore1965()
     {
@@ -72,13 +74,13 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the holiday during trial period in 1965-1970.
-     * @throws \ReflectionException
-     * @throws \Exception
-     * @throws \Exception
-     * @throws \Exception
-     * @throws \Exception
-     * @throws \Exception
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
+     * @throws Exception
+     * @throws Exception
+     * @throws Exception
+     * @throws Exception
+     * @throws Exception
      */
     public function testHolidayTrialPeriod()
     {
@@ -122,7 +124,7 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -135,7 +137,7 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -149,7 +151,7 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslationBeforeRename(): void
     {
@@ -163,7 +165,7 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
@@ -76,11 +76,6 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
      * Tests the holiday during trial period in 1965-1970.
      * @throws ReflectionException
      * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
      */
     public function testHolidayTrialPeriod()
     {

--- a/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
@@ -33,6 +33,11 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
     public const ESTABLISHMENT_YEAR = 1871;
 
     /**
+     * The year in which the holiday was renamed from August Bank Holiday to Summer Bank Holiday.
+     */
+    public const RENAME_YEAR = 1965;
+
+    /**
      * Tests the holiday defined in this test.
      * @throws \Exception
      * @throws \ReflectionException
@@ -137,8 +142,22 @@ class SummerBankHolidayTest extends NorthernIrelandBaseTestCase implements Yasum
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            $this->generateRandomYear(self::RENAME_YEAR),
             [self::LOCALE => 'Summer Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslationBeforeRename(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::RENAME_YEAR - 1),
+            [self::LOCALE => 'August Bank Holiday']
         );
     }
 

--- a/tests/UnitedKingdom/Scotland/BoxingDayTest.php
+++ b/tests/UnitedKingdom/Scotland/BoxingDayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\Scotland;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class BoxingDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterf
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -55,7 +57,7 @@ class BoxingDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterf
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -73,7 +75,7 @@ class BoxingDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterf
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -87,7 +89,7 @@ class BoxingDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInterf
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Scotland/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/Scotland/ChristmasDayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\Scotland;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class ChristmasDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInt
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -55,7 +57,7 @@ class ChristmasDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInt
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -73,7 +75,7 @@ class ChristmasDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInt
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -87,7 +89,7 @@ class ChristmasDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInt
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Scotland/GoodFridayTest.php
+++ b/tests/UnitedKingdom/Scotland/GoodFridayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\Scotland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -29,8 +31,8 @@ class GoodFridayTest extends ScotlandBaseTestCase implements YasumiTestCaseInter
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -45,7 +47,7 @@ class GoodFridayTest extends ScotlandBaseTestCase implements YasumiTestCaseInter
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -59,7 +61,7 @@ class GoodFridayTest extends ScotlandBaseTestCase implements YasumiTestCaseInter
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Scotland/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/Scotland/MayDayBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\Scotland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -35,8 +37,8 @@ class MayDayBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
     /**
      * Tests the holiday defined in this test.
      *
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -52,8 +54,8 @@ class MayDayBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
     /**
      * Tests the holiday exception in 1995 and 2020.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayExceptions()
     {
@@ -74,7 +76,7 @@ class MayDayBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -87,7 +89,7 @@ class MayDayBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -101,7 +103,7 @@ class MayDayBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Scotland/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/Scotland/NewYearsDayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\Scotland;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -46,8 +48,8 @@ class NewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInte
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayOnAfterEstablishment($year, $expected)
     {
@@ -62,7 +64,7 @@ class NewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInte
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -75,7 +77,7 @@ class NewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInte
 
     /**
      * Tests that the holiday defined in this test is of the type 'observance' before the year it was changed.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayIsObservedTypeBeforeChange()
     {
@@ -91,7 +93,7 @@ class NewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInte
      * Returns a list of random test dates used for assertion of the holiday defined in this test
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -108,7 +110,7 @@ class NewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInte
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -122,7 +124,7 @@ class NewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInte
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Scotland/ScotlandTest.php
+++ b/tests/UnitedKingdom/Scotland/ScotlandTest.php
@@ -12,6 +12,7 @@
 
 namespace Yasumi\tests\UnitedKingdom\Scotland;
 
+use ReflectionException;
 use Yasumi\Holiday;
 
 /**
@@ -26,7 +27,7 @@ class ScotlandTest extends ScotlandBaseTestCase
 
     /**
      * Tests if all official holidays in Scotland are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testOfficialHolidays(): void
     {
@@ -36,7 +37,7 @@ class ScotlandTest extends ScotlandBaseTestCase
 
     /**
      * Tests if all observed holidays in Scotland are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testObservedHolidays(): void
     {
@@ -45,7 +46,7 @@ class ScotlandTest extends ScotlandBaseTestCase
 
     /**
      * Tests if all seasonal holidays in Scotland are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testSeasonalHolidays(): void
     {
@@ -54,7 +55,7 @@ class ScotlandTest extends ScotlandBaseTestCase
 
     /**
      * Tests if all bank holidays in Scotland are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testBankHolidays(): void
     {
@@ -70,7 +71,7 @@ class ScotlandTest extends ScotlandBaseTestCase
 
     /**
      * Tests if all other holidays in Scotland are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testOtherHolidays(): void
     {

--- a/tests/UnitedKingdom/Scotland/SecondNewYearsDayTest.php
+++ b/tests/UnitedKingdom/Scotland/SecondNewYearsDayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\Scotland;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -46,8 +48,8 @@ class SecondNewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCa
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayOnAfterEstablishment($year, $expected)
     {
@@ -62,7 +64,7 @@ class SecondNewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -75,7 +77,7 @@ class SecondNewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests that the holiday defined in this test is of the type 'observance' before the year it was changed.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayIsObservedTypeBeforeChange()
     {
@@ -91,7 +93,7 @@ class SecondNewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCa
      * Returns a list of random test dates used for assertion of the holiday defined in this test
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -108,7 +110,7 @@ class SecondNewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -122,7 +124,7 @@ class SecondNewYearsDayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Scotland/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/Scotland/SpringBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\Scotland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -34,8 +36,8 @@ class SpringBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -50,7 +52,7 @@ class SpringBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -63,7 +65,7 @@ class SpringBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -77,7 +79,7 @@ class SpringBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Scotland/StAndrewsDayTest.php
+++ b/tests/UnitedKingdom/Scotland/StAndrewsDayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\Scotland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -40,8 +42,8 @@ class StAndrewsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInt
      * @param int       $year     the year for which the holiday defined in this test needs to be tested
      * @param \DateTime $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -58,7 +60,7 @@ class StAndrewsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInt
      * Returns a list of random test dates used for assertion of the holiday defined in this test
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -76,7 +78,7 @@ class StAndrewsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInt
     /**
      * Tests the translated name of the holiday defined in this test.
      *
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -90,7 +92,7 @@ class StAndrewsDayTest extends ScotlandBaseTestCase implements YasumiTestCaseInt
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Scotland/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/Scotland/SummerBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\Scotland;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -34,8 +36,8 @@ class SummerBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -50,7 +52,7 @@ class SummerBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -63,7 +65,7 @@ class SummerBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -77,7 +79,7 @@ class SummerBankHolidayTest extends ScotlandBaseTestCase implements YasumiTestCa
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/SpringBankHolidayTest.php
@@ -54,7 +54,6 @@ class SpringBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
      * Tests the holiday exceptions in 2002 and 2012.
      * @throws ReflectionException
      * @throws Exception
-     * @throws Exception
      */
     public function testHolidayException()
     {

--- a/tests/UnitedKingdom/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/SummerBankHolidayTest.php
@@ -75,11 +75,6 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
      * Tests the holiday during trial period in 1965-1970.
      * @throws ReflectionException
      * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
      */
     public function testHolidayTrialPeriod()
     {
@@ -136,7 +131,7 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -150,7 +145,7 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslationBeforeRename(): void
     {

--- a/tests/UnitedKingdom/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/SummerBankHolidayTest.php
@@ -136,7 +136,7 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function testTranslation(): void
     {
@@ -145,6 +145,20 @@ class SummerBankHolidayTest extends UnitedKingdomBaseTestCase implements YasumiT
             self::HOLIDAY,
             $this->generateRandomYear(self::RENAME_YEAR),
             [self::LOCALE => 'Summer Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslationBeforeRename(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::RENAME_YEAR - 1),
+            [self::LOCALE => 'August Bank Holiday']
         );
     }
 

--- a/tests/UnitedKingdom/Wales/BoxingDayTest.php
+++ b/tests/UnitedKingdom/Wales/BoxingDayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\Wales;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class BoxingDayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -55,7 +57,7 @@ class BoxingDayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -73,7 +75,7 @@ class BoxingDayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -87,7 +89,7 @@ class BoxingDayTest extends WalesBaseTestCase implements YasumiTestCaseInterface
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Wales/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/Wales/ChristmasDayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\Wales;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class ChristmasDayTest extends WalesBaseTestCase implements YasumiTestCaseInterf
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -55,7 +57,7 @@ class ChristmasDayTest extends WalesBaseTestCase implements YasumiTestCaseInterf
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -73,7 +75,7 @@ class ChristmasDayTest extends WalesBaseTestCase implements YasumiTestCaseInterf
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -87,7 +89,7 @@ class ChristmasDayTest extends WalesBaseTestCase implements YasumiTestCaseInterf
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Wales/EasterMondayTest.php
+++ b/tests/UnitedKingdom/Wales/EasterMondayTest.php
@@ -15,6 +15,8 @@ namespace Yasumi\tests\UnitedKingdom\Wales;
 use DateInterval;
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -36,8 +38,8 @@ class EasterMondayTest extends WalesBaseTestCase implements YasumiTestCaseInterf
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHoliday($year, $expected)
     {
@@ -53,7 +55,7 @@ class EasterMondayTest extends WalesBaseTestCase implements YasumiTestCaseInterf
      * Returns a list of test dates
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -72,7 +74,7 @@ class EasterMondayTest extends WalesBaseTestCase implements YasumiTestCaseInterf
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -86,7 +88,7 @@ class EasterMondayTest extends WalesBaseTestCase implements YasumiTestCaseInterf
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Wales/GoodFridayTest.php
+++ b/tests/UnitedKingdom/Wales/GoodFridayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\Wales;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -29,8 +31,8 @@ class GoodFridayTest extends WalesBaseTestCase implements YasumiTestCaseInterfac
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -45,7 +47,7 @@ class GoodFridayTest extends WalesBaseTestCase implements YasumiTestCaseInterfac
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -59,7 +61,7 @@ class GoodFridayTest extends WalesBaseTestCase implements YasumiTestCaseInterfac
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Wales/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/MayDayBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\Wales;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -35,8 +37,8 @@ class MayDayBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
     /**
      * Tests the holiday defined in this test.
      *
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -52,8 +54,8 @@ class MayDayBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
     /**
      * Tests the holiday exception in 1995 and 2020.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayExceptions()
     {
@@ -74,7 +76,7 @@ class MayDayBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -87,7 +89,7 @@ class MayDayBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -101,7 +103,7 @@ class MayDayBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Wales/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/Wales/NewYearsDayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\Wales;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -45,8 +47,8 @@ class NewYearsDayTest extends WalesBaseTestCase implements YasumiTestCaseInterfa
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayOnAfterEstablishment($year, $expected)
     {
@@ -60,7 +62,7 @@ class NewYearsDayTest extends WalesBaseTestCase implements YasumiTestCaseInterfa
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -73,7 +75,7 @@ class NewYearsDayTest extends WalesBaseTestCase implements YasumiTestCaseInterfa
 
     /**
      * Tests that the holiday defined in this test is of the type 'observance' before the year it was changed.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayIsObservedTypeBeforeChange()
     {
@@ -89,7 +91,7 @@ class NewYearsDayTest extends WalesBaseTestCase implements YasumiTestCaseInterfa
      * Returns a list of random test dates used for assertion of the holiday defined in this test
      *
      * @return array list of test dates for the holiday defined in this test
-     * @throws \Exception
+     * @throws Exception
      */
     public function HolidayDataProvider(): array
     {
@@ -98,7 +100,7 @@ class NewYearsDayTest extends WalesBaseTestCase implements YasumiTestCaseInterfa
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -112,7 +114,7 @@ class NewYearsDayTest extends WalesBaseTestCase implements YasumiTestCaseInterfa
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Wales/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/SpringBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\Wales;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -34,8 +36,8 @@ class SpringBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -51,8 +53,8 @@ class SpringBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
     /**
      * Tests the holiday exceptions in 2002 and 2012.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayException()
     {
@@ -73,7 +75,7 @@ class SpringBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -86,7 +88,7 @@ class SpringBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -100,7 +102,7 @@ class SpringBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Wales/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/SummerBankHolidayTest.php
@@ -14,6 +14,8 @@ namespace Yasumi\tests\UnitedKingdom\Wales;
 
 use DateTime;
 use DateTimeZone;
+use Exception;
+use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
@@ -39,8 +41,8 @@ class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests the holiday defined in this test.
-     * @throws \Exception
-     * @throws \ReflectionException
+     * @throws Exception
+     * @throws ReflectionException
      */
     public function testHoliday()
     {
@@ -56,8 +58,8 @@ class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
     /**
      * Tests the holiday exception in 2020.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayBefore1965()
     {
@@ -73,8 +75,8 @@ class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
     /**
      * Tests the holiday during trial period in 1965-1970.
      *
-     * @throws \ReflectionException
-     * @throws \Exception
+     * @throws ReflectionException
+     * @throws Exception
      */
     public function testHolidayTrialPeriod()
     {
@@ -118,7 +120,7 @@ class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests the holiday defined in this test before establishment.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayBeforeEstablishment()
     {
@@ -131,7 +133,7 @@ class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslation(): void
     {
@@ -145,7 +147,7 @@ class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests the translated name of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testTranslationBeforeRename(): void
     {
@@ -159,7 +161,7 @@ class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
 
     /**
      * Tests type of the holiday defined in this test.
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testHolidayType(): void
     {

--- a/tests/UnitedKingdom/Wales/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/SummerBankHolidayTest.php
@@ -33,6 +33,11 @@ class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
     public const ESTABLISHMENT_YEAR = 1871;
 
     /**
+     * The year in which the holiday was renamed from August Bank Holiday to Summer Bank Holiday.
+     */
+    public const RENAME_YEAR = 1965;
+
+    /**
      * Tests the holiday defined in this test.
      * @throws \Exception
      * @throws \ReflectionException
@@ -133,8 +138,22 @@ class SummerBankHolidayTest extends WalesBaseTestCase implements YasumiTestCaseI
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            $this->generateRandomYear(self::RENAME_YEAR),
             [self::LOCALE => 'Summer Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslationBeforeRename(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::RENAME_YEAR - 1),
+            [self::LOCALE => 'August Bank Holiday']
         );
     }
 

--- a/tests/UnitedKingdom/Wales/WalesTest.php
+++ b/tests/UnitedKingdom/Wales/WalesTest.php
@@ -12,6 +12,7 @@
 
 namespace Yasumi\tests\UnitedKingdom\Wales;
 
+use ReflectionException;
 use Yasumi\Holiday;
 
 /**
@@ -26,7 +27,7 @@ class WalesTest extends WalesBaseTestCase
 
     /**
      * Tests if all official holidays in Wales are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testOfficialHolidays(): void
     {
@@ -38,7 +39,7 @@ class WalesTest extends WalesBaseTestCase
 
     /**
      * Tests if all observed holidays in Wales are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testObservedHolidays(): void
     {
@@ -47,7 +48,7 @@ class WalesTest extends WalesBaseTestCase
 
     /**
      * Tests if all seasonal holidays in Wales are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testSeasonalHolidays(): void
     {
@@ -56,7 +57,7 @@ class WalesTest extends WalesBaseTestCase
 
     /**
      * Tests if all bank holidays in Wales are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testBankHolidays(): void
     {
@@ -71,7 +72,7 @@ class WalesTest extends WalesBaseTestCase
 
     /**
      * Tests if all other holidays in Wales are defined by the provider class
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
     public function testOtherHolidays(): void
     {


### PR DESCRIPTION
Fix the SummerBankHolidayTest for England, Wales and Northern Ireland which occasionally failed, because they failed to check for the renaming from August Bank Holiday to Summer Bank Holiday in 1965.

Also, update the tests for these countries to the coding standard introduced in 27c6e8173.