### PR TITLE
Locale override for getName() (with multiple fallbacks)

### DIFF
--- a/src/Yasumi/Exception/MissingTranslationException.php
+++ b/src/Yasumi/Exception/MissingTranslationException.php
@@ -23,7 +23,7 @@ class MissingTranslationException extends BaseException implements Exception
      * Initializes the Exception instance
      *
      * @param string $shortName The short name (internal name) of the holiday
-     * @param string $locales   The locales that was searched
+     * @param array  $locales   The locales that was searched
      */
     public function __construct(string $shortName, array $locales)
     {

--- a/src/Yasumi/Exception/MissingTranslationException.php
+++ b/src/Yasumi/Exception/MissingTranslationException.php
@@ -27,6 +27,6 @@ class MissingTranslationException extends BaseException implements Exception
      */
     public function __construct(string $shortName, array $locales)
     {
-        parent::__construct(\sprintf("Translation for '%s' not found for any locale: '%s'", $shortName, \implode($locales, "', '")));
+        parent::__construct(\sprintf("Translation for '%s' not found for any locale: '%s'", $shortName, \implode("', '", $locales)));
     }
 }

--- a/src/Yasumi/Exception/MissingTranslationException.php
+++ b/src/Yasumi/Exception/MissingTranslationException.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\Exception;
+
+use Exception as BaseException;
+
+/**
+ * Class MissingTranslationException.
+ */
+class MissingTranslationException extends BaseException implements Exception
+{
+    /**
+     * Initializes the Exception instance
+     *
+     * @param string $shortName The short name (internal name) of the holiday
+     * @param string $locales   The locales that was searched
+     */
+    public function __construct(string $shortName, array $locales)
+    {
+        parent::__construct(\sprintf("Translation for '%s' not found for any locale: '%s'", $shortName, \implode($locales, "', '")));
+    }
+}

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -16,6 +16,7 @@ use DateTime;
 use InvalidArgumentException;
 use JsonSerializable;
 use Yasumi\Exception\InvalidDateException;
+use Yasumi\Exception\MissingTranslationException;
 use Yasumi\Exception\UnknownLocaleException;
 
 /**
@@ -52,6 +53,11 @@ class Holiday extends DateTime implements JsonSerializable
      * The default locale. Used for translations of holiday names and other text strings.
      */
     public const DEFAULT_LOCALE = 'en_US';
+
+    /**
+     * Pseudo-locale representing the short name (internal name) of the holiday.
+     */
+    public const LOCALE_SHORT_NAME = 'shortName';
 
     /**
      * @var array list of all defined locales
@@ -152,49 +158,75 @@ class Holiday extends DateTime implements JsonSerializable
     }
 
     /**
-     * Returns the name of this holiday.
+     * Returns the localized name of this holiday
      *
-     * The name of this holiday is returned translated in the given locale. If for the given locale no translation is
-     * defined, the name in the default locale ('en_US') is returned. In case there is no translation at all, the short
-     * internal name is returned.
+     * The provided locales are searched for a translation. The first locale containing a translation will be used.
      *
-     * @param string $locale the locale to use; if omitted, the display locale is used
+     * If no locale is provided, proceed as if an array containing the display locale, Holiday::DEFAULT_LOCALE ('en_US'), and
+     * Holiday::LOCALE_SHORT_NAME (the short name (internal name) of this holiday) was provided.
+     *
+     * @param array $locales The locales to search for translations
+     *
+     * @see Holiday::DEFAULT_LOCALE
+     * @see Holiday::LOCALE_SHORT_NAME
      */
