### PR TITLE
Use fr_LU as locale identifier for Luxembourg

### DIFF
--- a/src/Yasumi/Provider/Luxembourg.php
+++ b/src/Yasumi/Provider/Luxembourg.php
@@ -70,8 +70,7 @@ class Luxembourg extends AbstractProvider
         if ($this->year >= 2019) {
             $this->addHoliday(new Holiday('europeDay', [
                 'en_US' => 'Europe day',
-                'fr_FR' => 'La Journée de l\'Europe',
-                'lu' => 'La Journée de l\'Europe',
+                'fr' => 'La Journée de l’Europe',
             ], new DateTime("$this->year-5-9", new DateTimeZone($this->timezone)), $this->locale));
         }
     }
@@ -96,8 +95,7 @@ class Luxembourg extends AbstractProvider
     {
         $this->addHoliday(new Holiday('nationalDay', [
             'en_US' => 'National day',
-            'fr_FR' => 'La Fête nationale',
-            'lu' => 'La Fête nationale',
+            'fr' => 'La Fête nationale',
         ], new DateTime("$this->year-6-23", new DateTimeZone($this->timezone)), $this->locale));
     }
 }

--- a/src/Yasumi/data/translations/allSaintsDay.php
+++ b/src/Yasumi/data/translations/allSaintsDay.php
@@ -26,7 +26,6 @@ return [
     'it' => 'Festa di Tutti i Santi',
     'it_CH' => 'Ognissanti',
     'lt' => 'Visų šventųjų diena (Vėlinės)',
-    'lu' => 'Toussaint',
     'nl' => 'Allerheiligen',
     'pl' => 'Uroczystość Wszystkich Świętych',
     'pt' => 'Dia de todos os Santos',

--- a/src/Yasumi/data/translations/ascensionDay.php
+++ b/src/Yasumi/data/translations/ascensionDay.php
@@ -21,7 +21,6 @@ return [
     'fi' => 'Helatorstai',
     'fr' => 'Ascension',
     'it' => 'Ascensione',
-    'lu' => 'Ascension',
     'nb' => 'Kristi himmelfartsdag',
     'nl' => 'Hemelvaart',
     'sv' => 'Kristi himmelsfärdsdag',

--- a/src/Yasumi/data/translations/assumptionOfMary.php
+++ b/src/Yasumi/data/translations/assumptionOfMary.php
@@ -23,7 +23,6 @@ return [
     'it' => 'Assunzione di Maria Vergine',
     'it_CH' => 'Assunzione',
     'lt' => 'Žolinė (Švč. Mergelės Marijos ėmimo į dangų diena)',
-    'lu' => 'Assomption',
     'nl' => 'Onze Lieve Vrouw hemelvaart',
     'pl' => 'Wniebowzięcie Najświętszej Marii Panny',
     'pt' => 'Assunção de Nossa Senhora',

--- a/src/Yasumi/data/translations/christmasDay.php
+++ b/src/Yasumi/data/translations/christmasDay.php
@@ -33,7 +33,6 @@ return [
     'it' => 'Natale',
     'ko' => '기독탄신일',
     'lt' => 'Šv. Kalėdos',
-    'lu' => 'Noël',
     'lv' => 'Ziemassvētki',
     'nb' => 'første juledag',
     'nl' => 'eerste kerstdag',

--- a/src/Yasumi/data/translations/easterMonday.php
+++ b/src/Yasumi/data/translations/easterMonday.php
@@ -29,7 +29,6 @@ return [
     'it' => 'Lunedì dell’Angelo',
     'it_CH' => 'Lunedi di Pasqua',
     'lt' => 'Antroji Velykų diena',
-    'lu' => 'Lundi de Pâques',
     'lv' => 'Otrās Lieldienas',
     'nb' => 'andre påskedag',
     'nl_BE' => 'paasmaandag',

--- a/src/Yasumi/data/translations/internationalWorkersDay.php
+++ b/src/Yasumi/data/translations/internationalWorkersDay.php
@@ -33,7 +33,6 @@ return [
     'ja' => '労働の日',
     'ko' => '노동절',
     'lt' => 'Tarptautinė darbo diena',
-    'lu' => 'Fête du Travail',
     'lv' => 'Darba svētki',
     'nb' => 'arbeidernes dag',
     'nl' => 'Dag van de arbeid',

--- a/src/Yasumi/data/translations/newYearsDay.php
+++ b/src/Yasumi/data/translations/newYearsDay.php
@@ -34,7 +34,6 @@ return [
     'ja' => '元日',
     'ko' => '새해',
     'lt' => 'Naujųjų metų diena',
-    'lu' => 'Jour de l\'An',
     'lv' => 'Jaunais Gads',
     'nb' => 'første nyttårsdag',
     'nl' => 'Nieuwjaar',

--- a/src/Yasumi/data/translations/pentecostMonday.php
+++ b/src/Yasumi/data/translations/pentecostMonday.php
@@ -21,9 +21,8 @@ return [
     'ga' => 'Luan Cincíse',
     'hu' => 'Pünkösdhétfő',
     'it' => 'Lunedi di Pentecoste',
-    'lu' => 'Lundi de Pentecôte',
-    'nb' => 'Andre pinsedag',
-    'nl' => 'Tweede pinksterdag',
-    'nl_BE' => 'Pinkstermaandag',
+    'nb' => 'andre pinsedag',
+    'nl' => 'tweede pinksterdag',
+    'nl_BE' => 'pinkstermaandag',
     'ro' => 'A doua zi de Rusalii',
 ];

--- a/src/Yasumi/data/translations/secondChristmasDay.php
+++ b/src/Yasumi/data/translations/secondChristmasDay.php
@@ -27,7 +27,6 @@ return [
     'hu' => 'Karácsony másnapja',
     'ko' => '성탄절 연휴',
     'lt' => 'Kalėdos (antra diena)',
-    'lu' => 'Lendemain de Noël',
     'lv' => 'Otrie Ziemassvētki',
     'nb' => 'andre juledag',
     'nl' => 'tweede kerstdag',

--- a/tests/Luxembourg/EuropeDayTest.php
+++ b/tests/Luxembourg/EuropeDayTest.php
@@ -73,7 +73,7 @@ class EuropeDayTest extends LuxembourgBaseTestCase implements YasumiTestCaseInte
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            [self::LOCALE => 'La Journée de l\'Europe']
+            [self::LOCALE => 'La Journée de l’Europe']
         );
     }
 

--- a/tests/Luxembourg/LuxembourgBaseTestCase.php
+++ b/tests/Luxembourg/LuxembourgBaseTestCase.php
@@ -35,5 +35,5 @@ abstract class LuxembourgBaseTestCase extends TestCase
     /**
      * Locale that is considered common for this provider
      */
-    public const LOCALE = 'lu';
+    public const LOCALE = 'fr_LU';
 }

--- a/tests/Luxembourg/NewYearsDayTest.php
+++ b/tests/Luxembourg/NewYearsDayTest.php
@@ -53,7 +53,7 @@ class NewYearsDayTest extends LuxembourgBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(),
-            [self::LOCALE => 'Jour de l\'An']
+            [self::LOCALE => 'Jour de l’An']
         );
     }
 


### PR DESCRIPTION
The locale identifier for Luxembourg is [`fr_LU`](http://www.localeplanet.com/icu/fr-LU/index.html), not `lu`.

The ISO 639-1 code  `lu` refers to the [Luba-Katanga language](https://en.wikipedia.org/wiki/Luba-Katanga_language).

Also, use typographic apostrophe in accordance with #197.

