### PR TITLE
update ukraine holidays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - Holiday providers for states of Austria. [\#182](https://github.com/azuyalabs/yasumi/pull/182) ([aprog](https://github.com/aprog))
 - Added missing return (correct) and parameter types in various methods.
 - Day of Liberation (Tag der Befreiung) is an one-time official holiday in 2020 in Berlin (Germany).
+- Catholic Christmas Day is a new official holiday since 2017 in the Ukraine. [\#202](https://github.com/azuyalabs/yasumi/pull/202)
 
 ### Changed
 - Holiday names in Danish, Dutch, and Norwegian are no longer capitalized. [\#185](https://github.com/azuyalabs/yasumi/pull/185) ([c960657](https://github.com/c960657))
@@ -21,12 +22,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - Refactored various conditional structures.
 - Changed signature of some methods as parameters with defaults should come after required parameters.
 - Updated third party dependencies.
+- Second International Workers Day was an official holiday only until 2018. [\#202](https://github.com/azuyalabs/yasumi/pull/202)
 
 ### Fixed
 - Fixed issue if the next working day happens to be in the next year  (i.e. not in the year of the Yasumi instance) [\#192](https://github.com/azuyalabs/yasumi/issues/192) ([tniemann](https://github.com/tniemann))
 - Fixed issue if the previous working day happens to be in the previous year (i.e. not in the year of the Yasumi instance)
 - Fix locale fallback for substitute holidays [\#180](https://github.com/azuyalabs/yasumi/pull/180) ([c960657](https://github.com/c960657))
 - Fixed compound conditions that are always true by simplifying the condition steps.
+- Fixed Ukraine holidays on weekends. These days need to be substituted. [\#202](https://github.com/azuyalabs/yasumi/pull/202)
 
 ### Removed
 - PHP 7.1 Support, as it has reached its end of life.

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Yasumi package.
  *
@@ -76,7 +78,7 @@ class Holiday extends DateTime implements JsonSerializable
     /**
      * @var string Locale (i.e. language) in which the holiday information needs to be displayed in. (Default 'en_US')
      */
-    protected $displayLocale;
+    public $displayLocale;
 
     /**
      * Creates a new Holiday.

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -1,6 +1,5 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
 /**
  * This file is part of the Yasumi package.
  *
@@ -78,7 +77,7 @@ class Holiday extends DateTime implements JsonSerializable
     /**
      * @var string Locale (i.e. language) in which the holiday information needs to be displayed in. (Default 'en_US')
      */
-    public $displayLocale;
+    protected $displayLocale;
 
     /**
      * Creates a new Holiday.

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -75,6 +75,11 @@ class Ukraine extends AbstractProvider
      * @param Holiday $holiday Holiday instance (representing a holiday) to be added to the internal list
      *                         of holidays of this country.
      * @param bool $substitutable Holidays on a weekend will be substituted to the next monday.
+     * 
+     * @throws InvalidDateException
+     * @throws UnknownLocaleException
+     * @throws \InvalidArgumentException
+     * @throws \Exception
      */
     public function addHoliday(Holiday $holiday, bool $substitutable = true): void
     {

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -1,6 +1,5 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
 /**
  * This file is part of the Yasumi package.
  *
@@ -39,13 +38,6 @@ class Ukraine extends AbstractProvider
     public const ID = 'UA';
 
     /**
-     * Type definition for postponed holidays due to weekend holidays.
-     * Normally holidays on a weekend will be postponed to monday.
-     * These mondays will get this type.
-     */
-    public const TYPE_POSTPONED = 'postponed';
-
-    /**
      * Initialize holidays for Ukraine.
      *
      * @throws InvalidDateException
@@ -58,7 +50,7 @@ class Ukraine extends AbstractProvider
         $this->timezone = 'Europe/Kiev';
 
         // Add common holidays
-        // New Years Day will not be postponed to an monday if it's on a weekend!
+        // New Years Day will not be substituted to an monday if it's on a weekend!
         $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale), false);
         $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->internationalWomensDay($this->year, $this->timezone, $this->locale));
@@ -69,6 +61,7 @@ class Ukraine extends AbstractProvider
 
         // Add other holidays
         $this->calculateChristmasDay();
+        $this->calculateSecondInternationalWorkersDay();
         $this->calculateVictoryDay();
         $this->calculateConstitutionDay();
         $this->calculateIndependenceDay();
@@ -81,73 +74,27 @@ class Ukraine extends AbstractProvider
      *
      * @param Holiday $holiday Holiday instance (representing a holiday) to be added to the internal list
      *                         of holidays of this country.
-     * @param bool $postpone Holidays on a weekend will be postponed to the next monday.
-     * @param bool $addOnlyPostpone If $postpone is true add holidays on a weekend on the postponed day.
+     * @param bool $substitutable Holidays on a weekend will be substituted to the next monday.
      */
-    public function addHoliday(Holiday $holiday, bool $postpone = true, bool $addOnlyPostpone = false): void
+    public function addHoliday(Holiday $holiday, bool $substitutable = true): void
     {
-        if (!$postpone || !$this->isWeekendDay($holiday)) {
-            parent::addHoliday($holiday);
-            return;
+        parent::addHoliday($holiday);
+
+        if (!$substitutable) return;
+
+        // Substitute holiday is on the next available weekday
+        // if a holiday falls on a Saturday or Sunday.
+        if ($this->isWeekendDay($holiday)) {
+            $date = clone $holiday;
+            $date->modify('next monday');
+
+            parent::addHoliday(new SubstituteHoliday(
+                $holiday,
+                [],
+                $date,
+                $this->locale
+            ));
         }
-
-        // Special case: Holiday on a weekend and should be postpone to monday.
-
-        // Add original holiday.
-        if (!$addOnlyPostpone) {
-            parent::addHoliday($holiday);
-        }
-
-        // Create postponed holiday.
-        $postponed = new Holiday(
-            $holiday->shortName . 'Postponed',
-            $holiday->translations,
-            $holiday,
-            $holiday->displayLocale,
-            self::TYPE_POSTPONED
-        );
-
-        // Holidays on weekends will be postponed to monday.
-        do {
-            $postponed->modify('+1 days');
-        } while ($this->isWeekendDay($postponed));
-
-        // Create add holiday.
-        parent::addHoliday($postponed);
-    }
-
-    /**
-     * Returns the number of defined holidays (for the given country and the given year).
-     * In case a holiday is substituted (e.g. observed), the holiday is only counted once.
-     *
-     * @param bool $ignorePostponedHolidays Do not count postponed holidays.
-     *
-     * @return int number of holidays
-     */
-    public function count(bool $ignorePostponedHolidays = true): int
-    {
-        $names = \array_reduce(
-            $this->getHolidays(),
-            static function (&$carry, &$holiday) use (&$ignorePostponedHolidays) {
-                // Ignore postponed holidays.
-                if ($ignorePostponedHolidays) {
-                    if ($holiday->getType() == self::TYPE_POSTPONED) {
-                        return $carry;
-                    }
-                }
-
-                if ($holiday instanceof SubstituteHoliday) {
-                    $carry[] = $holiday->substitutedHoliday->shortName;
-                    return $carry;
-                }
-
-                $carry[] =  $holiday->shortName;
-                return $carry;
-            },
-            []
-        );
-
-        return \count(\array_unique($names));
     }
 
     /**
@@ -166,6 +113,29 @@ class Ukraine extends AbstractProvider
             new \DateTime("$this->year-01-07", new \DateTimeZone($this->timezone)),
             $this->locale
         ));
+    }
+
+    /**
+     * International Workers' Day.
+     * National holiday until 2018.
+     *
+     * @link https://en.wikipedia.org/wiki/International_Workers%27_Day#Ukraine
+     *
+     * @throws InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    private function calculateSecondInternationalWorkersDay(): void
+    {
+        if ($this->year >= 2018) {
+            return;
+        }
+
+        $this->addHoliday(new Holiday('secondInternationalWorkersDay', [
+            'uk' => 'День міжнародної солідарності трудящих',
+            'ru' => 'День международной солидарности трудящихся',
+        ], new \DateTime("$this->year-05-02", new \DateTimeZone($this->timezone)), $this->locale));
     }
 
     /**
@@ -303,6 +273,10 @@ class Ukraine extends AbstractProvider
      */
     private function calculateCatholicChristmasDay(): void
     {
+        if ($this->year < 2017) {
+            return;
+        }
+
         $this->addHoliday(
             new Holiday(
                 'catholicChristmasDay',
@@ -313,7 +287,7 @@ class Ukraine extends AbstractProvider
                 new \DateTime("$this->year-12-25", new \DateTimeZone($this->timezone)),
                 $this->locale
             ),
-            false  // Catholic Christmas Day will not be postponed to an monday if it's on a weekend!
+            false  // Catholic Christmas Day will not be substituted to an monday if it's on a weekend!
         );
     }
 }

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -80,7 +80,9 @@ class Ukraine extends AbstractProvider
     {
         parent::addHoliday($holiday);
 
-        if (!$substitutable) return;
+        if (!$substitutable) {
+            return;
+        }
 
         // Substitute holiday is on the next available weekday
         // if a holiday falls on a Saturday or Sunday.

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -75,7 +75,7 @@ class Ukraine extends AbstractProvider
      * @param Holiday $holiday Holiday instance (representing a holiday) to be added to the internal list
      *                         of holidays of this country.
      * @param bool $substitutable Holidays on a weekend will be substituted to the next monday.
-     * 
+     *
      * @throws InvalidDateException
      * @throws UnknownLocaleException
      * @throws \InvalidArgumentException

--- a/tests/Base/WeekendTest.php
+++ b/tests/Base/WeekendTest.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 /**
  * This file is part of the Yasumi package.

--- a/tests/Ukraine/CatholicChristmasDayTest.php
+++ b/tests/Ukraine/CatholicChristmasDayTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Yasumi package.
  *
@@ -19,15 +21,15 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class SecondInternationalWorkersDayTest
+ * Class CatholicChristmasDayTest
  * @package Yasumi\tests\Ukraine
  */
-class SecondInternationalWorkersDayTest extends UkraineBaseTestCase implements YasumiTestCaseInterface
+class CatholicChristmasDayTest extends UkraineBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday
      */
-    public const HOLIDAY = 'secondInternationalWorkersDay';
+    public const HOLIDAY = 'catholicChristmasDay';
 
     /**
      * Tests International Workers' Day.
@@ -54,7 +56,7 @@ class SecondInternationalWorkersDayTest extends UkraineBaseTestCase implements Y
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(),
-            [self::LOCALE => 'День міжнародної солідарності трудящих']
+            [self::LOCALE => 'Католицький день Різдва']
         );
     }
 
@@ -75,6 +77,6 @@ class SecondInternationalWorkersDayTest extends UkraineBaseTestCase implements Y
      */
     public function SecondInternationalWorkersDayDataProvider(): array
     {
-        return $this->generateRandomDates(5, 2, self::TIMEZONE);
+        return $this->generateRandomDates(12, 25, self::TIMEZONE);
     }
 }

--- a/tests/Ukraine/PostponedHolidayTest.php
+++ b/tests/Ukraine/PostponedHolidayTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2020 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\Ukraine;
+
+use DateTime;
+use DateTimeZone;
+use Exception;
+use ReflectionException;
+use Yasumi\Holiday;
+use Yasumi\Provider\Ukraine;
+use Yasumi\tests\YasumiTestCaseInterface;
+use Yasumi\Yasumi;
+
+/**
+ * Class PostponedHolidayTest
+ * @package Yasumi\tests\Ukraine
+ */
+class PostponedHolidayTest extends UkraineBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * Tests the postponement of holidays on saturday (weekend).
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function testSaturdayPostponement()
+    {
+        // 2020-05-09 victoryDay (День перемоги)
+        $year = 2020;
+        $holiday = 'victoryDay';
+
+        $this->assertHolidayWithPostponement(
+            self::REGION,
+            $holiday,
+            $year,
+            new DateTime("$year-05-09", new DateTimeZone(self::TIMEZONE)),
+            new DateTime("$year-05-11", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the postponement of holidays on sunday (weekend).
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function testSundayPostponement(): void
+    {
+        // 2020-06-28 constitutionDay (День Конституції)
+        $year = 2020;
+        $holiday = 'constitutionDay';
+
+        $this->assertHolidayWithPostponement(
+            self::REGION,
+            $holiday,
+            $year,
+            new DateTime("$year-06-28", new DateTimeZone(self::TIMEZONE)),
+            new DateTime("$year-06-29", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the postponement of new year (1. January) on a weekend.
+     * Special: no postponement at new year (1. January) on a weekend.
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function testNewYearNoPostponement(): void
+    {
+        // 2022-01-01 (Saturday) constitutionDay (Новий Рік)
+        $year = 2022;
+        $holiday = 'newYearsDay';
+
+        $this->assertHolidayWithPostponement(
+            self::REGION,
+            $holiday,
+            $year,
+            new DateTime("$year-01-01", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the postponement of Catholic Christmas Day (25. December) on a weekend.
+     * Special: no postponement at Catholic Christmas Day (25. December) on a weekend.
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function testCatholicChristmasDayNoPostponement(): void
+    {
+        // 2022-12-25 (Sunday) catholicChristmasDay (Католицький день Різдва)
+        $year = 2022;
+        $holiday = 'catholicChristmasDay';
+
+        $this->assertHolidayWithPostponement(
+            self::REGION,
+            $holiday,
+            $year,
+            new DateTime("$year-12-25", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Dummy: Tests the translated name of the holiday defined in this test.
+     * @throws ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Dummy: Tests type of the holiday defined in this test.
+     * @throws ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Asserts that the expected date is indeed a holiday for that given year and name
+     *
+     * @param string $provider the holiday provider (i.e. country/state) for which the holiday need to be tested
+     * @param string $shortName string the short name of the holiday to be checked against
+     * @param int $year holiday calendar year
+     * @param DateTime $expected the official date to be checked against
+     * @param DateTime $expected the postponed date to be checked against
+     *
+     * @throws UnknownLocaleException
+     * @throws InvalidDateException
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
+     * @throws AssertionFailedError
+     * @throws ReflectionException
+     */
+    public function assertHolidayWithPostponement(
+        string $provider,
+        string $shortName,
+        int $year,
+        DateTime $expectedOfficial,
+        DateTime $expectedPostponed = null
+    ): void {
+        $holidays = Yasumi::create($provider, $year);
+
+        $holidayOfficial = $holidays->getHoliday($shortName);
+        $this->assertInstanceOf(Holiday::class, $holidayOfficial);
+        $this->assertNotNull($holidayOfficial);
+        $this->assertEquals($expectedOfficial, $holidayOfficial);
+        $this->assertTrue($holidays->isHoliday($holidayOfficial));
+        $this->assertEquals(Holiday::TYPE_OFFICIAL, $holidayOfficial->getType());
+
+        $holidayPostponed = $holidays->getHoliday($shortName . 'Postponed');
+        if ($expectedPostponed === null) {
+            // without postponement
+            $this->assertNull($holidayPostponed);
+        } else {
+            // with postponement
+            $this->assertInstanceOf(Holiday::class, $holidayPostponed);
+            $this->assertNotNull($holidayPostponed);
+            $this->assertEquals($expectedPostponed, $holidayPostponed);
+            $this->assertTrue($holidays->isHoliday($holidayPostponed));
+            $this->assertEquals(Ukraine::TYPE_POSTPONED, $holidayPostponed->getType());
+        }
+
+        unset($holidayOfficial, $holidayPostponed, $holidays);
+    }
+}

--- a/tests/Ukraine/SecondInternationalWorkersDayTest.php
+++ b/tests/Ukraine/SecondInternationalWorkersDayTest.php
@@ -14,45 +14,44 @@
 namespace Yasumi\tests\Ukraine;
 
 use DateTime;
-use Exception;
 use ReflectionException;
 use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 use Yasumi\Yasumi;
 
 /**
- * Class CatholicChristmasDayTest
+ * Class SecondInternationalWorkersDayTest
  * @package Yasumi\tests\Ukraine
  */
-class CatholicChristmasDayTest extends UkraineBaseTestCase implements YasumiTestCaseInterface
+class SecondInternationalWorkersDayTest extends UkraineBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday
      */
-    public const HOLIDAY = 'catholicChristmasDay';
+    public const HOLIDAY = 'secondInternationalWorkersDay';
 
     /**
-     * Tests Catholic Christmas Day.
+     * Tests International Workers' Day.
      *
-     * @dataProvider CatholicChristmasDayDataProvider
+     * @dataProvider SecondInternationalWorkersDayDataProvider
      *
      * @param int $year the year for which International Workers' Day needs to be tested
      * @param DateTime $expected the expected date
      *
      * @throws ReflectionException
      */
-    public function testCatholicChristmasDay($year, $expected)
+    public function testSecondInternationalWorkersDay($year, $expected)
     {
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
     }
 
     /**
-     * Tests Catholic Christmas Day before 2017.
+     * Tests International Workers' Day since 2018.
      * @throws ReflectionException
      */
-    public function testNoCatholicChristmasDayBefore2017()
+    public function testNoSecondInternationalWorkersDaySince2018()
     {
-        $year = $this->generateRandomYear(null, 2016);
+        $year = $this->generateRandomYear(2018);
         $holidays = Yasumi::create(self::REGION, $year);
         $holiday = $holidays->getHoliday(self::HOLIDAY);
 
@@ -70,8 +69,8 @@ class CatholicChristmasDayTest extends UkraineBaseTestCase implements YasumiTest
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(2017),
-            [self::LOCALE => 'Католицький день Різдва']
+            $this->generateRandomYear(null, 2017),
+            [self::LOCALE => 'День міжнародної солідарності трудящих']
         );
     }
 
@@ -81,22 +80,27 @@ class CatholicChristmasDayTest extends UkraineBaseTestCase implements YasumiTest
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(2017), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(null, 2017),
+            Holiday::TYPE_OFFICIAL
+        );
     }
 
     /**
-     * Returns a list of random test dates used for assertion of Catholic Christmas Day.
+     * Returns a list of random test dates used for assertion of International Workers' Day.
      *
-     * @return array list of test dates for Catholic Christmas Day
+     * @return array list of test dates for International Workers' Day
      * @throws Exception
      */
-    public function CatholicChristmasDayDataProvider(): array
+    public function SecondInternationalWorkersDayDataProvider(): array
     {
         $data = [];
 
         for ($y = 0; $y < 10; $y++) {
-            $year = $this->generateRandomYear(2017);
-            $data[] = [$year, new \DateTime("$year-12-25", new \DateTimeZone(self::TIMEZONE))];
+            $year = $this->generateRandomYear(null, 2017);
+            $data[] = [$year, new \DateTime("$year-05-02", new \DateTimeZone(self::TIMEZONE))];
         }
 
         return $data;

--- a/tests/Ukraine/UkraineTest.php
+++ b/tests/Ukraine/UkraineTest.php
@@ -64,9 +64,9 @@ class UkraineTest extends UkraineBaseTestCase
         }
 
         $this->assertDefinedHolidays(
-            $holidays, 
-            self::REGION, 
-            $this->year, 
+            $holidays,
+            self::REGION,
+            $this->year,
             Holiday::TYPE_OFFICIAL
         );
     }

--- a/tests/Ukraine/UkraineTest.php
+++ b/tests/Ukraine/UkraineTest.php
@@ -1,6 +1,5 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
 /**
  * This file is part of the Yasumi package.
  *

--- a/tests/Ukraine/UkraineTest.php
+++ b/tests/Ukraine/UkraineTest.php
@@ -33,20 +33,42 @@ class UkraineTest extends UkraineBaseTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $holidays = [
             'newYearsDay',
             'internationalWorkersDay',
-            //'secondInternationalWorkersDay',  // until 2018
             'christmasDay',
             'easter',
             'pentecost',
             'internationalWomensDay',
             'victoryDay',
-            'constitutionDay',
-            'independenceDay',
-            'defenderOfUkraineDay',
-            'catholicChristmasDay',
-        ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+
+        if ($this->year >= 1996) {
+            $holidays[] = 'constitutionDay';
+        }
+
+        if ($this->year >= 1991) {
+            $holidays[] = 'independenceDay';
+        }
+
+        if ($this->year >= 2015) {
+            $holidays[] = 'defenderOfUkraineDay';
+        }
+
+        if ($this->year < 2018) {
+            $holidays[] = 'secondInternationalWorkersDay';
+        }
+
+        if ($this->year >= 2017) {
+            $holidays[] = 'catholicChristmasDay';
+        }
+
+        $this->assertDefinedHolidays(
+            $holidays, 
+            self::REGION, 
+            $this->year, 
+            Holiday::TYPE_OFFICIAL
+        );
     }
 
     /**
@@ -90,6 +112,6 @@ class UkraineTest extends UkraineBaseTestCase
      */
     protected function setUp(): void
     {
-        $this->year = $this->generateRandomYear(2017, 2025);
+        $this->year = $this->generateRandomYear();
     }
 }

--- a/tests/Ukraine/UkraineTest.php
+++ b/tests/Ukraine/UkraineTest.php
@@ -36,6 +36,7 @@ class UkraineTest extends UkraineBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'internationalWorkersDay',
+            //'secondInternationalWorkersDay',  // until 2018
             'christmasDay',
             'easter',
             'pentecost',
@@ -89,6 +90,6 @@ class UkraineTest extends UkraineBaseTestCase
      */
     protected function setUp(): void
     {
-        $this->year = $this->generateRandomYear(2015, 2025);
+        $this->year = $this->generateRandomYear(2017, 2025);
     }
 }

--- a/tests/Ukraine/UkraineTest.php
+++ b/tests/Ukraine/UkraineTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * This file is part of the Yasumi package.
  *
@@ -35,7 +37,6 @@ class UkraineTest extends UkraineBaseTestCase
         $this->assertDefinedHolidays([
             'newYearsDay',
             'internationalWorkersDay',
-            'secondInternationalWorkersDay',
             'christmasDay',
             'easter',
             'pentecost',
@@ -44,6 +45,7 @@ class UkraineTest extends UkraineBaseTestCase
             'constitutionDay',
             'independenceDay',
             'defenderOfUkraineDay',
+            'catholicChristmasDay',
         ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 


### PR DESCRIPTION
## Date changes
The International Workers' Day (2. May) was a holiday until 2018. But *NOT* anymore. Instead since 2017 the Catholic Christmas Day (25 December) is a new holiday.

## Postponed holidays
In Ukraine, holidays have behaved a very employee-friendly. Every holiday which is on a weekend will be postponed to the next Monday. Weekend is via definition Saturday and Sunday. The only exceptions for this rule are New Year (1. January) and the Catholic Christmas Day (25. December). These days will not postponed even if they are on a weekend.

## Example (2020)
```
2020-01-01  official   New Year's Day               Новий Рік
2020-01-07  official   Christmas                    Різдво
2020-03-08  official   International Women's Day    Міжнародний жіночий день
2020-03-09  postponed  International Women's Day    Міжнародний жіночий день
2020-04-19  official   Easter Sunday                Великдень
2020-04-20  postponed  Easter Sunday                Великдень
2020-05-01  official   International Workers' Day   День міжнародної солідарності трудящих
2020-05-09  official   victoryDay                   День перемоги
2020-05-11  postponed  victoryDay                   День перемоги
2020-06-07  official   Whitsunday                   Трійця
2020-06-08  postponed  Whitsunday                   Трійця
2020-06-28  official   constitutionDay              День Конституції
2020-06-29  postponed  constitutionDay              День Конституції
2020-08-24  official   independenceDay              День Незалежності
2020-10-14  official   defenderOfUkraineDay         День захисника України
2020-12-25  official   catholicChristmasDay         Католицький день Різдва
```