### PR TITLE
Fix issue if calculated workday is in next year

### DIFF
--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -93,7 +93,7 @@ class Yasumi
 
         while ($workingDays > 0) {
             $date = $date->add(new \DateInterval('P1D'));
-            if (!$provider || (int)$date->format('Y') !== \getdate()['year']) {
+            if (!$provider || $provider->getYear() !== (int)$date->format('Y')) {
                 $provider = self::create($class, (int)$date->format('Y'));
             }
             if ($provider->isWorkingDay($date)) {

--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -93,7 +93,7 @@ class Yasumi
 
         while ($workingDays > 0) {
             $date = $date->add(new \DateInterval('P1D'));
-            if (!$provider || $provider->getYear() !== \getdate()['year']) {
+            if (!$provider || (int)$date->format('Y') !== \getdate()['year']) {
                 $provider = self::create($class, (int)$date->format('Y'));
             }
             if ($provider->isWorkingDay($date)) {


### PR DESCRIPTION
Currently, the year of the calculated date is not changed if it is in the next year.
When u try to get the next working day starting from 28.12.2019 and with 3 working days the calculated day is 1.1.2019 which is in the past.