### PR TITLE
Use fallback from DEAULT_LANGUAGE to 'en'

### DIFF
--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -181,7 +181,11 @@ class Holiday extends DateTime implements JsonSerializable
         while (\array_pop($parts) && $parts) {
             $locales[] = \implode('_', $parts);
         }
-        $locales[] = self::DEFAULT_LOCALE;
+
+        // DEFAULT_LOCALE is en_US
+        $locales[] = 'en_US';
+        $locales[] = 'en';
+
         return $locales;
     }
 

--- a/tests/Base/HolidayTest.php
+++ b/tests/Base/HolidayTest.php
@@ -122,9 +122,21 @@ class HolidayTest extends TestCase
     public function testHolidayGetNameWithOnlyDefaultTranslation(): void
     {
         $name = 'testHoliday';
+        $holiday = new Holiday($name, ['en' => 'Holiday EN', 'en_US' => 'Holiday EN-US'], new DateTime(), 'nl_NL');
+
+        $this->assertIsString($holiday->getName());
+        $this->assertEquals('Holiday EN-US', $holiday->getName());
+    }
+
+    /**
+     * Tests the getName function of the Holiday object with only a default translation for the name given.
+     * @throws Exception
+     */
+    public function testHolidayGetNameWithOnlyDefaultTranslationAndFallback(): void
+    {
+        $name = 'testHoliday';
         $translation = 'My Holiday';
-        $locale = 'en_US';
-        $holiday = new Holiday($name, [$locale => $translation], new DateTime(), $locale);
+        $holiday = new Holiday($name, ['en' => $translation], new DateTime(), 'nl_NL');
 
         $this->assertIsString($holiday->getName());
         $this->assertEquals($translation, $holiday->getName());


### PR DESCRIPTION
With the changes in #176, most translations for `en_US` have been replaces with a generic `en` translation.

The fallback to the parent locale works fine for providers created with `en_US` as display locale. But for providers with other locales (such as `it_IT`), the fallback to `DEFAULT_LANGUAGE` (if no Italian translation exists) only looks for a `en_US` and not the parent locale.

In other words, the lookup priority should be this:
  `it_IT` → `it` → `en_US` → `en` → `shortName`

But currently it is only this:
  `it_IT` → `it` → `en_US` → `shortName`
