### PR TITLE
One-time holiday: Day of Liberation, 2020-05-08, Berlin, Germany

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ## [Unreleased]
 
 ### Added
+- Day of Liberation (Tag der Befreiung) is an one-time official holiday in 2020 in Berlin (Germany).
 
 ### Changed
 

--- a/src/Yasumi/Provider/Germany/Berlin.php
+++ b/src/Yasumi/Provider/Germany/Berlin.php
@@ -12,6 +12,9 @@
 
 namespace Yasumi\Provider\Germany;
 
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Provider\Germany;
@@ -49,5 +52,43 @@ class Berlin extends Germany
         if ($this->year >= 2019) {
             $this->addHoliday($this->internationalWomensDay($this->year, $this->timezone, $this->locale));
         }
+
+        if ($this->year == 2020) {
+            $this->addHoliday($this->dayOfLiberation($this->timezone, $this->locale));
+        }
+    }
+
+    /**
+     * Day of Liberation
+     *
+     * Day of Liberation (Tag der Befreiung) is celebrated on May 8 2020 to commemorate the 75th anniversary
+     * of the German Instrument of Surrender.
+     *
+     * @link https://de.wikipedia.org/wiki/Tag_der_Befreiung
+     *
+     * @param string $timezone the timezone in which Day of Liberation is celebrated
+     * @param string $locale the locale for which Day of Liberation needs to be displayed in.
+     * @param string $type The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @return Holiday
+     *
+     * @throws InvalidDateException
+     * @throws UnknownLocaleException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    public function dayOfLiberation(
+        string $timezone,
+        string $locale,
+        string $type = Holiday::TYPE_OFFICIAL
+    ): Holiday {
+        return new Holiday(
+            'dayOfLiberation',
+            [],
+            new DateTime("2020-05-08", new DateTimeZone($timezone)),
+            $locale,
+            $type
+        );
     }
 }

--- a/src/Yasumi/Provider/Germany/Berlin.php
+++ b/src/Yasumi/Provider/Germany/Berlin.php
@@ -14,9 +14,9 @@ namespace Yasumi\Provider\Germany;
 
 use DateTime;
 use DateTimeZone;
-use Yasumi\Holiday;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
+use Yasumi\Holiday;
 use Yasumi\Provider\Germany;
 
 /**
@@ -86,7 +86,7 @@ class Berlin extends Germany
         return new Holiday(
             'dayOfLiberation',
             [],
-            new DateTime("2020-05-08", new DateTimeZone($timezone)),
+            new DateTime('2020-05-08', new DateTimeZone($timezone)),
             $locale,
             $type
         );

--- a/src/Yasumi/data/translations/dayOfLiberation.php
+++ b/src/Yasumi/data/translations/dayOfLiberation.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+// Translations for Day of Liberation
+return [
+    'de' => 'Tag der Befreiung',
+    'en' => 'Day of Liberation'
+];

--- a/src/Yasumi/data/translations/dayOfLiberation.php
+++ b/src/Yasumi/data/translations/dayOfLiberation.php
@@ -13,5 +13,5 @@
 // Translations for Day of Liberation
 return [
     'de' => 'Tag der Befreiung',
-    'en' => 'Day of Liberation'
+    'en' => 'Day of Liberation',
 ];

--- a/tests/Germany/Berlin/DayOfLiberation2020Test.php
+++ b/tests/Germany/Berlin/DayOfLiberation2020Test.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2019 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\Germany\Berlin;
+
+use DateTime;
+use DateTimeZone;
+use Exception;
+use ReflectionException;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing Day of Liberation 2020 in Berlin (Germany).
+ */
+class DayOfLiberation2020Test extends BerlinBaseTestCase implements YasumiTestCaseInterface
+{
+	/**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'dayOfLiberation';
+
+    /**
+     * The year in which the holiday takes place
+     */
+    public const YEAR = 2020;
+
+    /**
+     * Test the holiday defined in this test
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function testHolidayInYear()
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            self::YEAR,
+            new DateTime(self::YEAR . '-05-08', new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Test the holiday defined in this test in the years before
+     * @throws ReflectionException
+     */
+    public function testHolidayBeforeYear()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::YEAR - 1)
+        );
+    }
+
+    /**
+     * Test the holiday defined in this test in the years after
+     * @throws ReflectionException
+     */
+    public function testHolidayAfterYear()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::YEAR + 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            self::YEAR,
+            [self::LOCALE => 'Tag der Befreiung']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            self::YEAR,
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Germany/Berlin/DayOfLiberation2020Test.php
+++ b/tests/Germany/Berlin/DayOfLiberation2020Test.php
@@ -24,7 +24,7 @@ use Yasumi\tests\YasumiTestCaseInterface;
  */
 class DayOfLiberation2020Test extends BerlinBaseTestCase implements YasumiTestCaseInterface
 {
-	/**
+    /**
      * The name of the holiday to be tested
      */
     public const HOLIDAY = 'dayOfLiberation';


### PR DESCRIPTION
Berlin (Germany) has a one-time official holiday in 2020 on the 8th may.

Sources (unfortunately only in german):

> In Berlin wird der 75. Jahrestag am 8. Mai 2020 einmalig ein gesetzlicher Feiertag sein.
https://de.wikipedia.org/wiki/Tag_der_Befreiung

> Darin ist auch festgelegt, dass der 75. Jahrestag der Befreiung vom Nationalsozialismus am 8. Mai 2020 in der Hauptstadt einmalig als arbeitsfreier Feiertag begangen wird.
https://archiv.berliner-zeitung.de/berlin/parlamentsbeschluss-der-8--maerz-ist-nun-offiziell-ein-berliner-feiertag-31927822

> 8. Mai 2020: Berlin bekommt zusätzlichen Feiertag
https://www.berlin.de/special/jobs-und-ausbildung/nachrichten/berlin/5616720-5510939-8-mai-2020-feiertag-in-berlin.html