### PR TITLE
Save CPU time resources on DateTimeZone creation

### DIFF
--- a/src/Yasumi/Provider/Australia.php
+++ b/src/Yasumi/Provider/Australia.php
@@ -14,7 +14,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -70,7 +69,7 @@ class Australia extends AbstractProvider
      */
     private function calculateNewYearHolidays(): void
     {
-        $newyearsday = new DateTime("$this->year-01-01", new DateTimeZone($this->timezone));
+        $newyearsday = new DateTime("$this->year-01-01", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $this->calculateHoliday('newYearsDay', $newyearsday, [], false, false);
         switch ($newyearsday->format('w')) {
             case 0: // sunday
@@ -135,7 +134,7 @@ class Australia extends AbstractProvider
      */
     private function calculateAustraliaDay(): void
     {
-        $date = new DateTime("$this->year-01-26", new DateTimeZone($this->timezone));
+        $date = new DateTime("$this->year-01-26", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->calculateHoliday('australiaDay', $date, ['en' => 'Australia Day']);
     }
@@ -162,7 +161,7 @@ class Australia extends AbstractProvider
             return;
         }
 
-        $date = new DateTime("$this->year-04-25", new DateTimeZone($this->timezone));
+        $date = new DateTime("$this->year-04-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $this->calculateHoliday('anzacDay', $date, [], false, false);
         $easter = $this->calculateEaster($this->year, $this->timezone);
 
@@ -191,8 +190,8 @@ class Australia extends AbstractProvider
      */
     private function calculateChristmasDay(): void
     {
-        $christmasDay = new DateTime("$this->year-12-25", new DateTimeZone($this->timezone));
-        $boxingDay = new DateTime("$this->year-12-26", new DateTimeZone($this->timezone));
+        $christmasDay = new DateTime("$this->year-12-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $boxingDay = new DateTime("$this->year-12-26", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $this->calculateHoliday('christmasDay', $christmasDay, [], false, false);
         $this->calculateHoliday('secondChristmasDay', $boxingDay, [], false, false);
 

--- a/src/Yasumi/Provider/Australia/ACT.php
+++ b/src/Yasumi/Provider/Australia/ACT.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in Australian Capital Territory (Australia).
@@ -143,7 +143,7 @@ class ACT extends Australia
     {
         $this->calculateHoliday(
             'queensBirthday',
-            new DateTime('second monday of june ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             [],
             false,
             false
@@ -157,7 +157,7 @@ class ACT extends Australia
      */
     private function calculateLabourDay(): void
     {
-        $date = new DateTime("first monday of october $this->year", new DateTimeZone($this->timezone));
+        $date = new DateTime("first monday of october $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));
     }
@@ -175,7 +175,7 @@ class ACT extends Australia
             new Holiday(
                 'canberraDay',
                 ['en' => 'Canberra Day'],
-                new DateTime($datePattern, new DateTimeZone($this->timezone)),
+                new DateTime($datePattern, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             )
         );
@@ -192,7 +192,7 @@ class ACT extends Australia
             return;
         }
 
-        $date = new DateTime($this->year . '-05-27', new DateTimeZone($this->timezone));
+        $date = new DateTime($this->year . '-05-27', DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $day = (int)$date->format('w');
         if (1 !== $day) {
             $date = $date->add(0 === $day ? new DateInterval('P1D') : new DateInterval('P' . (8 - $day) . 'D'));

--- a/src/Yasumi/Provider/Australia/NSW.php
+++ b/src/Yasumi/Provider/Australia/NSW.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in New South Wales (Australia).
@@ -106,7 +106,7 @@ class NSW extends Australia
     {
         $this->calculateHoliday(
             'queensBirthday',
-            new DateTime('second monday of june ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             [],
             false,
             false
@@ -120,7 +120,7 @@ class NSW extends Australia
      */
     private function calculateLabourDay(): void
     {
-        $date = new DateTime("first monday of october $this->year", new DateTimeZone($this->timezone));
+        $date = new DateTime("first monday of october $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));
     }
@@ -135,7 +135,7 @@ class NSW extends Australia
     {
         $this->calculateHoliday(
             'bankHoliday',
-            new DateTime('first monday of august ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('first monday of august ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             ['en' => 'Bank Holiday'],
             false,
             false,

--- a/src/Yasumi/Provider/Australia/NT.php
+++ b/src/Yasumi/Provider/Australia/NT.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in Northern Territory (Australia).
@@ -105,7 +105,7 @@ class NT extends Australia
     {
         $this->calculateHoliday(
             'queensBirthday',
-            new DateTime('second monday of june ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             [],
             false,
             false
@@ -119,7 +119,7 @@ class NT extends Australia
      */
     private function calculateMayDay(): void
     {
-        $date = new DateTime("first monday of may $this->year", new DateTimeZone($this->timezone));
+        $date = new DateTime("first monday of may $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday('mayDay', ['en' => 'May Day'], $date, $this->locale));
     }
@@ -136,7 +136,7 @@ class NT extends Australia
     {
         $this->calculateHoliday(
             'picnicDay',
-            new DateTime('first monday of august ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('first monday of august ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             ['en' => 'Picnic Day'],
             false,
             false

--- a/src/Yasumi/Provider/Australia/Queensland.php
+++ b/src/Yasumi/Provider/Australia/Queensland.php
@@ -13,10 +13,10 @@
 namespace Yasumi\Provider\Australia;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in Queensland (Australia).
@@ -72,7 +72,7 @@ class Queensland extends Australia
 
         $this->calculateHoliday(
             'queensBirthday',
-            new DateTime($birthDay, new DateTimeZone($this->timezone)),
+            new DateTime($birthDay, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             [],
             false,
             false
@@ -86,9 +86,9 @@ class Queensland extends Australia
      */
     private function calculateLabourDay(): void
     {
-        $date = new DateTime("first monday of may $this->year", new DateTimeZone($this->timezone));
+        $date = new DateTime("first monday of may $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         if (2013 === $this->year || 2014 === $this->year || 2015 === $this->year) {
-            $date = new DateTime("first monday of october $this->year", new DateTimeZone($this->timezone));
+            $date = new DateTime("first monday of october $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         }
 
         $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));

--- a/src/Yasumi/Provider/Australia/Queensland/Brisbane.php
+++ b/src/Yasumi/Provider/Australia/Queensland/Brisbane.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia\Queensland;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia\Queensland;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in Brisbane (Australia).
@@ -67,7 +67,7 @@ class Brisbane extends Queensland
      */
     private function calculatePeoplesDay(): void
     {
-        $date = new DateTime('first friday of august ' . $this->year, new DateTimeZone($this->timezone));
+        $date = new DateTime('first friday of august ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         if ($date->format('d') < 5) {
             $date = $date->add(new DateInterval('P7D'));
         }

--- a/src/Yasumi/Provider/Australia/SA.php
+++ b/src/Yasumi/Provider/Australia/SA.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in South Australia (Australia).
@@ -113,7 +113,7 @@ class SA extends Australia
     {
         $this->calculateHoliday(
             'queensBirthday',
-            new DateTime('second monday of june ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             [],
             false,
             false
@@ -127,7 +127,7 @@ class SA extends Australia
      */
     private function calculateLabourDay(): void
     {
-        $date = new DateTime("first monday of october $this->year", new DateTimeZone($this->timezone));
+        $date = new DateTime("first monday of october $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday('labourDay', ['en' => 'Labour Day'], $date, $this->locale));
     }
@@ -151,7 +151,7 @@ class SA extends Australia
 
             $this->calculateHoliday(
                 'adelaideCup',
-                new DateTime($cupDay, new DateTimeZone($this->timezone)),
+                new DateTime($cupDay, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 ['en' => 'Adelaide Cup'],
                 false,
                 false
@@ -166,7 +166,7 @@ class SA extends Australia
      */
     private function calculateProclamationDay(): void
     {
-        $christmasDay = new DateTime("$this->year-12-25", new DateTimeZone($this->timezone));
+        $christmasDay = new DateTime("$this->year-12-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $this->calculateHoliday('christmasDay', $christmasDay, [], false, false);
         switch ($christmasDay->format('w')) {
             case 0: // sunday

--- a/src/Yasumi/Provider/Australia/Tasmania.php
+++ b/src/Yasumi/Provider/Australia/Tasmania.php
@@ -13,10 +13,10 @@
 namespace Yasumi\Provider\Australia;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in Tasmania (Australia).
@@ -55,7 +55,7 @@ class Tasmania extends Australia
      */
     private function calculateEightHoursDay(): void
     {
-        $date = new DateTime("second monday of march $this->year", new DateTimeZone($this->timezone));
+        $date = new DateTime("second monday of march $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday('eightHourDay', ['en' => 'Eight Hour Day'], $date, $this->locale));
     }
@@ -79,7 +79,7 @@ class Tasmania extends Australia
     {
         $this->calculateHoliday(
             'queensBirthday',
-            new DateTime('second monday of june ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             [],
             false,
             false
@@ -98,7 +98,7 @@ class Tasmania extends Australia
     {
         $this->calculateHoliday(
             'recreationDay',
-            new DateTime('first monday of november ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('first monday of november ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             ['en' => 'Recreation Day'],
             false,
             false

--- a/src/Yasumi/Provider/Australia/Tasmania/CentralNorth.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/CentralNorth.php
@@ -13,10 +13,10 @@
 namespace Yasumi\Provider\Australia\Tasmania;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia\Tasmania;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in central north Tasmania (Australia).
@@ -52,7 +52,7 @@ class CentralNorth extends Tasmania
      */
     private function calculateDevonportShow(): void
     {
-        $date = new DateTime($this->year . '-12-02', new DateTimeZone($this->timezone));
+        $date = new DateTime($this->year . '-12-02', DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->modify('previous friday');
         $this->addHoliday(new Holiday('devonportShow', ['en' => 'Devonport Show'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/FlindersIsland.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/FlindersIsland.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia\Tasmania;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia\Tasmania;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in Flinders Island (Australia).
@@ -53,7 +53,7 @@ class FlindersIsland extends Tasmania
      */
     private function calculateFlindersIslandShow(): void
     {
-        $date = new DateTime('third saturday of october ' . $this->year, new DateTimeZone($this->timezone));
+        $date = new DateTime('third saturday of october ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new DateInterval('P1D'));
         $this->addHoliday(new Holiday('flindersIslandShow', ['en' => 'Flinders Island Show'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/KingIsland.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/KingIsland.php
@@ -13,9 +13,9 @@
 namespace Yasumi\Provider\Australia\Tasmania;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Provider\Australia\Tasmania;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in King Island (Australia).
@@ -53,7 +53,7 @@ class KingIsland extends Tasmania
     {
         $this->calculateHoliday(
             'kingIslandShow',
-            new DateTime('first tuesday of march ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('first tuesday of march ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             ['en' => 'King Island Show'],
             false,
             false

--- a/src/Yasumi/Provider/Australia/Tasmania/Northeast.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northeast.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia\Tasmania;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia\Tasmania;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in northeastern Tasmania (Australia).
@@ -53,7 +53,7 @@ class Northeast extends Tasmania
      */
     private function calculateLauncestonShow(): void
     {
-        $date = new DateTime('second saturday of october ' . $this->year, new DateTimeZone($this->timezone));
+        $date = new DateTime('second saturday of october ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new DateInterval('P2D'));
         $this->addHoliday(new Holiday('launcestonShow', ['en' => 'Royal Launceston Show'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/Northwest.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northwest.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia\Tasmania;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia\Tasmania;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in northwestern Tasmania (Australia).
@@ -53,7 +53,7 @@ class Northwest extends Tasmania
      */
     private function calculateBurnieShow(): void
     {
-        $date = new DateTime('first saturday of october ' . $this->year, new DateTimeZone($this->timezone));
+        $date = new DateTime('first saturday of october ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new DateInterval('P1D'));
         $this->addHoliday(new Holiday('burnieShow', ['en' => 'Burnie Show'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/Northwest/CircularHead.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northwest/CircularHead.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia\Tasmania\Northwest;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia\Tasmania\Northwest;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in Circular Head (Australia).
@@ -53,7 +53,7 @@ class CircularHead extends Northwest
      */
     private function calculateAGFEST(): void
     {
-        $date = new DateTime('first thursday of may ' . $this->year, new DateTimeZone($this->timezone));
+        $date = new DateTime('first thursday of may ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->add(new DateInterval('P1D'));
         $this->addHoliday(new Holiday('agfest', ['en' => 'AGFEST'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/South.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/South.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia\Tasmania;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia\Tasmania;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in southern Tasmania (Australia).
@@ -53,7 +53,7 @@ class South extends Tasmania
      */
     private function calculateHobartShow(): void
     {
-        $date = new DateTime('fourth saturday of october ' . $this->year, new DateTimeZone($this->timezone));
+        $date = new DateTime('fourth saturday of october ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new DateInterval('P2D'));
         $this->addHoliday(new Holiday('hobartShow', ['en' => 'Royal Hobart Show'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/South/Southeast.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/South/Southeast.php
@@ -13,9 +13,9 @@
 namespace Yasumi\Provider\Australia\Tasmania\South;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Provider\Australia\Tasmania\South;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in southeastern Tasmania (Australia).
@@ -56,7 +56,7 @@ class Southeast extends South
     {
         $this->calculateHoliday(
             'hobartRegatta',
-            new DateTime('second monday of february ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('second monday of february ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             ['en' => 'Royal Hobart Regatta'],
             false,
             false

--- a/src/Yasumi/Provider/Australia/Victoria.php
+++ b/src/Yasumi/Provider/Australia/Victoria.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\Australia;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in Victoria (Australia).
@@ -131,7 +131,7 @@ class Victoria extends Australia
      */
     private function calculateLabourDay(): void
     {
-        $date = new DateTime("second monday of march $this->year", new DateTimeZone($this->timezone));
+        $date = new DateTime("second monday of march $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));
     }
@@ -155,7 +155,7 @@ class Victoria extends Australia
     {
         $this->calculateHoliday(
             'queensBirthday',
-            new DateTime('second monday of june ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             [],
             false,
             false
@@ -169,7 +169,7 @@ class Victoria extends Australia
      */
     private function calculateMelbourneCupDay(): void
     {
-        $date = new DateTime('first Tuesday of November' . " $this->year", new DateTimeZone($this->timezone));
+        $date = new DateTime('first Tuesday of November' . " $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday('melbourneCup', ['en' => 'Melbourne Cup'], $date, $this->locale));
     }
@@ -204,7 +204,7 @@ class Victoria extends Australia
                 return;
         }
 
-        $date = new DateTime($aflGrandFinalFriday, new DateTimeZone($this->timezone));
+        $date = new DateTime($aflGrandFinalFriday, DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday(
             'aflGrandFinalFriday',

--- a/src/Yasumi/Provider/Australia/WA.php
+++ b/src/Yasumi/Provider/Australia/WA.php
@@ -13,10 +13,10 @@
 namespace Yasumi\Provider\Australia;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia;
+use Yasumi\Provider\DateTimeZoneFactory;
 
 /**
  * Provider for all holidays in Western Australia (Australia).
@@ -76,7 +76,7 @@ class WA extends Australia
 
         $this->calculateHoliday(
             'queensBirthday',
-            new DateTime($birthDay, new DateTimeZone($this->timezone)),
+            new DateTime($birthDay, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             [],
             false,
             false
@@ -90,7 +90,7 @@ class WA extends Australia
      */
     private function calculateLabourDay(): void
     {
-        $date = new DateTime("first monday of march $this->year", new DateTimeZone($this->timezone));
+        $date = new DateTime("first monday of march $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));
     }
@@ -107,7 +107,7 @@ class WA extends Australia
     {
         $this->calculateHoliday(
             'westernAustraliaDay',
-            new DateTime('first monday of june ' . $this->year, new DateTimeZone($this->timezone)),
+            new DateTime('first monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             ['en' => 'Western Australia Day'],
             false,
             false

--- a/src/Yasumi/Provider/Belgium.php
+++ b/src/Yasumi/Provider/Belgium.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -67,6 +66,6 @@ class Belgium extends AbstractProvider
             'fr' => 'Fête nationale',
             'en' => 'Belgian National Day',
             'nl' => 'nationale feestdag',
-        ], new DateTime("$this->year-7-21", new DateTimeZone($this->timezone)), $this->locale));
+        ], new DateTime("$this->year-7-21", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
     }
 }

--- a/src/Yasumi/Provider/Bosnia.php
+++ b/src/Yasumi/Provider/Bosnia.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -59,7 +58,7 @@ class Bosnia extends AbstractProvider
         $this->addHoliday(new Holiday('orthodoxChristmasDay', [
             'en' => 'Orthodox Christmas Day',
             'bs_Latn' => 'Pravoslavni Božić',
-        ], new DateTime("{$this->year}-01-07", new DateTimeZone($this->timezone))));
+        ], new DateTime("{$this->year}-01-07", DateTimeZoneFactory::getDateTimeZone($this->timezone))));
 
         /**
          * Independence Day
@@ -68,7 +67,7 @@ class Bosnia extends AbstractProvider
             $this->addHoliday(new Holiday('independenceDay', [
                 'en' => 'Independence Day',
                 'bs_Latn' => 'Dan Nezavisnosti',
-            ], new DateTime("$this->year-3-1", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-3-1", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
 
         /**
@@ -78,7 +77,7 @@ class Bosnia extends AbstractProvider
             $this->addHoliday(new Holiday('statehoodDay', [
                 'en' => 'Statehood Day',
                 'bs_Latn' => 'Dan državnosti',
-            ], new DateTime("$this->year-11-25", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-11-25", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
 
         /**
@@ -87,7 +86,7 @@ class Bosnia extends AbstractProvider
         $this->addHoliday(new Holiday('dayAfterNewYearsDay', [
             'en' => 'Day after New Year’s Day',
             'bs_Latn' => 'Nova godina - drugi dan',
-        ], new DateTime("$this->year-01-02", new DateTimeZone($this->timezone)), $this->locale));
+        ], new DateTime("$this->year-01-02", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
 
         /**
          * Second Labour day
@@ -95,6 +94,6 @@ class Bosnia extends AbstractProvider
         $this->addHoliday(new Holiday('secondLabourDay', [
             'en' => 'Second Labour Day',
             'bs_Latn' => 'Praznik rada - drugi dan',
-        ], new DateTime("$this->year-05-02", new DateTimeZone($this->timezone)), $this->locale));
+        ], new DateTime("$this->year-05-02", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
     }
 }

--- a/src/Yasumi/Provider/Brazil.php
+++ b/src/Yasumi/Provider/Brazil.php
@@ -14,7 +14,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -98,7 +97,7 @@ class Brazil extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'tiradentesDay',
                 ['pt' => 'Dia de Tiradentes'],
-                new DateTime("$this->year-04-21", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-04-21", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -115,7 +114,7 @@ class Brazil extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'independenceDay',
                 ['pt' => 'Dia da Independência do Brasil'],
-                new DateTime("$this->year-09-07", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-09-07", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -135,7 +134,7 @@ class Brazil extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'ourLadyOfAparecidaDay',
                 ['pt' => 'Dia de Nossa Senhora Aparecida'],
-                new DateTime("$this->year-10-12", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-10-12", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -151,7 +150,7 @@ class Brazil extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'allSoulsDay',
                 ['pt' => 'Dia de Finados'],
-                new DateTime("$this->year-11-02", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-11-02", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -169,7 +168,7 @@ class Brazil extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'proclamationOfRepublicDay',
                 ['pt' => 'Dia da Proclamação da República'],
-                new DateTime("$this->year-11-15", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-11-15", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/ChristianHolidays.php
+++ b/src/Yasumi/Provider/ChristianHolidays.php
@@ -14,7 +14,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -131,7 +130,7 @@ trait ChristianHolidays
             $easterDays = $pfm + $tmp + 1; // Easter as the number of days after 21st March
         }
 
-        $easter = new DateTime("$year-3-21", new DateTimeZone($timezone));
+        $easter = new DateTime("$year-3-21", DateTimeZoneFactory::getDateTimeZone($timezone));
         $easter->add(new DateInterval('P' . $easterDays . 'D'));
 
         return $easter;
@@ -348,7 +347,7 @@ trait ChristianHolidays
         return new Holiday(
             'christmasEve',
             [],
-            new DateTime("$year-12-24", new DateTimeZone($timezone)),
+            new DateTime("$year-12-24", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -383,7 +382,7 @@ trait ChristianHolidays
         return new Holiday(
             'christmasDay',
             [],
-            new DateTime("$year-12-25", new DateTimeZone($timezone)),
+            new DateTime("$year-12-25", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -418,7 +417,7 @@ trait ChristianHolidays
         return new Holiday(
             'secondChristmasDay',
             [],
-            new DateTime("$year-12-26", new DateTimeZone($timezone)),
+            new DateTime("$year-12-26", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -453,7 +452,7 @@ trait ChristianHolidays
         string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('allSaintsDay', [], new DateTime("$year-11-1", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday('allSaintsDay', [], new DateTime("$year-11-1", DateTimeZoneFactory::getDateTimeZone($timezone)), $locale, $type);
     }
 
     /**
@@ -487,7 +486,7 @@ trait ChristianHolidays
         return new Holiday(
             'assumptionOfMary',
             [],
-            new DateTime("$year-8-15", new DateTimeZone($timezone)),
+            new DateTime("$year-8-15", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -558,7 +557,7 @@ trait ChristianHolidays
         string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('epiphany', [], new DateTime("$year-1-6", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday('epiphany', [], new DateTime("$year-1-6", DateTimeZoneFactory::getDateTimeZone($timezone)), $locale, $type);
     }
 
     /**
@@ -630,7 +629,7 @@ trait ChristianHolidays
         return new Holiday(
             'immaculateConception',
             [],
-            new DateTime("$year-12-8", new DateTimeZone($timezone)),
+            new DateTime("$year-12-8", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -669,7 +668,7 @@ trait ChristianHolidays
         return new Holiday(
             'stStephensDay',
             [],
-            new DateTime("$year-12-26", new DateTimeZone($timezone)),
+            new DateTime("$year-12-26", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -705,7 +704,7 @@ trait ChristianHolidays
         string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('stJosephsDay', [], new DateTime("$year-3-19", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday('stJosephsDay', [], new DateTime("$year-3-19", DateTimeZoneFactory::getDateTimeZone($timezone)), $locale, $type);
     }
 
     /**
@@ -775,7 +774,7 @@ trait ChristianHolidays
         string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('stGeorgesDay', [], new DateTime("$year-4-23", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday('stGeorgesDay', [], new DateTime("$year-4-23", DateTimeZoneFactory::getDateTimeZone($timezone)), $locale, $type);
     }
 
     /**
@@ -808,7 +807,7 @@ trait ChristianHolidays
         string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('stJohnsDay', [], new DateTime("$year-06-24", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday('stJohnsDay', [], new DateTime("$year-06-24", DateTimeZoneFactory::getDateTimeZone($timezone)), $locale, $type);
     }
 
     /**
@@ -844,7 +843,7 @@ trait ChristianHolidays
         return new Holiday(
             'annunciation',
             [],
-            new DateTime("$year-03-25", new DateTimeZone($timezone)),
+            new DateTime("$year-03-25", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -872,7 +871,7 @@ trait ChristianHolidays
         $month = \floor(($d + $e + 114) / 31);
         $day = (($d + $e + 114) % 31) + 1;
 
-        return (new DateTime("$year-$month-$day", new DateTimeZone($timezone)))->add(new DateInterval('P13D'));
+        return (new DateTime("$year-$month-$day", DateTimeZoneFactory::getDateTimeZone($timezone)))->add(new DateInterval('P13D'));
     }
 
     /**
@@ -912,7 +911,7 @@ trait ChristianHolidays
         return new Holiday(
             'reformationDay',
             [],
-            new DateTime("$year-10-31", new DateTimeZone($timezone)),
+            new DateTime("$year-10-31", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );

--- a/src/Yasumi/Provider/CommonHolidays.php
+++ b/src/Yasumi/Provider/CommonHolidays.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -54,7 +53,7 @@ trait CommonHolidays
         string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('newYearsEve', [], new DateTime("$year-12-31", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday('newYearsEve', [], new DateTime("$year-12-31", DateTimeZoneFactory::getDateTimeZone($timezone)), $locale, $type);
     }
 
     /**
@@ -88,7 +87,7 @@ trait CommonHolidays
         string $locale,
         string $type = Holiday::TYPE_OFFICIAL
     ): Holiday {
-        return new Holiday('newYearsDay', [], new DateTime("$year-1-1", new DateTimeZone($timezone)), $locale, $type);
+        return new Holiday('newYearsDay', [], new DateTime("$year-1-1", DateTimeZoneFactory::getDateTimeZone($timezone)), $locale, $type);
     }
 
     /**
@@ -124,7 +123,7 @@ trait CommonHolidays
         return new Holiday(
             'internationalWorkersDay',
             [],
-            new DateTime("$year-5-1", new DateTimeZone($timezone)),
+            new DateTime("$year-5-1", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -163,7 +162,7 @@ trait CommonHolidays
         return new Holiday(
             'valentinesDay',
             [],
-            new DateTime("$year-2-14", new DateTimeZone($timezone)),
+            new DateTime("$year-2-14", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -200,7 +199,7 @@ trait CommonHolidays
         return new Holiday(
             'worldAnimalDay',
             [],
-            new DateTime("$year-10-4", new DateTimeZone($timezone)),
+            new DateTime("$year-10-4", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -239,7 +238,7 @@ trait CommonHolidays
         return new Holiday(
             'stMartinsDay',
             [],
-            new DateTime("$year-11-11", new DateTimeZone($timezone)),
+            new DateTime("$year-11-11", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -277,7 +276,7 @@ trait CommonHolidays
         return new Holiday(
             'fathersDay',
             [],
-            new DateTime("third sunday of june $year", new DateTimeZone($timezone)),
+            new DateTime("third sunday of june $year", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -315,7 +314,7 @@ trait CommonHolidays
         return new Holiday(
             'mothersDay',
             [],
-            new DateTime("second sunday of may $year", new DateTimeZone($timezone)),
+            new DateTime("second sunday of may $year", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -353,7 +352,7 @@ trait CommonHolidays
         return new Holiday(
             'victoryInEuropeDay',
             [],
-            new DateTime("$year-5-8", new DateTimeZone($timezone)),
+            new DateTime("$year-5-8", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -393,7 +392,7 @@ trait CommonHolidays
         return new Holiday(
             'armisticeDay',
             [],
-            new DateTime("$year-11-11", new DateTimeZone($timezone)),
+            new DateTime("$year-11-11", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -428,7 +427,7 @@ trait CommonHolidays
         return new Holiday(
             'internationalWomensDay',
             [],
-            new DateTime("$year-03-08", new DateTimeZone($timezone)),
+            new DateTime("$year-03-08", DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );
@@ -498,7 +497,7 @@ trait CommonHolidays
         string $timezone,
         bool $summer
     ): ?\DateTimeImmutable {
-        $zone = new DateTimeZone($timezone);
+        $zone = DateTimeZoneFactory::getDateTimeZone($timezone);
 
         $transitions = $zone->getTransitions(\mktime(0, 0, 0, 1, 1, $year), \mktime(23, 59, 59, 12, 31, $year));
 

--- a/src/Yasumi/Provider/Croatia.php
+++ b/src/Yasumi/Provider/Croatia.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -66,7 +65,7 @@ class Croatia extends AbstractProvider
             $this->addHoliday(new Holiday('antifascistStruggleDay', [
                 'en' => 'Day of Antifascist Struggle',
                 'hr' => 'Dan antifašističke borbe',
-            ], new DateTime("$this->year-6-22", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-6-22", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
 
         $this->calculateStatehoodDay();
@@ -84,9 +83,9 @@ class Croatia extends AbstractProvider
         $statehoodDayDate = null;
 
         if ($this->year >= 1991 && $this->year < 2020) {
-            $statehoodDayDate = new DateTime("$this->year-6-25", new DateTimeZone($this->timezone));
+            $statehoodDayDate = new DateTime("$this->year-6-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 2020) {
-            $statehoodDayDate = new DateTime("$this->year-5-30", new DateTimeZone($this->timezone));
+            $statehoodDayDate = new DateTime("$this->year-5-30", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         }
 
         if ($statehoodDayDate != null) {
@@ -116,7 +115,7 @@ class Croatia extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'homelandThanksgiving',
                 $names,
-                new DateTime("$this->year-8-5", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-8-5", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -133,7 +132,7 @@ class Croatia extends AbstractProvider
             $this->addHoliday(new Holiday('independenceDay', [
                 'en' => 'Independence Day',
                 'hr' => 'Dan neovisnosti',
-            ], new DateTime("$this->year-10-8", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-10-8", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 
@@ -147,7 +146,7 @@ class Croatia extends AbstractProvider
             $this->addHoliday(new Holiday('remembranceDay', [
                 'en' => 'Remembrance Day for Homeland War Victims and Remembrance Day for the Victims of Vukovar and Skabrnja',
                 'hr' => 'Dan sjećanja na žrtve Domovinskog rata i Dan sjećanja na žrtvu Vukovara i Škabrnje',
-            ], new DateTime("$this->year-11-18", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-11-18", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 }

--- a/src/Yasumi/Provider/DateTimeZoneFactory.php
+++ b/src/Yasumi/Provider/DateTimeZoneFactory.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2020 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\Provider;
+
+/**
+ * This factory keep references to already instantiated DateTimeZone to save CPU time resources
+ *
+ * @author Pierrick VIGNAND <pierrick.vignand@gmail.com>
+ */
+final class DateTimeZoneFactory
+{
+    /** @var array<string, \DateTimeZone> */
+    private static $dateTimeZones;
+
+    public static function getDateTimeZone(string $timezone): \DateTimeZone
+    {
+        if (!isset(self::$dateTimeZones[$timezone])) {
+            self::$dateTimeZones[$timezone] = new \DateTimeZone($timezone);
+        }
+
+        return self::$dateTimeZones[$timezone];
+    }
+}

--- a/src/Yasumi/Provider/Denmark.php
+++ b/src/Yasumi/Provider/Denmark.php
@@ -14,7 +14,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -98,7 +97,7 @@ class Denmark extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'greatPrayerDay',
                 ['da' => 'store bededag'],
-                new DateTime("fourth friday $easter", new DateTimeZone($this->timezone)),
+                new DateTime("fourth friday $easter", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -126,7 +125,7 @@ class Denmark extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'constitutionDay',
                 ['da' => 'grundlovsdag'],
-                new DateTime("$this->year-6-5", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-6-5", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OBSERVANCE
             ));

--- a/src/Yasumi/Provider/Finland.php
+++ b/src/Yasumi/Provider/Finland.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -90,7 +89,7 @@ class Finland extends AbstractProvider
         $this->addHoliday(new Holiday(
             'stJohnsDay',
             [],
-            new DateTime($stJohnsDay, new DateTimeZone($this->timezone)),
+            new DateTime($stJohnsDay, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -122,7 +121,7 @@ class Finland extends AbstractProvider
         $this->addHoliday(new Holiday(
             'allSaintsDay',
             [],
-            new DateTime("$this->year-10-31 this saturday", new DateTimeZone($this->timezone)),
+            new DateTime("$this->year-10-31 this saturday", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -151,7 +150,7 @@ class Finland extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'independenceDay',
                 ['fi' => 'Itsenäisyyspäivä'],
-                new DateTime("$this->year-12-6", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-12-6", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/France.php
+++ b/src/Yasumi/Provider/France.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -90,7 +89,7 @@ class France extends AbstractProvider
             $this->addHoliday(new Holiday('bastilleDay', [
                 'en' => 'Bastille Day',
                 'fr' => 'La Fête nationale',
-            ], new DateTime("$this->year-7-14", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-7-14", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 }

--- a/src/Yasumi/Provider/Germany/Berlin.php
+++ b/src/Yasumi/Provider/Germany/Berlin.php
@@ -13,10 +13,10 @@
 namespace Yasumi\Provider\Germany;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Germany;
 
 /**
@@ -86,7 +86,7 @@ class Berlin extends Germany
         return new Holiday(
             'dayOfLiberation',
             [],
-            new DateTime('2020-05-08', new DateTimeZone($timezone)),
+            new DateTime('2020-05-08', DateTimeZoneFactory::getDateTimeZone($timezone)),
             $locale,
             $type
         );

--- a/src/Yasumi/Provider/Germany/Saxony.php
+++ b/src/Yasumi/Provider/Germany/Saxony.php
@@ -13,10 +13,10 @@
 namespace Yasumi\Provider\Germany;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Germany;
 
 /**
@@ -93,7 +93,7 @@ class Saxony extends Germany
             $this->addHoliday(new Holiday(
                 'repentanceAndPrayerDay',
                 ['de' => 'Buß- und Bettag'],
-                new DateTime("next wednesday $this->year-11-15", new DateTimeZone($this->timezone)),
+                new DateTime("next wednesday $this->year-11-15", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OFFICIAL
             ));

--- a/src/Yasumi/Provider/Greece.php
+++ b/src/Yasumi/Provider/Greece.php
@@ -14,7 +14,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -86,7 +85,7 @@ class Greece extends AbstractProvider
         $this->addHoliday(new Holiday(
             'threeHolyHierarchs',
             ['el' => 'Τριών Ιεραρχών'],
-            new DateTime("$this->year-1-30", new DateTimeZone($this->timezone)),
+            new DateTime("$this->year-1-30", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OTHER
         ));
@@ -150,7 +149,7 @@ class Greece extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'independenceDay',
                 ['el' => 'Εικοστή Πέμπτη Μαρτίου'],
-                new DateTime("$this->year-3-25", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-3-25", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -174,7 +173,7 @@ class Greece extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'ohiDay',
                 ['el' => 'Επέτειος του Όχι'],
-                new DateTime("$this->year-10-28", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-10-28", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -198,7 +197,7 @@ class Greece extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'polytechnio',
                 ['el' => 'Πολυτεχνείο'],
-                new DateTime("$this->year-11-17", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-11-17", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));

--- a/src/Yasumi/Provider/Hungary.php
+++ b/src/Yasumi/Provider/Hungary.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -68,7 +67,7 @@ class Hungary extends AbstractProvider
             $this->addHoliday(new Holiday('memorialDay1848', [
                 'en' => 'Memorial day of the 1848 Revolution',
                 'hu' => 'Az 1848-as forradalom ünnepe',
-            ], new DateTime("$this->year-3-15", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-3-15", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
 
         /**
@@ -78,7 +77,7 @@ class Hungary extends AbstractProvider
             $this->addHoliday(new Holiday('stateFoundation', [
                 'en' => 'State Foundation Day',
                 'hu' => 'Az államalapítás ünnepe',
-            ], new DateTime("$this->year-8-20", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-8-20", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
 
         /**
@@ -88,7 +87,7 @@ class Hungary extends AbstractProvider
             $this->addHoliday(new Holiday('memorialDay1956', [
                 'en' => 'Memorial day of the 1956 Revolution',
                 'hu' => 'Az 1956-os forradalom ünnepe',
-            ], new DateTime("$this->year-10-23", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-10-23", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 }

--- a/src/Yasumi/Provider/Ireland.php
+++ b/src/Yasumi/Provider/Ireland.php
@@ -14,7 +14,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -69,7 +68,7 @@ class Ireland extends AbstractProvider
         $this->addHoliday(new Holiday(
             'augustHoliday',
             ['en' => 'August Holiday', 'ga' => 'Lá Saoire i mí Lúnasa'],
-            new DateTime("next monday $this->year-7-31", new DateTimeZone($this->timezone)),
+            new DateTime("next monday $this->year-7-31", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
         $this->calculateOctoberHoliday();
@@ -158,7 +157,7 @@ class Ireland extends AbstractProvider
         $holiday = new Holiday(
             'christmasDay',
             ['en' => 'Christmas Day', 'ga' => 'Lá Nollag'],
-            new DateTime($this->year . '-12-25', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-12-25', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         );
 
@@ -198,7 +197,7 @@ class Ireland extends AbstractProvider
         $holiday = new Holiday(
             'stStephensDay',
             [],
-            new DateTime($this->year . '-12-26', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-12-26', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         );
 
@@ -243,7 +242,7 @@ class Ireland extends AbstractProvider
         $holiday = new Holiday(
             'stPatricksDay',
             ['en' => 'St. Patrick’s Day', 'ga' => 'Lá Fhéile Pádraig'],
-            new DateTime($this->year . '-3-17', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-3-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         );
 
@@ -289,7 +288,7 @@ class Ireland extends AbstractProvider
         $this->addHoliday(new Holiday(
             'mayDay',
             ['en' => 'May Day', 'ga' => 'Lá Bealtaine'],
-            new DateTime("next monday $this->year-4-30", new DateTimeZone($this->timezone)),
+            new DateTime("next monday $this->year-4-30", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -317,7 +316,7 @@ class Ireland extends AbstractProvider
         $this->addHoliday(new Holiday(
             'juneHoliday',
             ['en' => 'June Holiday', 'ga' => 'Lá Saoire i mí an Mheithimh'],
-            new DateTime("next monday $this->year-5-31", new DateTimeZone($this->timezone)),
+            new DateTime("next monday $this->year-5-31", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -344,7 +343,7 @@ class Ireland extends AbstractProvider
         $this->addHoliday(new Holiday(
             'octoberHoliday',
             ['en' => 'October Holiday', 'ga' => 'Lá Saoire i mí Dheireadh Fómhair'],
-            new DateTime("previous monday $this->year-11-01", new DateTimeZone($this->timezone)),
+            new DateTime("previous monday $this->year-11-01", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/Italy.php
+++ b/src/Yasumi/Provider/Italy.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -85,7 +84,7 @@ class Italy extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'liberationDay',
                 ['it' => 'Festa della Liberazione'],
-                new DateTime("$this->year-4-25", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-4-25", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -113,7 +112,7 @@ class Italy extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'republicDay',
                 ['it' => 'Festa della Repubblica'],
-                new DateTime("$this->year-6-2", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-6-2", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Japan.php
+++ b/src/Yasumi/Provider/Japan.php
@@ -16,7 +16,6 @@ namespace Yasumi\Provider;
 use DateInterval;
 use DateTime;
 use DateTimeInterface;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -123,7 +122,7 @@ class Japan extends AbstractProvider
                     'en' => 'National Foundation Day',
                     'ja' => '建国記念の日',
                 ],
-                new DateTime("$this->year-2-11", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-2-11", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -143,7 +142,7 @@ class Japan extends AbstractProvider
                     'en' => 'Showa Day',
                     'ja' => '昭和の日',
                 ],
-                new DateTime("$this->year-4-29", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-4-29", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -163,7 +162,7 @@ class Japan extends AbstractProvider
                     'en' => 'Constitution Memorial Day',
                     'ja' => '憲法記念日',
                 ],
-                new DateTime("$this->year-5-3", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-5-3", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -183,7 +182,7 @@ class Japan extends AbstractProvider
                     'en' => 'Children’s Day',
                     'ja' => 'こどもの日',
                 ],
-                new DateTime("$this->year-5-5", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-5-5", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -200,7 +199,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'cultureDay',
                 ['en' => 'Culture Day', 'ja' => '文化の日'],
-                new DateTime("$this->year-11-3", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-11-3", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -217,7 +216,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'laborThanksgivingDay',
                 ['en' => 'Labor Thanksgiving Day', 'ja' => '勤労感謝の日'],
-                new DateTime("$this->year-11-23", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-11-23", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -246,7 +245,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'emperorsBirthday',
                 ['en' => 'Emperors Birthday', 'ja' => '天皇誕生日'],
-                new DateTime($emperorsBirthday, new DateTimeZone($this->timezone)),
+                new DateTime($emperorsBirthday, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -285,7 +284,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'vernalEquinoxDay',
                 ['en' => 'Vernal Equinox Day', 'ja' => '春分の日'],
-                new DateTime("$this->year-3-$day", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-3-$day", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -307,9 +306,9 @@ class Japan extends AbstractProvider
     {
         $date = null;
         if ($this->year >= 2000) {
-            $date = new DateTime("second monday of january $this->year", new DateTimeZone($this->timezone));
+            $date = new DateTime("second monday of january $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 1948) {
-            $date = new DateTime("$this->year-1-15", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-1-15", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         }
 
         if ($date instanceof DateTimeInterface) {
@@ -337,9 +336,9 @@ class Japan extends AbstractProvider
     {
         $date = null;
         if ($this->year >= 2007) {
-            $date = new DateTime("$this->year-5-4", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-5-4", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 1989) {
-            $date = new DateTime("$this->year-4-29", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-4-29", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         }
 
         if ($date instanceof DateTimeInterface) {
@@ -369,11 +368,11 @@ class Japan extends AbstractProvider
     {
         $date = null;
         if (2020 === $this->year) {
-            $date = new DateTime("$this->year-7-23", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-7-23", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 2003) {
-            $date = new DateTime("third monday of july $this->year", new DateTimeZone($this->timezone));
+            $date = new DateTime("third monday of july $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 1996) {
-            $date = new DateTime("$this->year-7-20", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-7-20", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         }
 
         if ($date instanceof DateTimeInterface) {
@@ -400,9 +399,9 @@ class Japan extends AbstractProvider
     {
         $date = null;
         if (2020 === $this->year) {
-            $date = new DateTime("$this->year-8-10", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-8-10", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 2016) {
-            $date = new DateTime("$this->year-8-11", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-8-11", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         }
 
         if ($date instanceof DateTimeInterface) {
@@ -431,9 +430,9 @@ class Japan extends AbstractProvider
     {
         $date = null;
         if ($this->year >= 2003) {
-            $date = new DateTime("third monday of september $this->year", new DateTimeZone($this->timezone));
+            $date = new DateTime("third monday of september $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 1996) {
-            $date = new DateTime("$this->year-9-15", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-9-15", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         }
 
         if ($date instanceof DateTimeInterface) {
@@ -463,11 +462,11 @@ class Japan extends AbstractProvider
     {
         $date = null;
         if (2020 === $this->year) {
-            $date = new DateTime("$this->year-7-24", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-7-24", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 2000) {
-            $date = new DateTime("second monday of october $this->year", new DateTimeZone($this->timezone));
+            $date = new DateTime("second monday of october $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 1996) {
-            $date = new DateTime("$this->year-10-10", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-10-10", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         }
 
         $holidayName = ['en' => 'Health And Sports Day', 'ja' => '体育の日'];
@@ -518,7 +517,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'autumnalEquinoxDay',
                 ['en' => 'Autumnal Equinox Day', 'ja' => '秋分の日'],
-                new DateTime("$this->year-9-$day", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-9-$day", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -586,7 +585,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'coronationDay',
                 ['en' => 'Coronation Day', 'ja' => '即位の日'],
-                new DateTime("$this->year-5-1", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-5-1", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -604,7 +603,7 @@ class Japan extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'enthronementProclamationCeremony',
                 ['en' => 'Enthronement Proclamation Ceremony', 'ja' => '即位礼正殿の儀'],
-                new DateTime("$this->year-10-22", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-10-22", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Luxembourg.php
+++ b/src/Yasumi/Provider/Luxembourg.php
@@ -3,7 +3,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -71,7 +70,7 @@ class Luxembourg extends AbstractProvider
             $this->addHoliday(new Holiday('europeDay', [
                 'en_US' => 'Europe day',
                 'fr' => 'La Journée de l’Europe',
-            ], new DateTime("$this->year-5-9", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-5-9", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 
@@ -96,6 +95,6 @@ class Luxembourg extends AbstractProvider
         $this->addHoliday(new Holiday('nationalDay', [
             'en_US' => 'National day',
             'fr' => 'La Fête nationale',
-        ], new DateTime("$this->year-6-23", new DateTimeZone($this->timezone)), $this->locale));
+        ], new DateTime("$this->year-6-23", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
     }
 }

--- a/src/Yasumi/Provider/Netherlands.php
+++ b/src/Yasumi/Provider/Netherlands.php
@@ -14,7 +14,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -187,7 +186,7 @@ class Netherlands extends AbstractProvider
         $this->addHoliday(new Holiday(
             'stNicholasDay',
             ['en' => 'St. Nicholas’ Day', 'nl' => 'Sinterklaas'],
-            new DateTime("$this->year-12-5", new DateTimeZone($this->timezone)),
+            new DateTime("$this->year-12-5", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OBSERVANCE
         ));
@@ -210,7 +209,7 @@ class Netherlands extends AbstractProvider
         $this->addHoliday(new Holiday(
             'halloween',
             ['en' => 'Halloween', 'nl' => 'Halloween'],
-            new DateTime("$this->year-10-31", new DateTimeZone($this->timezone)),
+            new DateTime("$this->year-10-31", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OBSERVANCE
         ));
@@ -229,7 +228,7 @@ class Netherlands extends AbstractProvider
         $this->addHoliday(new Holiday(
             'princesDay',
             ['en' => 'Prince’s Day', 'nl' => 'Prinsjesdag'],
-            new DateTime("third tuesday of september $this->year", new DateTimeZone($this->timezone)),
+            new DateTime("third tuesday of september $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OTHER
         ));
@@ -247,9 +246,9 @@ class Netherlands extends AbstractProvider
     private function calculateQueensday(): void
     {
         if ($this->year >= 1891 && $this->year <= 2013) {
-            $date = new DateTime("$this->year-4-30", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-4-30", DateTimeZoneFactory::getDateTimeZone($this->timezone));
             if ($this->year <= 1948) {
-                $date = new DateTime("$this->year-8-31", new DateTimeZone($this->timezone));
+                $date = new DateTime("$this->year-8-31", DateTimeZoneFactory::getDateTimeZone($this->timezone));
             }
 
             // Determine substitution day
@@ -277,7 +276,7 @@ class Netherlands extends AbstractProvider
     private function calculateKingsday(): void
     {
         if ($this->year >= 2014) {
-            $date = new DateTime("$this->year-4-27", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-4-27", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
             if (0 === (int)$date->format('w')) {
                 $date->sub(new DateInterval('P1D'));
@@ -305,14 +304,14 @@ class Netherlands extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'commemorationDay',
                 ['en' => 'Commemoration Day', 'nl' => 'dodenherdenking'],
-                new DateTime("$this->year-5-4", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-5-4", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OBSERVANCE
             ));
             $this->addHoliday(new Holiday(
                 'liberationDay',
                 ['en' => 'Liberation Day', 'nl' => 'Bevrijdingsdag'],
-                new DateTime("$this->year-5-5", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-5-5", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OFFICIAL
             ));

--- a/src/Yasumi/Provider/NewZealand.php
+++ b/src/Yasumi/Provider/NewZealand.php
@@ -14,7 +14,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -75,8 +74,8 @@ class NewZealand extends AbstractProvider
      */
     private function calculateNewYearHolidays(): void
     {
-        $newYearsDay = new DateTime("$this->year-01-01", new DateTimeZone($this->timezone));
-        $dayAfterNewYearsDay = new DateTime("$this->year-01-02", new DateTimeZone($this->timezone));
+        $newYearsDay = new DateTime("$this->year-01-01", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $dayAfterNewYearsDay = new DateTime("$this->year-01-02", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         switch ($newYearsDay->format('w')) {
             case 0:
@@ -119,7 +118,7 @@ class NewZealand extends AbstractProvider
             return;
         }
 
-        $date = new DateTime("$this->year-02-6", new DateTimeZone($this->timezone));
+        $date = new DateTime("$this->year-02-6", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         if ($this->year >= 2015 && !$this->isWorkingDay($date)) {
             $date->modify('next monday');
@@ -149,7 +148,7 @@ class NewZealand extends AbstractProvider
             return;
         }
 
-        $date = new DateTime("$this->year-04-25", new DateTimeZone($this->timezone));
+        $date = new DateTime("$this->year-04-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         if ($this->year >= 2015 && !$this->isWorkingDay($date)) {
             $date->modify('next monday');
@@ -185,7 +184,7 @@ class NewZealand extends AbstractProvider
         $this->addHoliday(new Holiday(
             'queensBirthday',
             [],
-            new DateTime("first monday of june $this->year", new DateTimeZone($this->timezone)),
+            new DateTime("first monday of june $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -217,7 +216,7 @@ class NewZealand extends AbstractProvider
 
         $date = new DateTime(
             ($this->year < 1910 ? 'second wednesday of october' : 'fourth monday of october') . " $this->year",
-            new DateTimeZone($this->timezone)
+            DateTimeZoneFactory::getDateTimeZone($this->timezone)
         );
 
         $this->addHoliday(new Holiday('labourDay', [], $date, $this->locale));
@@ -240,8 +239,8 @@ class NewZealand extends AbstractProvider
      */
     private function calculateChristmasHolidays(): void
     {
-        $christmasDay = new DateTime("$this->year-12-25", new DateTimeZone($this->timezone));
-        $boxingDay = new DateTime("$this->year-12-26", new DateTimeZone($this->timezone));
+        $christmasDay = new DateTime("$this->year-12-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $boxingDay = new DateTime("$this->year-12-26", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         switch ($christmasDay->format('w')) {
             case 0:

--- a/src/Yasumi/Provider/Norway.php
+++ b/src/Yasumi/Provider/Norway.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -86,7 +85,7 @@ class Norway extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'constitutionDay',
                 ['nb' => 'grunnlovsdagen'],
-                new DateTime("$this->year-5-17", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-5-17", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Poland.php
+++ b/src/Yasumi/Provider/Poland.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -88,7 +87,7 @@ class Poland extends AbstractProvider
         $this->addHoliday(new Holiday('independenceDay', [
             'en' => 'Independence Day',
             'pl' => 'Narodowe Święto Niepodległości',
-        ], new DateTime("$this->year-11-11", new DateTimeZone($this->timezone)), $this->locale));
+        ], new DateTime("$this->year-11-11", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
     }
 
     /**
@@ -116,6 +115,6 @@ class Poland extends AbstractProvider
         $this->addHoliday(new Holiday('constitutionDay', [
             'en' => 'Constitution Day',
             'pl' => 'Święto Narodowe Trzeciego Maja',
-        ], new DateTime("$this->year-5-3", new DateTimeZone($this->timezone)), $this->locale));
+        ], new DateTime("$this->year-5-3", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
     }
 }

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -89,7 +88,7 @@ class Portugal extends AbstractProvider
             $this->addHoliday(new Holiday(
                 '25thApril',
                 ['pt' => 'Dia da Liberdade'],
-                new DateTime("$this->year-04-25", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-04-25", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OFFICIAL
             ));
@@ -136,7 +135,7 @@ class Portugal extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'portugalDay',
                 ['pt' => 'Dia de Portugal'],
-                new DateTime("$this->year-06-10", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-06-10", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -170,7 +169,7 @@ class Portugal extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'portugueseRepublic',
                 ['pt' => 'Implantação da República Portuguesa'],
-                new DateTime("$this->year-10-05", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-10-05", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -226,7 +225,7 @@ class Portugal extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'restorationOfIndependence',
                 ['pt' => 'Restauração da Independência'],
-                new DateTime("$this->year-12-01", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-12-01", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OFFICIAL
             ));

--- a/src/Yasumi/Provider/Romania.php
+++ b/src/Yasumi/Provider/Romania.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -91,7 +90,7 @@ class Romania extends AbstractProvider
         $this->addHoliday(new Holiday(
             'dayAfterNewYearsDay',
             [],
-            new DateTime("$this->year-01-02", new DateTimeZone($this->timezone)),
+            new DateTime("$this->year-01-02", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -118,7 +117,7 @@ class Romania extends AbstractProvider
             $this->addHoliday(new Holiday('unitedPrincipalitiesDay', [
                 'en' => 'Union Day / Small Union',
                 'ro' => 'Unirea Principatelor Române / Mica Unire',
-            ], new DateTime("$this->year-01-24", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-01-24", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 
@@ -140,7 +139,7 @@ class Romania extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'stAndrewsDay',
                 [],
-                new DateTime($this->year . '-11-30', new DateTimeZone($this->timezone)),
+                new DateTime($this->year . '-11-30', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -183,7 +182,7 @@ class Romania extends AbstractProvider
             $this->addHoliday(new Holiday('nationalDay', [
                 'en' => 'National Day',
                 'ro' => 'Ziua Națională',
-            ], new DateTime($nationalDay, new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime($nationalDay, DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 
@@ -207,7 +206,7 @@ class Romania extends AbstractProvider
                     'en' => 'Constantin Brâncuși day',
                     'ro' => 'Ziua Constantin Brâncuși',
                 ],
-                new DateTime("$this->year-02-19", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-02-19", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OBSERVANCE
             ));
@@ -236,7 +235,7 @@ class Romania extends AbstractProvider
                     'en' => 'International Children’s Day',
                     'ro' => 'Ziua Copilului',
                 ],
-                new DateTime("$this->year-06-01", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-06-01", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OBSERVANCE
             ));
@@ -246,7 +245,7 @@ class Romania extends AbstractProvider
             $this->addHoliday(new Holiday('childrensDay', [
                 'en' => 'International Children’s Day',
                 'ro' => 'Ziua Copilului',
-            ], new DateTime("$this->year-06-01", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-06-01", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 

--- a/src/Yasumi/Provider/Slovakia.php
+++ b/src/Yasumi/Provider/Slovakia.php
@@ -14,7 +14,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -125,7 +124,7 @@ class Slovakia extends AbstractProvider
                 'sk' => 'Deň vzniku Slovenskej republiky',
                 'en' => 'Day of the Establishment of the Slovak Republic',
             ],
-            new DateTime($this->year . '-01-01', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-01-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -151,7 +150,7 @@ class Slovakia extends AbstractProvider
                 'cs' => 'Den slovanských věrozvěstů Cyrila a Metoděje',
                 'en' => 'Saints Cyril and Methodius Day',
             ],
-            new DateTime($this->year . '-07-05', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-07-05', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -175,7 +174,7 @@ class Slovakia extends AbstractProvider
                 'sk' => 'Výročie Slovenského národného povstania',
                 'en' => 'Slovak National Uprising Day',
             ],
-            new DateTime($this->year . '-08-29', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-08-29', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -199,7 +198,7 @@ class Slovakia extends AbstractProvider
                 'sk' => 'Deň Ústavy Slovenskej republiky',
                 'en' => 'Day of the Constitution of the Slovak Republic',
             ],
-            new DateTime($this->year . '-09-01', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-09-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -224,7 +223,7 @@ class Slovakia extends AbstractProvider
         $this->addHoliday(new Holiday('ourLadyOfSorrowsDay', [
             'sk' => 'Sviatok Sedembolestnej Panny Márie',
             'en' => 'Our Lady of Sorrows Day',
-        ], new DateTime($this->year . '-09-15', new DateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_BANK));
+        ], new DateTime($this->year . '-09-15', DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_BANK));
     }
 
     /**
@@ -246,7 +245,7 @@ class Slovakia extends AbstractProvider
                 'cs' => 'Den boje za svobodu a demokracii',
                 'en' => 'Struggle for Freedom and Democracy Day',
             ],
-            new DateTime($this->year . '-11-17', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-11-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));

--- a/src/Yasumi/Provider/SouthAfrica.php
+++ b/src/Yasumi/Provider/SouthAfrica.php
@@ -15,7 +15,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -100,7 +99,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'humanRightsDay',
             ['en' => 'Human Rights Day'],
-            new DateTime($this->year . '-3-21', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-3-21', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -145,7 +144,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'freedomDay',
             ['en' => 'Freedom Day'],
-            new DateTime($this->year . '-4-27', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-4-27', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -172,7 +171,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'youthDay',
             ['en' => 'Youth Day'],
-            new DateTime($this->year . '-6-16', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-6-16', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -199,7 +198,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             '2016MunicipalElectionsDay',
             ['en' => '2016 Municipal Elections Day'],
-            new DateTime('2016-8-3', new DateTimeZone($this->timezone)),
+            new DateTime('2016-8-3', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -224,7 +223,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'nationalWomensDay',
             ['en' => 'National Women’s Day'],
-            new DateTime($this->year . '-8-9', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-8-9', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -249,7 +248,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'heritageDay',
             ['en' => 'Heritage Day'],
-            new DateTime($this->year . '-9-24', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-9-24', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -276,7 +275,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'reconciliationDay',
             ['en' => 'Day of Reconciliation'],
-            new DateTime($this->year . '-12-16', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-12-16', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -306,7 +305,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'substituteDayOfGoodwill',
             ['en' => 'Day of Goodwill observed'],
-            new DateTime('2016-12-27', new DateTimeZone($this->timezone)),
+            new DateTime('2016-12-27', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/SouthKorea.php
+++ b/src/Yasumi/Provider/SouthKorea.php
@@ -15,7 +15,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -165,7 +164,7 @@ class SouthKorea extends AbstractProvider
                 $this->addHoliday(new Holiday(
                     'dayAfterNewYearsDay',
                     [],
-                    new DateTime("$this->year-1-2", new DateTimeZone($this->timezone)),
+                    new DateTime("$this->year-1-2", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                     $this->locale
                 ));
             }
@@ -173,7 +172,7 @@ class SouthKorea extends AbstractProvider
                 $this->addHoliday(new Holiday(
                     'twoDaysLaterNewYearsDay',
                     ['en' => 'Two Days Later New Year’s Day', 'ko' => '새해 연휴'],
-                    new DateTime("$this->year-1-3", new DateTimeZone($this->timezone)),
+                    new DateTime("$this->year-1-3", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                     $this->locale
                 ));
             }
@@ -191,7 +190,7 @@ class SouthKorea extends AbstractProvider
     public function calculateSeollal(): void
     {
         if ($this->year >= 1985 && isset(self::LUNAR_HOLIDAY['seollal'][$this->year])) {
-            $seollal = new DateTime(self::LUNAR_HOLIDAY['seollal'][$this->year], new DateTimeZone($this->timezone));
+            $seollal = new DateTime(self::LUNAR_HOLIDAY['seollal'][$this->year], DateTimeZoneFactory::getDateTimeZone($this->timezone));
             $this->addHoliday(new Holiday(
                 'seollal',
                 ['en' => 'Seollal', 'ko' => '설날'],
@@ -232,7 +231,7 @@ class SouthKorea extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'buddhasBirthday',
                 ['en' => 'Buddha’s Birthday', 'ko' => '부처님오신날'],
-                new DateTime(self::LUNAR_HOLIDAY['buddhasBirthday'][$this->year], new DateTimeZone($this->timezone)),
+                new DateTime(self::LUNAR_HOLIDAY['buddhasBirthday'][$this->year], DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -255,7 +254,7 @@ class SouthKorea extends AbstractProvider
             $chuseok = new Holiday(
                 'chuseok',
                 ['en' => 'Chuseok', 'ko' => '추석'],
-                new DateTime(self::LUNAR_HOLIDAY['chuseok'][$this->year], new DateTimeZone($this->timezone)),
+                new DateTime(self::LUNAR_HOLIDAY['chuseok'][$this->year], DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             );
             $this->addHoliday($chuseok);
@@ -295,7 +294,7 @@ class SouthKorea extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'independenceMovementDay',
                 ['en' => 'Independence Movement Day', 'ko' => '삼일절'],
-                new DateTime("$this->year-3-1", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-3-1", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -314,7 +313,7 @@ class SouthKorea extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'arborDay',
                 ['en' => 'Arbor Day', 'ko' => '식목일'],
-                new DateTime("$this->year-4-5", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-4-5", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -333,7 +332,7 @@ class SouthKorea extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'childrensDay',
                 ['en' => 'Children’s Day', 'ko' => '어린이날'],
-                new DateTime("$this->year-5-5", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-5-5", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -352,7 +351,7 @@ class SouthKorea extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'memorialDay',
                 ['en' => 'Memorial Day', 'ko' => '현충일'],
-                new DateTime("$this->year-6-6", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-6-6", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -374,7 +373,7 @@ class SouthKorea extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'constitutionDay',
                 ['en' => 'Constitution Day', 'ko' => '제헌절'],
-                new DateTime("$this->year-7-17", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-7-17", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -393,7 +392,7 @@ class SouthKorea extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'liberationDay',
                 ['en' => 'Liberation Day', 'ko' => '광복절'],
-                new DateTime("$this->year-8-15", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-8-15", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -412,7 +411,7 @@ class SouthKorea extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'armedForcesDay',
                 ['en' => 'Armed Forces Day', 'ko' => '국군의 날'],
-                new DateTime("$this->year-10-1", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-10-1", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -431,7 +430,7 @@ class SouthKorea extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'nationalFoundationDay',
                 ['en' => 'National Foundation Day', 'ko' => '개천절'],
-                new DateTime("$this->year-10-3", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-10-3", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -450,7 +449,7 @@ class SouthKorea extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'hangulDay',
                 ['en' => 'Hangul Day', 'ko' => '한글날'],
-                new DateTime("$this->year-10-9", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-10-9", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain.php
+++ b/src/Yasumi/Provider/Spain.php
@@ -13,7 +13,6 @@
 namespace Yasumi\Provider;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -87,7 +86,7 @@ class Spain extends AbstractProvider
                     'ca' => 'Festa Nacional d’Espanya',
                     'es' => 'Fiesta Nacional de España',
                 ],
-                new DateTime("$this->year-10-12", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-10-12", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -116,7 +115,7 @@ class Spain extends AbstractProvider
                     'ca' => 'Dia de la Constitució',
                     'es' => 'Día de la Constitución',
                 ],
-                new DateTime("$this->year-12-6", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-12-6", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/Andalusia.php
+++ b/src/Yasumi/Provider/Spain/Andalusia.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -79,7 +79,7 @@ class Andalusia extends Spain
             $this->addHoliday(new Holiday(
                 'andalusiaDay',
                 ['es' => 'Día de Andalucía'],
-                new DateTime("$this->year-2-28", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-2-28", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/Asturias.php
+++ b/src/Yasumi/Provider/Spain/Asturias.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -81,7 +81,7 @@ class Asturias extends Spain
             $this->addHoliday(new Holiday(
                 'asturiasDay',
                 ['es' => 'Día de Asturias'],
-                new DateTime("$this->year-9-8", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-9-8", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/BalearicIslands.php
+++ b/src/Yasumi/Provider/Spain/BalearicIslands.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -84,7 +84,7 @@ class BalearicIslands extends Spain
                     'ca' => 'Diada de les Illes Balears',
                     'es' => 'Día de les Illes Balears',
                 ],
-                new DateTime("$this->year-3-1", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-3-1", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/BasqueCountry.php
+++ b/src/Yasumi/Provider/Spain/BasqueCountry.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -81,7 +81,7 @@ class BasqueCountry extends Spain
             $this->addHoliday(new Holiday(
                 'basqueCountryDay',
                 ['es' => 'Euskadi Eguna'],
-                new DateTime("$this->year-10-25", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-10-25", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/CanaryIslands.php
+++ b/src/Yasumi/Provider/Spain/CanaryIslands.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -80,7 +80,7 @@ class CanaryIslands extends Spain
             $this->addHoliday(new Holiday(
                 'canaryIslandsDay',
                 ['es' => 'Día de las Canarias'],
-                new DateTime("$this->year-5-30", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-5-30", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/Cantabria.php
+++ b/src/Yasumi/Provider/Spain/Cantabria.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -84,7 +84,7 @@ class Cantabria extends Spain
             $this->addHoliday(new Holiday(
                 'cantabriaDay',
                 ['es' => 'Día de Cantabria'],
-                new DateTime("second sunday of august $this->year", new DateTimeZone($this->timezone)),
+                new DateTime("second sunday of august $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/CastileAndLeon.php
+++ b/src/Yasumi/Provider/Spain/CastileAndLeon.php
@@ -14,11 +14,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -81,7 +81,7 @@ class CastileAndLeon extends Spain
             $this->addHoliday(new Holiday(
                 'castileAndLeonDay',
                 ['es' => 'Día de Castilla y León'],
-                new DateTime("$this->year-4-23", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-4-23", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/CastillaLaMancha.php
+++ b/src/Yasumi/Provider/Spain/CastillaLaMancha.php
@@ -14,11 +14,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -84,7 +84,7 @@ class CastillaLaMancha extends Spain
             $this->addHoliday(new Holiday(
                 'castillaLaManchaDay',
                 ['es' => 'Día de la Región Castilla-La Mancha'],
-                new DateTime("$this->year-5-31", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-5-31", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/Catalonia.php
+++ b/src/Yasumi/Provider/Spain/Catalonia.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -87,7 +87,7 @@ class Catalonia extends Spain
                     'ca' => 'Diada Nacional de Catalunya',
                     'es' => 'Diada Nacional de Cataluña',
                 ],
-                new DateTime("$this->year-9-11", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-9-11", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/Ceuta.php
+++ b/src/Yasumi/Provider/Spain/Ceuta.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -78,7 +78,7 @@ class Ceuta extends Spain
             $this->addHoliday(new Holiday(
                 'ceutaDay',
                 ['es' => 'Día de Ceuta'],
-                new DateTime("$this->year-9-2", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-9-2", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/CommunityOfMadrid.php
+++ b/src/Yasumi/Provider/Spain/CommunityOfMadrid.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -84,7 +84,7 @@ class CommunityOfMadrid extends Spain
         $this->addHoliday(new Holiday(
             'dosdeMayoUprisingDay',
             ['es' => 'Fiesta de la Comunidad de Madrid'],
-            new DateTime("$this->year-5-2", new DateTimeZone($this->timezone)),
+            new DateTime("$this->year-5-2", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/Spain/Extremadura.php
+++ b/src/Yasumi/Provider/Spain/Extremadura.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -81,7 +81,7 @@ class Extremadura extends Spain
             $this->addHoliday(new Holiday(
                 'extremaduraDay',
                 ['es' => 'Día de Extremadura'],
-                new DateTime("$this->year-9-8", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-9-8", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Spain/Galicia.php
+++ b/src/Yasumi/Provider/Spain/Galicia.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -82,7 +82,7 @@ class Galicia extends Spain
             $this->addHoliday(new Holiday('galicianLiteratureDay', [
                 'es' => 'Día de las Letras Gallegas',
                 'gl' => 'Día das Letras Galegas',
-            ], new DateTime("$this->year-5-17", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-5-17", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 
@@ -109,7 +109,7 @@ class Galicia extends Spain
         if ($this->year >= 2000) {
             $this->addHoliday(new Holiday('stJamesDay', [
                 'es' => 'Santiago Apostol',
-            ], new DateTime("$this->year-7-25", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-7-25", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 }

--- a/src/Yasumi/Provider/Spain/LaRioja.php
+++ b/src/Yasumi/Provider/Spain/LaRioja.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -77,7 +77,7 @@ class LaRioja extends Spain
         if ($this->year >= 1983) {
             $this->addHoliday(new Holiday('laRiojaDay', [
                 'es' => 'Día de La Rioja',
-            ], new DateTime("$this->year-6-9", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-6-9", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 }

--- a/src/Yasumi/Provider/Spain/RegionOfMurcia.php
+++ b/src/Yasumi/Provider/Spain/RegionOfMurcia.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -78,7 +78,7 @@ class RegionOfMurcia extends Spain
         if ($this->year >= 1983) {
             $this->addHoliday(new Holiday('murciaDay', [
                 'es' => 'Día de la Región de Murcia',
-            ], new DateTime("$this->year-6-9", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-6-9", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 }

--- a/src/Yasumi/Provider/Spain/ValencianCommunity.php
+++ b/src/Yasumi/Provider/Spain/ValencianCommunity.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Spain;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Spain;
 
 /**
@@ -89,7 +89,7 @@ class ValencianCommunity extends Spain
                     'ca' => 'Diada Nacional del País Valencià',
                     'es' => 'Día de la Comunidad Valenciana',
                 ],
-                new DateTime("$this->year-10-9", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-10-9", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Sweden.php
+++ b/src/Yasumi/Provider/Sweden.php
@@ -14,7 +14,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -90,7 +89,7 @@ class Sweden extends AbstractProvider
         $this->addHoliday(new Holiday(
             'epiphanyEve',
             [],
-            new DateTime("$this->year-1-5", new DateTimeZone($this->timezone)),
+            new DateTime("$this->year-1-5", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OBSERVANCE
         ));
@@ -118,7 +117,7 @@ class Sweden extends AbstractProvider
         $this->addHoliday(new Holiday(
             'walpurgisEve',
             [],
-            new DateTime("$this->year-4-30", new DateTimeZone($this->timezone)),
+            new DateTime("$this->year-4-30", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OBSERVANCE
         ));
@@ -145,7 +144,7 @@ class Sweden extends AbstractProvider
      */
     private function calculateStJohnsHolidays(): void
     {
-        $date = new DateTime("$this->year-6-20 this saturday", new DateTimeZone($this->timezone));
+        $date = new DateTime("$this->year-6-20 this saturday", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $this->addHoliday(new Holiday(
             'stJohnsDay',
             [],
@@ -186,7 +185,7 @@ class Sweden extends AbstractProvider
      */
     private function calculateAllSaintsHolidays(): void
     {
-        $date = new DateTime("$this->year-10-31 this saturday", new DateTimeZone($this->timezone));
+        $date = new DateTime("$this->year-10-31 this saturday", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $this->addHoliday(new Holiday(
             'allSaintsDay',
             [],
@@ -234,7 +233,7 @@ class Sweden extends AbstractProvider
         $this->addHoliday(new Holiday(
             'nationalDay',
             ['sv' => $holidayName],
-            new DateTime("$this->year-6-6", new DateTimeZone($this->timezone)),
+            new DateTime("$this->year-6-6", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/Switzerland.php
+++ b/src/Yasumi/Provider/Switzerland.php
@@ -14,7 +14,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -75,7 +74,7 @@ class Switzerland extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'swissNationalDay',
                 $translations,
-                new DateTime($this->year . '-08-01', new DateTimeZone($this->timezone)),
+                new DateTime($this->year . '-08-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OFFICIAL
             ));
@@ -83,7 +82,7 @@ class Switzerland extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'swissNationalDay',
                 $translations,
-                new DateTime($this->year . '-08-01', new DateTimeZone($this->timezone)),
+                new DateTime($this->year . '-08-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OBSERVANCE
             ));
@@ -113,7 +112,7 @@ class Switzerland extends AbstractProvider
                 'fr' => 'Jour de la Saint-Berthold',
                 'en' => 'Berchtoldstag',
             ],
-            new DateTime($this->year . '-01-02', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-01-02', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OTHER
         ));
@@ -138,7 +137,7 @@ class Switzerland extends AbstractProvider
     {
         if ($this->year >= 1832) {
             // Find third Sunday of September
-            $date = new DateTime('Third Sunday of ' . $this->year . '-09', new DateTimeZone($this->timezone));
+            $date = new DateTime('Third Sunday of ' . $this->year . '-09', DateTimeZoneFactory::getDateTimeZone($this->timezone));
             // Go to next Thursday
             $date->add(new DateInterval('P1D'));
 

--- a/src/Yasumi/Provider/Switzerland/Geneva.php
+++ b/src/Yasumi/Provider/Switzerland/Geneva.php
@@ -14,11 +14,11 @@ namespace Yasumi\Provider\Switzerland;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Switzerland;
 
 /**
@@ -81,7 +81,7 @@ class Geneva extends Switzerland
         }
 
         // Find first Sunday of September
-        $date = new DateTime('First Sunday of ' . $this->year . '-09', new DateTimeZone($this->timezone));
+        $date = new DateTime('First Sunday of ' . $this->year . '-09', DateTimeZoneFactory::getDateTimeZone($this->timezone));
         // Go to next Thursday
         $date->add(new DateInterval('P4D'));
 
@@ -118,7 +118,7 @@ class Geneva extends Switzerland
                 [
                     'fr' => 'Restauration de la République',
                 ],
-                new DateTime($this->year . '-12-31', new DateTimeZone($this->timezone)),
+                new DateTime($this->year . '-12-31', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));

--- a/src/Yasumi/Provider/Switzerland/Glarus.php
+++ b/src/Yasumi/Provider/Switzerland/Glarus.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Switzerland;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Switzerland;
 
 /**
@@ -77,7 +77,7 @@ class Glarus extends Switzerland
     private function calculateNafelserFahrt(): void
     {
         if ($this->year >= 1389) {
-            $date = new DateTime('First Thursday of ' . $this->year . '-04', new DateTimeZone($this->timezone));
+            $date = new DateTime('First Thursday of ' . $this->year . '-04', DateTimeZoneFactory::getDateTimeZone($this->timezone));
             $this->addHoliday(new Holiday('nafelserFahrt', [
                 'de' => 'Näfelser Fahrt',
             ], $date, $this->locale, Holiday::TYPE_OTHER));

--- a/src/Yasumi/Provider/Switzerland/Jura.php
+++ b/src/Yasumi/Provider/Switzerland/Jura.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Switzerland;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Switzerland;
 
 /**
@@ -85,7 +85,7 @@ class Jura extends Switzerland
                 [
                     'fr' => 'Commémoration du plébiscite jurassien',
                 ],
-                new DateTime($this->year . '-06-23', new DateTimeZone($this->timezone)),
+                new DateTime($this->year . '-06-23', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));

--- a/src/Yasumi/Provider/Switzerland/Neuchatel.php
+++ b/src/Yasumi/Provider/Switzerland/Neuchatel.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Switzerland;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Switzerland;
 
 /**
@@ -83,7 +83,7 @@ class Neuchatel extends Switzerland
                 [
                     'fr' => 'Instauration de la République',
                 ],
-                new DateTime($this->year . '-03-01', new DateTimeZone($this->timezone)),
+                new DateTime($this->year . '-03-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));

--- a/src/Yasumi/Provider/Switzerland/Obwalden.php
+++ b/src/Yasumi/Provider/Switzerland/Obwalden.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Switzerland;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Switzerland;
 
 /**
@@ -87,7 +87,7 @@ class Obwalden extends Switzerland
                 [
                     'de' => 'Bruder-Klausen-Fest',
                 ],
-                new DateTime($this->year . '-09-25', new DateTimeZone($this->timezone)),
+                new DateTime($this->year . '-09-25', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));
@@ -97,7 +97,7 @@ class Obwalden extends Switzerland
                 [
                     'de' => 'Bruder-Klausen-Fest',
                 ],
-                new DateTime($this->year . '-09-21', new DateTimeZone($this->timezone)),
+                new DateTime($this->year . '-09-21', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));

--- a/src/Yasumi/Provider/Switzerland/Ticino.php
+++ b/src/Yasumi/Provider/Switzerland/Ticino.php
@@ -13,11 +13,11 @@
 namespace Yasumi\Provider\Switzerland;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\ChristianHolidays;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\Switzerland;
 
 /**
@@ -94,7 +94,7 @@ class Ticino extends Switzerland
                 'fr' => 'Solennité des saints Pierre et Paul',
                 'de' => 'St. Peter und Paul',
             ],
-            new DateTime($this->year . '-06-29', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-06-29', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OTHER
         ));

--- a/src/Yasumi/Provider/USA.php
+++ b/src/Yasumi/Provider/USA.php
@@ -14,7 +14,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -79,7 +78,7 @@ class USA extends AbstractProvider
         if ($this->year >= 1986) {
             $this->addHoliday(new Holiday('martinLutherKingDay', [
                 'en' => 'Dr. Martin Luther King Jr’s Birthday',
-            ], new DateTime("third monday of january $this->year", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("third monday of january $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 
@@ -101,9 +100,9 @@ class USA extends AbstractProvider
     private function calculateWashingtonsBirthday(): void
     {
         if ($this->year >= 1879) {
-            $date = new DateTime("$this->year-2-22", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-2-22", DateTimeZoneFactory::getDateTimeZone($this->timezone));
             if ($this->year >= 1968) {
-                $date = new DateTime("third monday of february $this->year", new DateTimeZone($this->timezone));
+                $date = new DateTime("third monday of february $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
             }
             $this->addHoliday(new Holiday('washingtonsBirthday', [
                 'en' => 'Washington’s Birthday',
@@ -126,9 +125,9 @@ class USA extends AbstractProvider
     private function calculateMemorialDay(): void
     {
         if ($this->year >= 1865) {
-            $date = new DateTime("$this->year-5-30", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-5-30", DateTimeZoneFactory::getDateTimeZone($this->timezone));
             if ($this->year >= 1968) {
-                $date = new DateTime("last monday of may $this->year", new DateTimeZone($this->timezone));
+                $date = new DateTime("last monday of may $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
             }
             $this->addHoliday(new Holiday('memorialDay', [
                 'en' => 'Memorial Day',
@@ -153,7 +152,7 @@ class USA extends AbstractProvider
         if ($this->year >= 1776) {
             $this->addHoliday(new Holiday('independenceDay', [
                 'en' => 'Independence Day',
-            ], new DateTime("$this->year-7-4", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-7-4", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 
@@ -175,7 +174,7 @@ class USA extends AbstractProvider
                 [
                     'en' => 'Labour Day',
                 ],
-                new DateTime("first monday of september $this->year", new DateTimeZone($this->timezone)),
+                new DateTime("first monday of september $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -197,9 +196,9 @@ class USA extends AbstractProvider
     private function calculateColumbusDay(): void
     {
         if ($this->year >= 1937) {
-            $date = new DateTime("$this->year-10-12", new DateTimeZone($this->timezone));
+            $date = new DateTime("$this->year-10-12", DateTimeZoneFactory::getDateTimeZone($this->timezone));
             if ($this->year >= 1970) {
-                $date = new DateTime("second monday of october $this->year", new DateTimeZone($this->timezone));
+                $date = new DateTime("second monday of october $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
             }
             $this->addHoliday(new Holiday('columbusDay', [
                 'en' => 'Columbus Day',
@@ -225,7 +224,7 @@ class USA extends AbstractProvider
 
             $this->addHoliday(new Holiday('veteransDay', [
                 'en' => $name,
-            ], new DateTime("$this->year-11-11", new DateTimeZone($this->timezone)), $this->locale));
+            ], new DateTime("$this->year-11-11", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale));
         }
     }
 
@@ -249,7 +248,7 @@ class USA extends AbstractProvider
                 [
                     'en' => 'Thanksgiving Day',
                 ],
-                new DateTime("fourth thursday of november $this->year", new DateTimeZone($this->timezone)),
+                new DateTime("fourth thursday of november $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/UnitedKingdom.php
+++ b/src/Yasumi/Provider/UnitedKingdom.php
@@ -14,7 +14,6 @@ namespace Yasumi\Provider;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
@@ -87,7 +86,7 @@ class UnitedKingdom extends AbstractProvider
             $type = Holiday::TYPE_OBSERVANCE;
         }
 
-        $newYearsDay = new DateTime("$this->year-01-01", new DateTimeZone($this->timezone));
+        $newYearsDay = new DateTime("$this->year-01-01", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         // If New Years Day falls on a Saturday or Sunday, it is observed the next Monday (January 2nd or 3rd)
         if (\in_array((int)$newYearsDay->format('w'), [0, 6], true)) {
@@ -126,7 +125,7 @@ class UnitedKingdom extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'mayDayBankHoliday',
                 ['en' => 'May Day Bank Holiday'],
-                new DateTime("$this->year-5-8", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-5-8", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_BANK
             ));
@@ -137,7 +136,7 @@ class UnitedKingdom extends AbstractProvider
         $this->addHoliday(new Holiday(
             'mayDayBankHoliday',
             ['en' => 'May Day Bank Holiday'],
-            new DateTime("first monday of may $this->year", new DateTimeZone($this->timezone)),
+            new DateTime("first monday of may $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         ));
@@ -172,7 +171,7 @@ class UnitedKingdom extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'springBankHoliday',
                 ['en' => 'Spring Bank Holiday'],
-                new DateTime("$this->year-6-4", new DateTimeZone($this->timezone)),
+                new DateTime("$this->year-6-4", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_BANK
             ));
@@ -183,7 +182,7 @@ class UnitedKingdom extends AbstractProvider
         $this->addHoliday(new Holiday(
             'springBankHoliday',
             ['en' => 'Spring Bank Holiday'],
-            new DateTime("last monday of may $this->year", new DateTimeZone($this->timezone)),
+            new DateTime("last monday of may $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         ));
@@ -215,7 +214,7 @@ class UnitedKingdom extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'summerBankHoliday',
                 ['en' => 'August Bank Holiday'],
-                new DateTime("first monday of august $this->year", new DateTimeZone($this->timezone)),
+                new DateTime("first monday of august $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_BANK
             ));
@@ -230,7 +229,7 @@ class UnitedKingdom extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'summerBankHoliday',
                 ['en' => 'Summer Bank Holiday'],
-                new DateTime("first monday of september $this->year", new DateTimeZone($this->timezone)),
+                new DateTime("first monday of september $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_BANK
             ));
@@ -241,7 +240,7 @@ class UnitedKingdom extends AbstractProvider
         $this->addHoliday(new Holiday(
             'summerBankHoliday',
             ['en' => 'Summer Bank Holiday'],
-            new DateTime("last monday of august $this->year", new DateTimeZone($this->timezone)),
+            new DateTime("last monday of august $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         ));

--- a/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
@@ -13,10 +13,10 @@
 namespace Yasumi\Provider\UnitedKingdom;
 
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\UnitedKingdom;
 use Yasumi\SubstituteHoliday;
 
@@ -79,7 +79,7 @@ class NorthernIreland extends UnitedKingdom
         $holiday = new Holiday(
             'stPatricksDay',
             ['en' => 'St. Patrick’s Day'],
-            new DateTime($this->year . '-3-17', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-3-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         );
@@ -125,7 +125,7 @@ class NorthernIreland extends UnitedKingdom
         $holiday = new Holiday(
             'battleOfTheBoyne',
             ['en' => 'Battle of the Boyne'],
-            new DateTime($this->year . '-7-12', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-7-12', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         );

--- a/src/Yasumi/Provider/UnitedKingdom/Scotland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/Scotland.php
@@ -14,10 +14,10 @@ namespace Yasumi\Provider\UnitedKingdom;
 
 use DateInterval;
 use DateTime;
-use DateTimeZone;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
+use Yasumi\Provider\DateTimeZoneFactory;
 use Yasumi\Provider\UnitedKingdom;
 use Yasumi\SubstituteHoliday;
 
@@ -99,7 +99,7 @@ class Scotland extends UnitedKingdom
         $secondNewYearsDay = new Holiday(
             'secondNewYearsDay',
             [],
-            new DateTime("$this->year-1-2", new DateTimeZone($this->timezone)),
+            new DateTime("$this->year-1-2", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             $type
         );
@@ -153,7 +153,7 @@ class Scotland extends UnitedKingdom
         $this->addHoliday(new Holiday(
             'summerBankHoliday',
             ['en' => 'August Bank Holiday'],
-            new DateTime("first monday of august $this->year", new DateTimeZone($this->timezone)),
+            new DateTime("first monday of august $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         ));
@@ -180,7 +180,7 @@ class Scotland extends UnitedKingdom
         $holiday = new Holiday(
             'stAndrewsDay',
             [],
-            new DateTime($this->year . '-11-30', new DateTimeZone($this->timezone)),
+            new DateTime($this->year . '-11-30', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         );


### PR DESCRIPTION
Introduces a DateTimeZoneFactory to keep references of already instatiated DateTimeZone.

Benchmark used:  
```
<?php
require 'vendor/autoload.php';
$holidays = Yasumi\Yasumi::create('France', 2019);
```
Run on develop branch : 
`blackfire run --samples=20 php benchmark.php`
```
Profiling: [########################################] 20/20
Blackfire Run completed
Graph URL https://blackfire.io/profiles/bc72f011-ad87-4c92-8472-ea90ef178aa3/graph
No tests! Create some now https://blackfire.io/docs/cookbooks/tests
No recommendations

I/O Wait     1.49ms
CPU Time     13.1ms
Memory        614KB
Wall Time    14.6ms
Network         n/a     n/a     n/a
SQL             n/a     n/a
```


Run on PR branch : 
`blackfire run --samples=20 php benchmark.php`
```
Profiling: [########################################] 20/20
Blackfire Run completed
Graph URL https://blackfire.io/profiles/7fc3116c-358c-4213-8435-c7676e84ea54/graph
No tests! Create some now https://blackfire.io/docs/cookbooks/tests
No recommendations

Wall Time    11.1ms
I/O Wait      632µs
CPU Time     10.5ms
Memory        616KB
Network         n/a     n/a     n/a
SQL             n/a     n/a
```

![image](https://user-images.githubusercontent.com/5188832/80483226-f7276100-8955-11ea-96cb-795603fd5b4e.png)
https://blackfire.io/profiles/compare/d1d4c4ea-b553-4738-aba1-851351a01ebe/graph