### PR TITLE
Updates to the holidays of Croatia, starting from the year 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
+- Statehood Day is celebrated at a new date since 2020 in Croatia. [\#203](https://github.com/azuyalabs/yasumi/pull/203) ([krukru](https://github.com/krukru))
+- Homeland Thanksgiving Day has been renamed to "Victory and Homeland Thanksgiving Day and the Day of Croatian Defenders" since 2020 in Croatia. [\#203](https://github.com/azuyalabs/yasumi/pull/203) ([krukru](https://github.com/krukru))
+- Independence Day is no longer an official holiday since 2020 in Croatia. [\#203](https://github.com/azuyalabs/yasumi/pull/203) ([krukru](https://github.com/krukru))
+- Remembrance Day for Homeland War Victims and Remembrance Day for the Victims of Vukovar and Skabrnja is a new official holiday since 2020 in Croatia. [\#203](https://github.com/azuyalabs/yasumi/pull/203) ([krukru](https://github.com/krukru))
 
 ### Added
 - Catalan translations for holidays in Catalonia, Valencian Community, Balearic Islands and Aragon [\#189](https://github.com/azuyalabs/yasumi/pull/189) ([c960657](https://github.com/c960657))

--- a/src/Yasumi/Provider/Croatia.php
+++ b/src/Yasumi/Provider/Croatia.php
@@ -98,7 +98,7 @@ class Croatia extends AbstractProvider
     }
 
     /**
-     * Starting from the year 2020. homeland thanksgiving day name is slightly changed
+     * Starting from the year 2020. Homeland Thanksgiving Day name is slightly changed
      * Source: https://narodne-novine.nn.hr/clanci/sluzbeni/2019_11_110_2212.html
      */
     private function calculateHomelandThanksgivingDay(): void
@@ -123,8 +123,8 @@ class Croatia extends AbstractProvider
     }
 
     /**
-     * Starting from the year 2020. independane day is no longer a holiday, but is still remembered (under a different name)
-     * (Day of Croatian Paralment, Dan Hrvatskog sabora)
+     * Starting from the year 2020. Independence Day is no longer an official holiday,
+     * but is still remembered under a different name as Croatian Parliament Day (Dan Hrvatskog sabora)
      * Source: https://narodne-novine.nn.hr/clanci/sluzbeni/2019_11_110_2212.html
      */
     private function calculateIndependenceDay(): void
@@ -137,6 +137,10 @@ class Croatia extends AbstractProvider
         }
     }
 
+    /**
+     * Starting from the year 2020. a new holiday was added
+     * Source: https://narodne-novine.nn.hr/clanci/sluzbeni/2019_11_110_2212.html
+     */
     private function calculateRemembranceDayForHomelandWarVictims(): void
     {
         if ($this->year >= 2020) {

--- a/src/Yasumi/Provider/Croatia.php
+++ b/src/Yasumi/Provider/Croatia.php
@@ -69,34 +69,74 @@ class Croatia extends AbstractProvider
             ], new DateTime("$this->year-6-22", new DateTimeZone($this->timezone)), $this->locale));
         }
 