-    public function getName(string $locale = null): string
+    public function getName(array $locales = null): string
     {
-        foreach ($this->getLocales($locale) as $locale) {
+        $locales = $this->getLocales($locales);
+        foreach ($locales as $locale) {
+            if ($locale === self::LOCALE_SHORT_NAME) {
+                return $this->shortName;
+            }
             if (isset($this->translations[$locale])) {
                 return $this->translations[$locale];
             }
         }
 
-        return $this->shortName;
+        throw new MissingTranslationException($this->shortName, $locales);
     }
 
     /**
-     * Returns the display locale and its fallback locales.
+     * Expands the provided locale into an array of locales to check for translations.
      *
-     * @param string $locale the locale to use; if omitted, the display locale is used
+     * For each provided locale, return all locales including their parent locales. E.g.
+     * ['ca_ES_VALENCIA', 'es_ES'] is expanded into ['ca_ES_VALENCIA', 'ca_ES', 'ca', 'es_ES', 'es'].
+     *
+     * If a string is provided, return as if this string, Holiday::DEFAULT_LOCALE, and Holiday::LOCALE_SHORT_NAM
+     * was provided. E.g. 'de_DE' is expanded into ['de_DE', 'de', 'en_US', 'en', Holiday::LOCALE_SHORT_NAME].
+     *
+     * If null is provided, return as if the display locale was provided as a string.
+     *
+     * @param string|array|null Array of locales, or null if the display locale should be used
      *
      * @return array
+     *
+     * @throws MissingTranslationException
+     *
+     * @see Holiday::DEFAULT_LOCALE
+     * @see Holiday::LOCALE_SHORT_NAME
      */
-    protected function getLocales(?string $locale): array
+    protected function getLocales(?array $locales): array
     {
-        if (!$locale) {
-            $locale = $this->displayLocale;
+        if ($locales) {
+            $expanded = [];
+            $locales = $locales;
+        } else {
+            $locales = [$this->displayLocale];
+            // DEFAULT_LOCALE is 'en_US', and its parent is 'en'.
+            $expanded = [self::LOCALE_SHORT_NAME, 'en', 'en_US'];
         }
 
-        $locales = [$locale];
-        $parts = \explode('_', $locale);
-        while (\array_pop($parts) && $parts) {
-            $locales[] = \implode('_', $parts);
+        // Expand e.g. ['de_DE', 'en_GB'] into  ['de_DE', 'de', 'en_GB', 'en'].
+        foreach (\array_reverse($locales) as $locale) {
+            $parent = \strtok($locale, '_');
+            while ($child = \strtok('_')) {
+                $expanded[] = $parent;
+                $parent .= '_' . $child;
+            }
+            $expanded[] = $locale;
         }
 
-        // DEFAULT_LOCALE is en_US
-        $locales[] = 'en_US';
-        $locales[] = 'en';
-
-        return $locales;
+        return \array_reverse($expanded);
     }
 
     /**

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -157,10 +157,12 @@ class Holiday extends DateTime implements JsonSerializable
      * The name of this holiday is returned translated in the given locale. If for the given locale no translation is
      * defined, the name in the default locale ('en_US') is returned. In case there is no translation at all, the short
      * internal name is returned.
+     *
+     * @param string $locale the locale to use; if omitted, the display locale is used
      */
-    public function getName(): string
+    public function getName(string $locale = null): string
     {
-        foreach ($this->getLocales() as $locale) {
+        foreach ($this->getLocales($locale) as $locale) {
             if (isset($this->translations[$locale])) {
                 return $this->translations[$locale];
             }
@@ -172,12 +174,18 @@ class Holiday extends DateTime implements JsonSerializable
     /**
      * Returns the display locale and its fallback locales.
      *
+     * @param string $locale the locale to use; if omitted, the display locale is used
+     *
      * @return array
      */
-    protected function getLocales(): array
+    protected function getLocales(?string $locale): array
     {
-        $locales = [$this->displayLocale];
-        $parts = \explode('_', $this->displayLocale);
+        if (!$locale) {
+            $locale = $this->displayLocale;
+        }
+
+        $locales = [$locale];
+        $parts = \explode('_', $locale);
         while (\array_pop($parts) && $parts) {
             $locales[] = \implode('_', $parts);
         }

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -198,7 +198,7 @@ class Holiday extends DateTime implements JsonSerializable
      *
      * If null is provided, return as if the display locale was provided as a string.
      *
-     * @param array Array of locales, or null if the display locale should be used
+     * @param array $locales Array of locales, or null if the display locale should be used
      *
      * @return array
      *

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -167,6 +167,8 @@ class Holiday extends DateTime implements JsonSerializable
      *
      * @param array $locales The locales to search for translations
      *
+     * @throws MissingTranslationException
+     *
      * @see Holiday::DEFAULT_LOCALE
      * @see Holiday::LOCALE_SHORT_NAME
      */
@@ -196,11 +198,9 @@ class Holiday extends DateTime implements JsonSerializable
      *
      * If null is provided, return as if the display locale was provided as a string.
      *
-     * @param string|array|null Array of locales, or null if the display locale should be used
+     * @param array Array of locales, or null if the display locale should be used
      *
      * @return array
-     *
-     * @throws MissingTranslationException
      *
      * @see Holiday::DEFAULT_LOCALE
      * @see Holiday::LOCALE_SHORT_NAME

--- a/src/Yasumi/SubstituteHoliday.php
+++ b/src/Yasumi/SubstituteHoliday.php
@@ -13,6 +13,7 @@
 namespace Yasumi;
 
 use Yasumi\Exception\InvalidDateException;
+use Yasumi\Exception\MissingTranslationException;
 use Yasumi\Exception\UnknownLocaleException;
 
 /**
@@ -90,13 +91,13 @@ class SubstituteHoliday extends Holiday
      * @see Holiday::DEFAULT_LOCALE
      * @see Holiday::LOCALE_SHORT_NAME
      */
-    public function getName($locale = null): string
+    public function getName($locales = null): string
     {
         $name = parent::getName();
 
         if ($name === $this->shortName) {
-            foreach ($this->getLocales($locale) as $locale) {
-                $pattern = $this->substituteHolidayTranslations[$locale] ?? null;
+            foreach ($this->getLocales($locales) as $locales) {
+                $pattern = $this->substituteHolidayTranslations[$locales] ?? null;
                 if ($pattern) {
                     return \str_replace('{0}', $this->substitutedHoliday->getName(), $pattern);
                 }

--- a/src/Yasumi/SubstituteHoliday.php
+++ b/src/Yasumi/SubstituteHoliday.php
@@ -76,14 +76,16 @@ class SubstituteHoliday extends Holiday
     }
 
     /**
-     * Returns the localized name of this holiday for the specified locale(s).
+     * Returns the localized name of this holiday
      *
-     * If no locale is provided, return as if the display locale was provided as a string.
+     * The provided locales are searched for a translation. The first locale containing a translation will be used.
      *
-     * If a string or no locale is provided, additionally fall back to Holiday::DEFAULT_LOCALE ('en_US') and
-     * Holiday::LOCALE_SHORT_NAME (the short name (internal name) of this holiday).
+     * If no locale is provided, proceed as if an array containing the display locale, Holiday::DEFAULT_LOCALE ('en_US'), and
+     * Holiday::LOCALE_SHORT_NAME (the short name (internal name) of this holiday) was provided.
      *
-     * @param string|array $locales the locale(s) to use; if omitted, the display locale is used
+     * @param array $locales The locales to search for translations
+     *
+     * @throws MissingTranslationException
      *
      * @see Holiday::DEFAULT_LOCALE
      * @see Holiday::LOCALE_SHORT_NAME

--- a/src/Yasumi/SubstituteHoliday.php
+++ b/src/Yasumi/SubstituteHoliday.php
@@ -81,13 +81,15 @@ class SubstituteHoliday extends Holiday
      * The name of this holiday is returned translated in the given locale. If for the given locale no translation is
      * defined, the name in the default locale ('en_US') is returned. In case there is no translation at all, the short
      * internal name is returned.
+     *
+     * @param string $locale the locale to use; if omitted, the display locale is used
      */
-    public function getName(): string
+    public function getName(string $locale = null): string
     {
         $name = parent::getName();
 
         if ($name === $this->shortName) {
-            foreach ($this->getLocales() as $locale) {
+            foreach ($this->getLocales($locale) as $locale) {
                 $pattern = $this->substituteHolidayTranslations[$locale] ?? null;
                 if ($pattern) {
                     return \str_replace('{0}', $this->substitutedHoliday->getName(), $pattern);

--- a/src/Yasumi/SubstituteHoliday.php
+++ b/src/Yasumi/SubstituteHoliday.php
@@ -76,15 +76,19 @@ class SubstituteHoliday extends Holiday
     }
 
     /**
-     * Returns the name of this holiday.
+     * Returns the localized name of this holiday for the specified locale(s).
      *
-     * The name of this holiday is returned translated in the given locale. If for the given locale no translation is
-     * defined, the name in the default locale ('en_US') is returned. In case there is no translation at all, the short
-     * internal name is returned.
+     * If no locale is provided, return as if the display locale was provided as a string.
      *
-     * @param string $locale the locale to use; if omitted, the display locale is used
+     * If a string or no locale is provided, additionally fall back to Holiday::DEFAULT_LOCALE ('en_US') and
+     * Holiday::LOCALE_SHORT_NAME (the short name (internal name) of this holiday).
+     *
+     * @param string|array $locales the locale(s) to use; if omitted, the display locale is used
+     *
+     * @see Holiday::DEFAULT_LOCALE
+     * @see Holiday::LOCALE_SHORT_NAME
      */
-    public function getName(string $locale = null): string
+    public function getName($locale = null): string
     {
         $name = parent::getName();
 

--- a/tests/Base/HolidayTest.php
+++ b/tests/Base/HolidayTest.php
@@ -89,73 +89,112 @@ class HolidayTest extends TestCase
     }
 
     /**
-     * Tests the getName function of the Holiday object with no translations for the name given.
-     * @throws Exception
-     */
-    public function testHolidayGetNameWithNoTranslations(): void
-    {
-        $name = 'testHoliday';
-        $holiday = new Holiday($name, [], new DateTime(), 'en_US');
-
-        $this->assertIsString($holiday->getName());
-        $this->assertEquals($name, $holiday->getName());
-    }
-
-    /**
-     * Tests the getName function of the Holiday object with only a parent translation for the name given.
+     * Tests the getName function of the Holiday object with parent translation fallback.
      * @throws Exception
      */
     public function testHolidayGetNameWithParentLocaleTranslation(): void
     {
-        $name = 'testHoliday';
-        $translation = 'My Holiday';
-        $holiday = new Holiday($name, ['de' => $translation], new DateTime(), 'de_DE');
+        $translations = [
+            'de' => 'Holiday DE',
+            'de_AT' => 'Holiday DE-AT',
+            'nl' => 'Holiday NL',
+            'it_IT' => 'Holiday IT-IT',
+            'en_US' => 'Holiday EN-US',
+        ];
+        $holiday = new Holiday('testHoliday', $translations, new DateTime(), 'de_DE');
 
-        $this->assertIsString($holiday->getName());
-        $this->assertEquals($translation, $holiday->getName());
+        $this->assertEquals('Holiday DE', $holiday->getName());
+        $this->assertEquals('Holiday DE', $holiday->getName('de'));
+        $this->assertEquals('Holiday DE', $holiday->getName('de_DE'));
+        $this->assertEquals('Holiday DE', $holiday->getName('de_DE_berlin'));
+        $this->assertEquals('Holiday DE-AT', $holiday->getName('de_AT'));
+        $this->assertEquals('Holiday DE-AT', $holiday->getName('de_AT_vienna'));
+        $this->assertEquals('Holiday NL', $holiday->getName('nl'));
+        $this->assertEquals('Holiday NL', $holiday->getName('nl_NL'));
+        $this->assertEquals('Holiday IT-IT', $holiday->getName('it_IT'));
+        $this->assertEquals('Holiday EN-US', $holiday->getName('it'));
+        $this->assertEquals('Holiday EN-US', $holiday->getName('da'));
     }
 
     /**
-     * Tests the getName function of the Holiday object with only a default translation for the name given.
+     * Tests the getName function of the Holiday object with no translation for the display locale.
      * @throws Exception
      */
-    public function testHolidayGetNameWithOnlyDefaultTranslation(): void
+    public function testHolidayGetNameWithoutDisplayLocaleTranslation(): void
     {
-        $name = 'testHoliday';
-        $holiday = new Holiday($name, ['en' => 'Holiday EN', 'en_US' => 'Holiday EN-US'], new DateTime(), 'nl_NL');
+        $translations = [
+            'en_US' => 'Holiday EN-US',
+            'de_DE' => 'Holiday DE-DE',
+        ];
+        $holiday = new Holiday('testHoliday', $translations, new DateTime(), 'ja_JP');
 
-        $this->assertIsString($holiday->getName());
         $this->assertEquals('Holiday EN-US', $holiday->getName());
+        $this->assertEquals('Holiday EN-US', $holiday->getName('ja_JP'));
+        $this->assertEquals('Holiday EN-US', $holiday->getName('de'));
+        $this->assertEquals('Holiday DE-DE', $holiday->getName('de_DE'));
+        $this->assertEquals('Holiday EN-US', $holiday->getName('en_US'));
     }
 
     /**
-     * Tests the getName function of the Holiday object with only a default translation for the name given.
+     * Tests the getName function of the Holiday object with no translations.
      * @throws Exception
      */
-    public function testHolidayGetNameWithOnlyDefaultTranslationAndFallback(): void
+    public function testHolidayGetNameWithNoFallback(): void
     {
-        $name = 'testHoliday';
-        $translation = 'My Holiday';
-        $holiday = new Holiday($name, ['en' => $translation], new DateTime(), 'nl_NL');
+        $holiday = new Holiday('testHoliday', [], new DateTime(), 'ja_JP');
 
-        $this->assertIsString($holiday->getName());
-        $this->assertEquals($translation, $holiday->getName());
+        $this->assertEquals('testHoliday', $holiday->getName());
+        $this->assertEquals('testHoliday', $holiday->getName('en'));
+        $this->assertEquals('testHoliday', $holiday->getName('en_US'));
+        $this->assertEquals('testHoliday', $holiday->getName('ja_JP'));
     }
 
     /**
-     * Tests the getName function of the Holiday object with only a default translation for the name given.
+     * Tests the getName function of the Holiday object with an 'en_US' fallback translation.
      *
      * @throws Exception
      */
-    public function testHolidayGetNameWithOneNonDefaultTranslation(): void
+    public function testHolidayGetNameWithEnUsFallback(): void
     {
         $name = 'testHoliday';
-        $translation = 'My Holiday';
-        $holiday = new Holiday($name, ['en_US' => $translation], new DateTime(), 'nl_NL');
+        $holiday = new Holiday($name, [
+            'en' => 'Holiday EN',
+            'en_US' => 'Holiday EN-US',
+            'de_DE' => 'Holiday DE',
+        ], new DateTime(), 'de_DE');
 
         $this->assertNotNull($holiday->getName());
         $this->assertIsString($holiday->getName());
-        $this->assertEquals($translation, $holiday->getName());
+        $this->assertEquals('Holiday DE', $holiday->getName());
+        $this->assertEquals('Holiday EN-US', $holiday->getName('de'));
+        $this->assertEquals('Holiday DE', $holiday->getName('de_DE'));
+        $this->assertEquals('Holiday EN-US', $holiday->getName('nl_NL'));
+        $this->assertEquals('Holiday EN', $holiday->getName('en'));
+        $this->assertEquals('Holiday EN-US', $holiday->getName('en_US'));
+        $this->assertEquals('Holiday EN-US', $holiday->getName('en-GB'));
+    }
+
+    /**
+     * Tests the getName function of the Holiday object with an 'en' fallback translation.
+     *
+     * @throws Exception
+     */
+    public function testHolidayGetNameWithEnFallback(): void
+    {
+        $translations = [
+            'en' => 'Holiday EN',
+            'en_GB' => 'Holiday EN-GB',
+            'de_DE' => 'Holiday DE',
+        ];
+        $holiday = new Holiday('testHoliday', $translations, new DateTime(), 'de_DE');
+
+        $this->assertEquals('Holiday DE', $holiday->getName());
+        $this->assertEquals('Holiday EN', $holiday->getName('de'));
+        $this->assertEquals('Holiday DE', $holiday->getName('de_DE'));
+        $this->assertEquals('Holiday EN', $holiday->getName('nl_NL'));
+        $this->assertEquals('Holiday EN', $holiday->getName('en'));
+        $this->assertEquals('Holiday EN', $holiday->getName('en_US'));
+        $this->assertEquals('Holiday EN-GB', $holiday->getName('en_GB'));
     }
 
     /**


### PR DESCRIPTION
_This PR is an alternative to #184. This PR additionally adds support for multiple fallback locales._

Sometimes you need multiple translations for the same holiday. 

Pre v2.2.0 you could easily access all translations in `$holiday->translations`. With the introduction of locale fallback in #176, things got more complicated, especially with substitute holidays (introduced in #162), so accessing the `translations` property is difficult.

I suggest adding an optional `$locales` parameter to `$holiday->getName()`. This allows passing an array of locales to be searched for translations. E.g if `['es_ES', 'de_AT']` is provided, the following lookup priority is used: `es_ES` → `es` → `de_AT` → `de`.

If no parameter is provided, use the display locale with fallback to `DEFAULT_LOCALE` and the short name. E.g. if the display locale is `es_ES`, the following lookup priority is used: `es_ES` → `es` → `en_US` → `en` → _short name_.

Note that when providing the optional `$locales` parameter, `DEFAULT_LOCALE` and the short name is not used as fallbacks unless explicitly requested. This offers the user better control over fallback behaviour while preserving backwards compatibility.

Parent locales (e.g. `de` is the parent locale of `de_AT`) are always used, even when not specified explicitly. Parent locales are not considered a “fallback”. Instead, all strings in a parent locale are considered to be identical in the child locales unless explicitly overridden. I believe this convention is also used elsewhere, e.g. in CLDR.
