### PR TITLE
Fix issue if calculated workday is in next year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Changed
 
 ### Fixed
+- Fixed issue if the next working day happens to be in the next year
 
 ### Removed
 - PHP 7.1 Support, as it has reached its end of life.

--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -92,7 +92,7 @@ class Yasumi
 
         while ($workingDays > 0) {
             $date = $date->add(new \DateInterval('P1D'));
-            if (! $provider instanceof ProviderInterface || $provider->getYear() !== \getdate()['year']) {
+            if (! $provider instanceof ProviderInterface || $provider->getYear() !== (int)$date->format('Y')) {
                 $provider = self::create($class, (int)$date->format('Y'));
             }
             if ($provider->isWorkingDay($date)) {

--- a/tests/Base/YasumiWorkdayTest.php
+++ b/tests/Base/YasumiWorkdayTest.php
@@ -153,9 +153,8 @@ class YasumiWorkdayTest extends TestCase
      * @param string $expectedNext
      * @throws ReflectionException
      * @throws Exception
-     * @group test
      */
-    public function testWorkdayIsNextYear(string $start, int $workdays, string $expectedNext): void
+    public function testWorkDayIsNextYear(string $start, int $workdays, string $expectedNext): void
     {
         $provider = 'USA';
         $timezone = 'America/New_York';

--- a/tests/Base/YasumiWorkdayTest.php
+++ b/tests/Base/YasumiWorkdayTest.php
@@ -180,7 +180,7 @@ class YasumiWorkdayTest extends TestCase
                 '2018-12-28',
                 2,
                 '2019-01-02',
-            ]
+            ],
         ];
     }
 }

--- a/tests/Base/YasumiWorkdayTest.php
+++ b/tests/Base/YasumiWorkdayTest.php
@@ -142,4 +142,45 @@ class YasumiWorkdayTest extends TestCase
         $result = Yasumi::prevWorkingDay($provider, $startDate, $interval);
         $this->assertEquals($expectedPrevious, $result->format(self::FORMAT_DATE));
     }
+
+
+    /**
+     * Tests when the next working day happens to be in the next year.
+     *
+     * @dataProvider dataProviderWorkDayNextYear
+     * @param string $start
+     * @param int $workdays
+     * @param string $expectedNext
+     * @throws ReflectionException
+     * @throws Exception
+     * @group test
+     */
+    public function testDeliveryDates(string $start, int $workdays, string $expectedNext): void
+    {
+        $provider = 'USA';
+        $timezone = 'America/New_York';
+        $startDate = new DateTime($start, new DateTimeZone($timezone));
+        $result = Yasumi::nextWorkingDay($provider, $startDate, $workdays);
+
+        $this->assertEquals($expectedNext, $result->format(self::FORMAT_DATE));
+    }
+
+    /**
+     * @return array
+     */
+    public function dataProviderWorkDayNextYear(): array
+    {
+        return [
+            [
+                '2019-12-30',
+                2,
+                '2020-01-02',
+            ],
+            [
+                '2018-12-28',
+                2,
+                '2019-01-02',
+            ]
+        ];
+    }
 }

--- a/tests/Base/YasumiWorkdayTest.php
+++ b/tests/Base/YasumiWorkdayTest.php
@@ -155,7 +155,7 @@ class YasumiWorkdayTest extends TestCase
      * @throws Exception
      * @group test
      */
-    public function testDeliveryDates(string $start, int $workdays, string $expectedNext): void
+    public function testWorkdayIsNextYear(string $start, int $workdays, string $expectedNext): void
     {
         $provider = 'USA';
         $timezone = 'America/New_York';


### PR DESCRIPTION
Currently, the year of the calculated date is not changed if it is in the next year.
When u try to get the next working day starting from 28.12.2019 and with 3 working days the calculated day is 1.1.2019 which is in the past.