-        /**
-         * Croatian Statehood Day
-         */
-        if ($this->year >= 1991) {
+        $this->calculateStatehoodDay();
+        $this->calculateHomelandThanksgivingDay();
+        $this->calculateIndependenceDay();
+        $this->calculateRemembranceDayForHomelandWarVictims();
+    }
+
+    /**
+     * Starting from the year 2020. statehood day is celebrated at a new date
+     * Source: https://narodne-novine.nn.hr/clanci/sluzbeni/2019_11_110_2212.html
+     */
+    private function calculateStatehoodDay(): void {
+        $statehoodDayDate = null;
+
+        if ($this->year >= 1991 && $this->year < 2020) {
+            $statehoodDayDate = new DateTime("$this->year-6-25", new DateTimeZone($this->timezone));
+        } else if ($this->year >= 2020) {
+            $statehoodDayDate = new DateTime("$this->year-5-30", new DateTimeZone($this->timezone));
+        }
+
+        if ($statehoodDayDate != null) {
             $this->addHoliday(new Holiday('statehoodDay', [
                 'en' => 'Statehood Day',
                 'hr' => 'Dan državnosti',
-            ], new DateTime("$this->year-6-25", new DateTimeZone($this->timezone)), $this->locale));
+            ],$statehoodDayDate, $this->locale));
+        }
+    }
+
+    /**
+     * Starting from the year 2020. homeland thanksgiving day name is slightly changed
+     * Source: https://narodne-novine.nn.hr/clanci/sluzbeni/2019_11_110_2212.html
+     */
+    private function calculateHomelandThanksgivingDay(): void {
+        $names = null;
+        if ($this->year >= 1995 && $this->year < 2020) {
+            $names['en'] = 'Homeland Thanksgiving Day';
+            $names['hr'] = 'Dan domovinske zahvalnosti';
+        } else if ($this->year >= 2020) {
+            $names['en'] = 'Victory and Homeland Thanksgiving Day and the Day of Croatian Defenders';
+            $names['hr'] = 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja';
         }
 
-        /**
-         * Homeland Thanksgiving Day
-         */
-        if ($this->year >= 1995) {
-            $this->addHoliday(new Holiday('homelandThanksgiving', [
-                'en' => 'Homeland Thanksgiving Day',
-                'hr' => 'Dan domovinske zahvalnosti',
-            ], new DateTime("$this->year-8-5", new DateTimeZone($this->timezone)), $this->locale));
+        if ($names != null) {
+            $this->addHoliday(new Holiday('homelandThanksgiving',
+                $names,
+                new DateTime("$this->year-8-5", new DateTimeZone($this->timezone)), $this->locale));
         }
+    }
 
-        /**
-         * Independence Day
-         */
-        if ($this->year >= 1991) {
+    /**
+     * Starting from the year 2020. independane day is no longer a holiday, but is still remembered (under a different name)
+     * (Day of Croatian Paralment, Dan Hrvatskog sabora)
+     * Source: https://narodne-novine.nn.hr/clanci/sluzbeni/2019_11_110_2212.html
+     */
+    private function calculateIndependenceDay(): void {
+        if ($this->year >= 1991 && $this->year < 2020) {
             $this->addHoliday(new Holiday('independenceDay', [
                 'en' => 'Independence Day',
                 'hr' => 'Dan neovisnosti',
             ], new DateTime("$this->year-10-8", new DateTimeZone($this->timezone)), $this->locale));
+        }
+    }
+
+    private function calculateRemembranceDayForHomelandWarVictims(): void {
+        if ($this->year >= 2020) {
+            $this->addHoliday(new Holiday('remembranceDay', [
+                'en' => 'Remembrance Day for Homeland War Victims and Remembrance Day for the Victims of Vukovar and Skabrnja',
+                'hr' => 'Dan sjećanja na žrtve Domovinskog rata i Dan sjećanja na žrtvu Vukovara i Škabrnje',
+            ], new DateTime("$this->year-11-18", new DateTimeZone($this->timezone)), $this->locale));
         }
     }
 }

--- a/src/Yasumi/Provider/Croatia.php
+++ b/src/Yasumi/Provider/Croatia.php
@@ -113,9 +113,12 @@ class Croatia extends AbstractProvider
         }
 
         if ($names != null) {
-            $this->addHoliday(new Holiday('homelandThanksgiving',
+            $this->addHoliday(new Holiday(
+                'homelandThanksgiving',
                 $names,
-                new DateTime("$this->year-8-5", new DateTimeZone($this->timezone)), $this->locale));
+                new DateTime("$this->year-8-5", new DateTimeZone($this->timezone)),
+                $this->locale
+            ));
         }
     }
 

--- a/src/Yasumi/Provider/Croatia.php
+++ b/src/Yasumi/Provider/Croatia.php
@@ -79,12 +79,13 @@ class Croatia extends AbstractProvider
      * Starting from the year 2020. statehood day is celebrated at a new date
      * Source: https://narodne-novine.nn.hr/clanci/sluzbeni/2019_11_110_2212.html
      */
-    private function calculateStatehoodDay(): void {
+    private function calculateStatehoodDay(): void
+    {
         $statehoodDayDate = null;
 
         if ($this->year >= 1991 && $this->year < 2020) {
             $statehoodDayDate = new DateTime("$this->year-6-25", new DateTimeZone($this->timezone));
-        } else if ($this->year >= 2020) {
+        } elseif ($this->year >= 2020) {
             $statehoodDayDate = new DateTime("$this->year-5-30", new DateTimeZone($this->timezone));
         }
 
@@ -92,7 +93,7 @@ class Croatia extends AbstractProvider
             $this->addHoliday(new Holiday('statehoodDay', [
                 'en' => 'Statehood Day',
                 'hr' => 'Dan državnosti',
-            ],$statehoodDayDate, $this->locale));
+            ], $statehoodDayDate, $this->locale));
         }
     }
 
