### PR TITLE
Add Catalan translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ## [Unreleased]
 
 ### Added
+- Catalan translations for holidays in Catalonia, Valencian Community, Balearic Islands and Aragon [\#999](https://github.com/azuyalabs/yasumi/pull/999) ([pioc92](https://github.com/c960657))
 
 ### Changed
 

--- a/src/Yasumi/Provider/Spain.php
+++ b/src/Yasumi/Provider/Spain.php
@@ -85,7 +85,7 @@ class Spain extends AbstractProvider
                 'nationalDay',
                 [
                     'ca' => 'Festa Nacional d\'Espanya',
-                    'es' => 'Fiesta Nacional de España'
+                    'es' => 'Fiesta Nacional de España',
                 ],
                 new DateTime("$this->year-10-12", new DateTimeZone($this->timezone)),
                 $this->locale
@@ -114,7 +114,7 @@ class Spain extends AbstractProvider
                 'constitutionDay',
                 [
                     'ca' => 'Dia de la Constitució',
-                    'es' => 'Día de la Constitución'
+                    'es' => 'Día de la Constitución',
                 ],
                 new DateTime("$this->year-12-6", new DateTimeZone($this->timezone)),
                 $this->locale

--- a/src/Yasumi/Provider/Spain.php
+++ b/src/Yasumi/Provider/Spain.php
@@ -83,7 +83,10 @@ class Spain extends AbstractProvider
         if ($this->year >= 1981) {
             $this->addHoliday(new Holiday(
                 'nationalDay',
-                ['es' => 'Fiesta Nacional de España'],
+                [
+                    'ca' => 'Festa Nacional d\'Espanya',
+                    'es' => 'Fiesta Nacional de España'
+                ],
                 new DateTime("$this->year-10-12", new DateTimeZone($this->timezone)),
                 $this->locale
             ));
@@ -109,7 +112,10 @@ class Spain extends AbstractProvider
         if ($this->year >= 1978) {
             $this->addHoliday(new Holiday(
                 'constitutionDay',
-                ['es' => 'Día de la Constitución'],
+                [
+                    'ca' => 'Dia de la Constitució',
+                    'es' => 'Día de la Constitución'
+                ],
                 new DateTime("$this->year-12-6", new DateTimeZone($this->timezone)),
                 $this->locale
             ));

--- a/src/Yasumi/Provider/Spain/BalearicIslands.php
+++ b/src/Yasumi/Provider/Spain/BalearicIslands.php
@@ -80,7 +80,10 @@ class BalearicIslands extends Spain
         if ($this->year >= 1983) {
             $this->addHoliday(new Holiday(
                 'balearicIslandsDay',
-                ['es' => 'Día de les Illes Balears'],
+                [
+                    'ca' => 'Diada de les Illes Balears',
+                    'es' => 'Día de les Illes Balears',
+                ],
                 new DateTime("$this->year-3-1", new DateTimeZone($this->timezone)),
                 $this->locale
             ));

--- a/src/Yasumi/Provider/Spain/Catalonia.php
+++ b/src/Yasumi/Provider/Spain/Catalonia.php
@@ -83,7 +83,10 @@ class Catalonia extends Spain
         if ($this->year >= 1886) {
             $this->addHoliday(new Holiday(
                 'nationalCataloniaDay',
-                ['es' => 'Diada Nacional de Catalunya'],
+                [
+                    'ca' => 'Diada Nacional de Catalunya',
+                    'es' => 'Diada Nacional de Cataluña',
+                ],
                 new DateTime("$this->year-9-11", new DateTimeZone($this->timezone)),
                 $this->locale
             ));

--- a/src/Yasumi/Provider/Spain/ValencianCommunity.php
+++ b/src/Yasumi/Provider/Spain/ValencianCommunity.php
@@ -83,9 +83,15 @@ class ValencianCommunity extends Spain
     private function calculateValencianCommunityDay(): void
     {
         if ($this->year >= 1239) {
-            $this->addHoliday(new Holiday('valencianCommunityDay', [
-                'es' => 'Día de la Comunidad Valenciana',
-            ], new DateTime("$this->year-10-9", new DateTimeZone($this->timezone)), $this->locale));
+            $this->addHoliday(new Holiday(
+                'valencianCommunityDay',
+                [
+                    'ca' => 'Diada Nacional del País Valencià',
+                    'es' => 'Día de la Comunidad Valenciana',
+                ],
+                new DateTime("$this->year-10-9", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
         }
     }
 }

--- a/src/Yasumi/data/translations/allSaintsDay.php
+++ b/src/Yasumi/data/translations/allSaintsDay.php
@@ -12,6 +12,7 @@
 
 // Translations for All Saints' Day
 return [
+    'ca' => 'Dia de Tots Sants',
     'de' => 'Allerheiligen',
     'el' => 'Άγιοι Πάντες',
     'en' => 'All Saints\' Day',

--- a/src/Yasumi/data/translations/assumptionOfMary.php
+++ b/src/Yasumi/data/translations/assumptionOfMary.php
@@ -12,6 +12,7 @@
 
 // Translations for Assumption of Mary
 return [
+    'ca' => 'l\'Assumpció',
     'de' => 'Mariä Himmelfahrt',
     'el' => 'Κοίμηση της Θεοτόκου',
     'en' => 'Assumption of Mary',

--- a/src/Yasumi/data/translations/christmasDay.php
+++ b/src/Yasumi/data/translations/christmasDay.php
@@ -13,6 +13,7 @@
 // Translations for Christmas
 return [
     'bs_Latn' => 'Božić',
+    'ca' => 'Nadal',
     'cs' => '1. svátek vánoční',
     'cy' => 'Nadolig',
     'da' => 'Juledag',

--- a/src/Yasumi/data/translations/easter.php
+++ b/src/Yasumi/data/translations/easter.php
@@ -13,6 +13,7 @@
 // Translations for Easter Sunday
 return [
     'bs_Latn' => 'Uskrs',
+    'ca' => 'Pasqua',
     'cy' => 'Sul y Pasg',
     'da' => 'Påskedag',
     'de' => 'Ostersonntag',

--- a/src/Yasumi/data/translations/easterMonday.php
+++ b/src/Yasumi/data/translations/easterMonday.php
@@ -12,6 +12,7 @@
 
 // Translations for Easter Monday
 return [
+    'ca' => 'dilluns de Pasqua',
     'cs' => 'Velikonoční pondělí',
     'cy' => 'Llun y Pasg',
     'da' => '2. påskedag',

--- a/src/Yasumi/data/translations/epiphany.php
+++ b/src/Yasumi/data/translations/epiphany.php
@@ -12,6 +12,7 @@
 
 // Translations for Epiphany
 return [
+    'ca' => 'Epifania',
     'de_AT' => 'Heilige Drei Könige',
     'de_CH' => 'Heilige Drei Könige',
     'de' => 'Heilige 3 Könige',

--- a/src/Yasumi/data/translations/goodFriday.php
+++ b/src/Yasumi/data/translations/goodFriday.php
@@ -12,6 +12,7 @@
 
 // Translations for Good Friday
 return [
+    'ca' => 'Divendres Sant',
     'cs' => 'Velký pátek',
     'cy' => 'Gwener y Groglith',
     'da' => 'Langfredag',

--- a/src/Yasumi/data/translations/immaculateConception.php
+++ b/src/Yasumi/data/translations/immaculateConception.php
@@ -12,6 +12,7 @@
 
 // Translations for Immaculate Conception
 return [
+    'ca' => 'Immaculada Concepció',
     'de' => 'Mariä Empfängnis',
     'el' => 'Ευαγγελισμός της Θεοτόκου',
     'en' => 'Immaculate Conception',

--- a/src/Yasumi/data/translations/internationalWorkersDay.php
+++ b/src/Yasumi/data/translations/internationalWorkersDay.php
@@ -13,6 +13,7 @@
 // Translations for International Workers' Day
 return [
     'bs_Latn' => 'Praznik rada',
+    'ca' => 'Dia del Treball',
     'cs' => 'Svátek práce',
     'da' => 'Første maj',
     'de' => 'Tag der Arbeit',

--- a/src/Yasumi/data/translations/maundyThursday.php
+++ b/src/Yasumi/data/translations/maundyThursday.php
@@ -12,6 +12,7 @@
 
 // Translations for Maundy Thursday
 return [
+    'ca' => 'dijous Sant',
     'da' => 'Skærtorsdag',
     'el' => 'Μεγάλη Πέμπτη',
     'en' => 'Maundy Thursday',

--- a/src/Yasumi/data/translations/newYearsDay.php
+++ b/src/Yasumi/data/translations/newYearsDay.php
@@ -13,6 +13,7 @@
 // Translations for New Year's Day
 return [
     'bs_Latn' => 'Nova godina',
+    'ca' => 'Cap d\'any',
     'cs' => 'Nový rok',
     'cy' => 'Dydd Calan',
     'da' => 'Nytårsdag',

--- a/src/Yasumi/data/translations/stGeorgesDay.php
+++ b/src/Yasumi/data/translations/stGeorgesDay.php
@@ -12,6 +12,7 @@
 
 // Translations for St. George's Day
 return [
+    'ca' => 'Sant Jordi',
     'el' => 'Αγίου Γεωργίου',
     'en' => 'St. George\'s Day',
     'es' => 'San Jorge',

--- a/src/Yasumi/data/translations/stJohnsDay.php
+++ b/src/Yasumi/data/translations/stJohnsDay.php
@@ -12,6 +12,7 @@
 
 // Translations for St. John's Day
 return [
+    'ca' => 'Sant Joan',
     'da' => 'Sankthansaften',
     'el' => 'Σύναξις Προφήτου Προδρόμου και Βαπτιστού Ιωάννου',
     'en' => 'St. John\'s Day',

--- a/src/Yasumi/data/translations/stJosephsDay.php
+++ b/src/Yasumi/data/translations/stJosephsDay.php
@@ -12,6 +12,7 @@
 
 // Translations for St. Joseph's Day
 return [
+    'ca' => 'Sant Josep',
     'de' => 'Josephstag',
     'en' => 'St. Joseph\'s Day',
     'es' => 'San José',

--- a/src/Yasumi/data/translations/stStephensDay.php
+++ b/src/Yasumi/data/translations/stStephensDay.php
@@ -12,6 +12,7 @@
 
 // Translations for St. Stephen's Day
 return [
+    'ca' => 'Sant Esteve',
     'cy' => 'Gŵyl San Steffan',
     'de' => 'Stephanstag',
     'en' => 'St. Stephen\'s Day',

--- a/src/Yasumi/data/translations/valentinesDay.php
+++ b/src/Yasumi/data/translations/valentinesDay.php
@@ -12,6 +12,7 @@
 
 // Translations for Valentine's Day
 return [
+    'ca' => 'Dia de Sant Valentí',
     'de' => 'Valentinstag',
     'el' => 'Αγίου Βαλεντίνου',
     'en' => 'Valentine\'s Day',

--- a/tests/Spain/Catalonia/nationalCataloniaDayTest.php
+++ b/tests/Spain/Catalonia/nationalCataloniaDayTest.php
@@ -73,7 +73,10 @@ class nationalCataloniaDayTest extends CataloniaBaseTestCase implements YasumiTe
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            [self::LOCALE => 'Diada Nacional de Catalunya']
+            [
+                'es' => 'Diada Nacional de Cataluña',
+                'ca' => 'Diada Nacional de Catalunya',
+            ]
         );
     }
 


### PR DESCRIPTION
Catalan is an official language in the Spanish regions Catalonia, the Balearic Islands and Valencia.

This PR adds Catalan translations for the providers for these three regions.

I am not a Catalan speaker myself, so this work is based on Wikipedia etc.