### PR TITLE
Fix locale fallback for substitute holiday

### DIFF
--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -160,20 +160,28 @@ class Holiday extends DateTime implements JsonSerializable
      */
     public function getName(): string
     {
-        $locales = [$this->displayLocale];
-        $parts = \explode('_', $this->displayLocale);
-        while (\array_pop($parts) && $parts) {
-            $locales[] = \implode('_', $parts);
-        }
-        $locales[] = self::DEFAULT_LOCALE;
-
-        foreach ($locales as $locale) {
+        foreach ($this->getLocales() as $locale) {
             if (isset($this->translations[$locale])) {
                 return $this->translations[$locale];
             }
         }
 
         return $this->shortName;
+    }
+
+    /**
+     * Returns the display locale and its fallback locales.
+     *
+     * @return array
+     */
+    protected function getLocales(): array {
+        $locales = [$this->displayLocale];
+        $parts = \explode('_', $this->displayLocale);
+        while (\array_pop($parts) && $parts) {
+            $locales[] = \implode('_', $parts);
+        }
+        $locales[] = self::DEFAULT_LOCALE;
+        return $locales;
     }
 
     /**

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -174,7 +174,8 @@ class Holiday extends DateTime implements JsonSerializable
      *
      * @return array
      */
-    protected function getLocales(): array {
+    protected function getLocales(): array
+    {
         $locales = [$this->displayLocale];
         $parts = \explode('_', $this->displayLocale);
         while (\array_pop($parts) && $parts) {

--- a/src/Yasumi/SubstituteHoliday.php
+++ b/src/Yasumi/SubstituteHoliday.php
@@ -87,11 +87,12 @@ class SubstituteHoliday extends Holiday
         $name = parent::getName();
 
         if ($name === $this->shortName) {
-            $pattern = $this->substituteHolidayTranslations[$this->displayLocale]
-                ?? $this->substituteHolidayTranslations[self::DEFAULT_LOCALE]
-                ?? $this->shortName;
-
-            $name = \str_replace('{0}', $this->substitutedHoliday->getName(), $pattern);
+            foreach ($this->getLocales() as $locale) {
+                $pattern = $this->substituteHolidayTranslations[$locale] ?? null;
+                if ($pattern) {
+                    return \str_replace('{0}', $this->substitutedHoliday->getName(), $pattern);
+                }
+            }
         }
 
         return $name;

--- a/tests/Base/SubstituteHolidayTest.php
+++ b/tests/Base/SubstituteHolidayTest.php
@@ -138,12 +138,35 @@ class SubstituteHolidayTest extends TestCase
         $translationsStub = $this->getMockBuilder(TranslationsInterface::class)->getMock();
         $translationsStub->expects($this->at(0))->method('getTranslations')->with($this->equalTo('substituteHoliday'))->willReturn([$locale => 'foo']);
         $translationsStub->expects($this->at(1))->method('getTranslations')->with($this->equalTo('substituteHoliday:testHoliday'))->willReturn([$locale => 'foo']);
-        $translationsStub->expects($this->at(2))->method('getTranslations')->with($this->equalTo('testHoliday'))->willReturn([$locale => 'foo']);
+        $translationsStub->expects($this->at(2))->method('getTranslations')->with($this->equalTo('testHoliday'))->willReturn(['en' => 'foo']);
 
         $substitute->mergeGlobalTranslations($translationsStub);
 
         $this->assertIsString($substitute->getName());
         $this->assertEquals($translation, $substitute->getName());
+    }
+
+    /**
+     * Tests the getName function of the SubstituteHoliday object when substitute holiday pattern uses fallback.
+     * @throws \Exception
+     */
+    public function testSubstituteHolidayGetNameWithPatternFallback(): void
+    {
+        $name        = 'testHoliday';
+        $translation = 'My Holiday';
+        $locale      = 'en_US';
+        $holiday     = new Holiday($name, [], new DateTime('2019-01-01'), $locale);
+        $substitute  = new SubstituteHoliday($holiday, [], new DateTime('2019-01-02'), $locale);
+
+        $translationsStub = $this->getMockBuilder(TranslationsInterface::class)->getMock();
+        $translationsStub->expects($this->at(0))->method('getTranslations')->with($this->equalTo('substituteHoliday'))->willReturn(['en' => '{0} obs']);
+        $translationsStub->expects($this->at(1))->method('getTranslations')->with($this->equalTo('substituteHoliday:testHoliday'))->willReturn([]);
+        $translationsStub->expects($this->at(2))->method('getTranslations')->with($this->equalTo('testHoliday'))->willReturn([$locale => $translation]);
+
+        $substitute->mergeGlobalTranslations($translationsStub);
+
+        $this->assertIsString($substitute->getName());
+        $this->assertEquals('My Holiday obs', $substitute->getName());
     }
 
     /**


### PR DESCRIPTION
Locale fallback for the substituteHoliday pattern does not work (my bad).

E.g. for en_GB, the name is currently “Foo Day observed”. The expected name is “Foo Day (substitute day)”.