@@ -100,12 +101,13 @@ class Croatia extends AbstractProvider
      * Starting from the year 2020. homeland thanksgiving day name is slightly changed
      * Source: https://narodne-novine.nn.hr/clanci/sluzbeni/2019_11_110_2212.html
      */
-    private function calculateHomelandThanksgivingDay(): void {
+    private function calculateHomelandThanksgivingDay(): void
+    {
         $names = null;
         if ($this->year >= 1995 && $this->year < 2020) {
             $names['en'] = 'Homeland Thanksgiving Day';
             $names['hr'] = 'Dan domovinske zahvalnosti';
-        } else if ($this->year >= 2020) {
+        } elseif ($this->year >= 2020) {
             $names['en'] = 'Victory and Homeland Thanksgiving Day and the Day of Croatian Defenders';
             $names['hr'] = 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja';
         }
@@ -122,7 +124,8 @@ class Croatia extends AbstractProvider
      * (Day of Croatian Paralment, Dan Hrvatskog sabora)
      * Source: https://narodne-novine.nn.hr/clanci/sluzbeni/2019_11_110_2212.html
      */
-    private function calculateIndependenceDay(): void {
+    private function calculateIndependenceDay(): void
+    {
         if ($this->year >= 1991 && $this->year < 2020) {
             $this->addHoliday(new Holiday('independenceDay', [
                 'en' => 'Independence Day',
@@ -131,7 +134,8 @@ class Croatia extends AbstractProvider
         }
     }
 
-    private function calculateRemembranceDayForHomelandWarVictims(): void {
+    private function calculateRemembranceDayForHomelandWarVictims(): void
+    {
         if ($this->year >= 2020) {
             $this->addHoliday(new Holiday('remembranceDay', [
                 'en' => 'Remembrance Day for Homeland War Victims and Remembrance Day for the Victims of Vukovar and Skabrnja',

--- a/tests/Croatia/IndependenceDayTest.php
+++ b/tests/Croatia/IndependenceDayTest.php
@@ -35,13 +35,18 @@ class IndependenceDayTest extends CroatiaBaseTestCase implements YasumiTestCaseI
     public const ESTABLISHMENT_YEAR = 1991;
 
     /**
+     * The year after which this is no longer a holiday
+     */
+    public const DISBANDMENT_YEAR = 2020;
+
+    /**
      * Tests Independence Day on or after 1991.
      * @throws Exception
      * @throws ReflectionException
      */
     public function testIndependenceDayOnAfter1991()
     {
-        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::DISBANDMENT_YEAR - 1);
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
@@ -64,6 +69,19 @@ class IndependenceDayTest extends CroatiaBaseTestCase implements YasumiTestCaseI
     }
 
     /**
+     * Tests Independence Day before 1991.
+     * @throws ReflectionException
+     */
+    public function testIndependenceDayAfterDisbandment()
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::DISBANDMENT_YEAR)
+        );
+    }
+
+    /**
      * Tests translated name of Independence Day.
      * @throws ReflectionException
      */
@@ -72,7 +90,7 @@ class IndependenceDayTest extends CroatiaBaseTestCase implements YasumiTestCaseI
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::DISBANDMENT_YEAR - 1),
             [self::LOCALE => 'Dan neovisnosti']
         );
     }
@@ -86,7 +104,7 @@ class IndependenceDayTest extends CroatiaBaseTestCase implements YasumiTestCaseI
         $this->assertHolidayType(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::DISBANDMENT_YEAR - 1),
             Holiday::TYPE_OFFICIAL
         );
     }

--- a/tests/Croatia/RemembranceDayTest.php
+++ b/tests/Croatia/RemembranceDayTest.php
@@ -20,46 +20,42 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class containing tests for Homeland Thanksgiving Day in Croatia.
+ * Class containing tests for Statehood Day in Croatia.
  */
-class HomelandThanksgivingDayTest extends CroatiaBaseTestCase implements YasumiTestCaseInterface
+class RemembranceDayTest extends CroatiaBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday
      */
-    public const HOLIDAY = 'homelandThanksgiving';
+    public const HOLIDAY = 'remembranceDay';
 
     /**
      * The year in which the holiday was first established
      */
-    public const ESTABLISHMENT_YEAR = 1995;
+    public const ESTABLISHMENT_YEAR = 2020;
 
     /**
-     * The year in which the holiday name was changed
-     */
-    public const NAME_CHANGED_YEAR = 2020;
-
-    /**
-     * Tests Homeland Thanksgiving Day on or after 1995.
+     * Tests Remembrance Day
      * @throws Exception
      * @throws ReflectionException
      */
-    public function testHomelandThanksgivingDayOnAfter1995()
+    public function testRemembranceDayAfterItWasEstablished()
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
-            new DateTime("$year-8-5", new DateTimeZone(self::TIMEZONE))
+            new DateTime("$year-11-18", new DateTimeZone(self::TIMEZONE))
         );
     }
 
     /**
-     * Tests Homeland Thanksgiving Day before 1995.
+     * Tests Remembrance Day
+     * @throws Exception
      * @throws ReflectionException
      */
-    public function testHomelandThanksgivingDayBefore1995()
+    public function testRemembranceDayBeforeItWasEstablished()
     {
         $this->assertNotHoliday(
             self::REGION,
@@ -69,27 +65,16 @@ class HomelandThanksgivingDayTest extends CroatiaBaseTestCase implements YasumiT
     }
 
     /**
-     * Tests translated name of Homeland Thanksgiving Day.
+     * Tests translated name of Remembrance Day.
      * @throws ReflectionException
      */
     public function testTranslation(): void
     {
-        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::NAME_CHANGED_YEAR - 1);
-        $expectedText = 'Dan domovinske zahvalnosti';
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $year,
-            [self::LOCALE => $expectedText]
-        );
-
-        $year = $this->generateRandomYear(self::NAME_CHANGED_YEAR);
-        $expectedText = 'Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja';
-        $this->assertTranslatedHolidayName(
-            self::REGION,
-            self::HOLIDAY,
-            $year,
-            [self::LOCALE => $expectedText]
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Dan sjećanja na žrtve Domovinskog rata i Dan sjećanja na žrtvu Vukovara i Škabrnje']
         );
     }
 

