### PR TITLE
Add AFL Grand Final Friday dates for 2019 / 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ## [Unreleased]
 
 ### Added
-
+- Additional Dates for Australia/Victoria:AFL Grand Final Friday  [\#190](https://github.com/azuyalabs/yasumi/pull/190) ([brucealdridge](https://github.com/brucealdridge))
 ### Changed
 
 ### Fixed

--- a/src/Yasumi/Provider/Australia/Victoria.php
+++ b/src/Yasumi/Provider/Australia/Victoria.php
@@ -198,7 +198,7 @@ class Victoria extends Australia
                 $aflGrandFinalFriday = '2019-09-27';
                 break;
             case 2020:
-                $aflGrandFinalFriday = '2018-09-25';
+                $aflGrandFinalFriday = '2020-09-25';
                 break;
             default:
                 return;

--- a/src/Yasumi/Provider/Australia/Victoria.php
+++ b/src/Yasumi/Provider/Australia/Victoria.php
@@ -194,6 +194,12 @@ class Victoria extends Australia
             case 2018:
                 $aflGrandFinalFriday = '2018-09-28';
                 break;
+            case 2019:
+                $aflGrandFinalFriday = '2019-09-27';
+                break;
+            case 2020:
+                $aflGrandFinalFriday = '2018-09-25';
+                break;
             default:
                 return;
         }

--- a/tests/Australia/Victoria/AFLGrandFinalFridayTest.php
+++ b/tests/Australia/Victoria/AFLGrandFinalFridayTest.php
@@ -30,7 +30,7 @@ class AFLGrandFinalFridayTest extends VictoriaBaseTestCase implements YasumiTest
     public const HOLIDAY = 'aflGrandFinalFriday';
 
     public const ESTABLISHMENT_YEAR = 2015;
-    public const LAST_KNOWN_YEAR = 2018;
+    public const LAST_KNOWN_YEAR = 2020;
 
     /**
      * Tests AFL Grand Final Friday
@@ -103,6 +103,8 @@ class AFLGrandFinalFridayTest extends VictoriaBaseTestCase implements YasumiTest
             [2016, '2016-09-30'],
             [2017, '2017-09-29'],
             [2018, '2018-09-28'],
+            [2019, '2019-09-27'],
+            [2020, '2020-09-25'],
         ];
 
         return $data;


### PR DESCRIPTION
sources
2019: https://www.timeanddate.com/holidays/australia/afl-grand-final-friday
2020: https://publicholidays.com.au/afl-grand-final-holiday/