--- a/tests/Croatia/StatehoodDayTest.php
+++ b/tests/Croatia/StatehoodDayTest.php
@@ -35,18 +35,33 @@ class StatehoodDayTest extends CroatiaBaseTestCase implements YasumiTestCaseInte
     public const ESTABLISHMENT_YEAR = 1991;
 
     /**
-     * Tests Statehood Day on or after 1991.
+     * The year in which the holiday celebration date has changed
+     */
+    public const DATE_CHANGE_YEAR = 2020;
+
+    /**
+     * Tests Statehood Day
      * @throws Exception
      * @throws ReflectionException
      */
-    public function testStatehoodDayOnAfter1991()
+    public function testStatehoodDay()
     {
-        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::DATE_CHANGE_YEAR - 1);
+        $expectedDate = "$year-6-25";
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
-            new DateTime("$year-6-25", new DateTimeZone(self::TIMEZONE))
+            new DateTime($expectedDate, new DateTimeZone(self::TIMEZONE))
+        );
+
+        $year = $this->generateRandomYear(self::DATE_CHANGE_YEAR);
+        $expectedDate = "$year-5-30";
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime($expectedDate, new DateTimeZone(self::TIMEZONE))
         );
     }
 


### PR DESCRIPTION
Starting from the year 2020, there are some changes to the national holidays of Croatia. Some holidays have changed names, some have been disbanded and a new holiday was added.
The holiday list which is valid from the year 2020 can be found at the "Narodne novine" https://narodne-novine.nn.hr/clanci/sluzbeni/2019_11_110_2212.html 
(English: The People's Newspaper), the official gazette of the Republic of Croatia which publishes laws, regulations, appointments and official decisions and releases them in the public domain 

Edit: The full list of changes
* Statehood day is now celebrated at a new date. The old date is still remembered (called "Spomendan") as Independence Day (Dan neovisnosti), but is not an official holiday.
* Homeland Thanksgiving Day has been given a different name to include Victory Day and Day of Croatian Defenders (full name: Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja/Victory and Homeland Thanksgiving Day and the Day of Croatian Defenders).
* Independence Day is no longer an official holiday. (It is still remembered as a "Spomendan" and is called Croatian Parliament Day. This PR only removes the official holiday - does not add the "Spomendan").
* A new official holiday is created called "Remembrance Day for Homeland War Victims and Remembrance Day for the Victims of Vukovar and Skabrnja"