### PR TITLE
Feature/childrens day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ## [Unreleased]
 
 ### Added
+- Added children's day to Germany as Holiday Type_other and add children's day to thuriniga/germany as official holiday because it is a new official holiday since 2019 [\#219](https://github.com/azuyalabs/yasumi/pull/219)
 - Added Canada Provider [\#215](https://github.com/azuyalabs/yasumi/pull/215) ([lux](https://github.com/lux))
 - Added Luxembourg Provider [\#205](https://github.com/azuyalabs/yasumi/pull/205) ([Arkounay](https://github.com/Arkounay))
 - Catholic Christmas Day is a new official holiday since 2017 in the Ukraine. [\#202](https://github.com/azuyalabs/yasumi/pull/202)

--- a/src/Yasumi/Provider/CommonHolidays.php
+++ b/src/Yasumi/Provider/CommonHolidays.php
@@ -551,4 +551,41 @@ trait CommonHolidays
 
         return null;
     }
+
+     /**
+     * (international) children's Day
+     *
+     * Children's Day is a day celebrated in over 145 states to honor children.
+     * However, it has no uniform date and is therefore celebrated differently in many states.
+     *
+     * @link https://en.wikipedia.org/wiki/Children%27s_Day
+     *
+     * @param int $year the year for which children's day need to be created
+     * @param int $month the month for which children's day need to be created
+     * @param int $day the day for which children's day need to be created
+     * @param string $locale the locale for which summer time need to be displayed in.
+     * @param string $timezone the timezone in which children's day occurs
+     * @param string $type The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an seasonal holiday is considered.
+     *
+     * @return Holiday
+     * @throws \Exception
+     *
+     */
+    public function childrensDay(
+        int $year,
+        int $month,
+        int $day,
+        string $locale,
+        string $timezone,
+        string $type = Holiday::TYPE_SEASON
+    ): Holiday {
+        return new Holiday(
+            'childrensDay',
+            [],
+            new DateTime("$year-$month-$day", DateTimeZoneFactory::getDateTimeZone($timezone)),
+            $locale,
+            $type
+        );
+    }
 }

--- a/src/Yasumi/Provider/CommonHolidays.php
+++ b/src/Yasumi/Provider/CommonHolidays.php
@@ -552,33 +552,33 @@ trait CommonHolidays
         return null;
     }
 
-     /**
-     * (international) children's Day
-     *
-     * Children's Day is a day celebrated in over 145 states to honor children.
-     * However, it has no uniform date and is therefore celebrated differently in many states.
-     *
-     * @link https://en.wikipedia.org/wiki/Children%27s_Day
-     *
-     * @param int $year the year for which children's day need to be created
-     * @param int $month the month for which children's day need to be created
-     * @param int $day the day for which children's day need to be created
-     * @param string $locale the locale for which summer time need to be displayed in.
-     * @param string $timezone the timezone in which children's day occurs
-     * @param string $type The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
-     *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an seasonal holiday is considered.
-     *
-     * @return Holiday
-     * @throws \Exception
-     *
-     */
+    /**
+    * (international) children's Day
+    *
+    * Children's Day is a day celebrated in over 145 countries to honor children.
+    * However, it has no uniform date and is therefore celebrated differently in many states.
+    *
+    * @link https://en.wikipedia.org/wiki/Children%27s_Day
+    *
+    * @param int $year the year for which children's day need to be created
+    * @param int $month the month for which children's day need to be created
+    * @param int $day the day for which children's day need to be created
+    * @param string $locale the locale for which summer time need to be displayed in.
+    * @param string $timezone the timezone in which children's day occurs
+    * @param string $type The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+    *                         TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an other holiday is considered.
+    *
+    * @return Holiday
+    * @throws \Exception
+    *
+    */
     public function childrensDay(
         int $year,
         int $month,
         int $day,
         string $locale,
         string $timezone,
-        string $type = Holiday::TYPE_SEASON
+        string $type = Holiday::TYPE_OTHER
     ): Holiday {
         return new Holiday(
             'childrensDay',

--- a/src/Yasumi/Provider/Germany.php
+++ b/src/Yasumi/Provider/Germany.php
@@ -45,6 +45,7 @@ class Germany extends AbstractProvider
 
         // Add common holidays
         $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->calculateChildrensDay();
 
         // Add common Christian holidays (common in Germany)
         $this->addHoliday($this->ascensionDay($this->year, $this->timezone, $this->locale));
@@ -91,5 +92,24 @@ class Germany extends AbstractProvider
                 $this->locale
             ));
         }
+    }
+
+    /**
+     * @throws \Exception
+     */
+    private function calculateChildrensDay(): void
+    {
+        if ($this->year < 1954) {
+            return;
+        }
+
+        $this->addHoliday($this->childrensDay(
+            $this->year,
+            9,
+            20,
+            $this->locale,
+            $this->timezone,
+            Holiday::TYPE_SEASON
+        ));
     }
 }

--- a/src/Yasumi/Provider/Germany.php
+++ b/src/Yasumi/Provider/Germany.php
@@ -109,7 +109,7 @@ class Germany extends AbstractProvider
             20,
             $this->locale,
             $this->timezone,
-            Holiday::TYPE_SEASON
+            Holiday::TYPE_OTHER
         ));
     }
 }

--- a/src/Yasumi/Provider/Germany/Thuringia.php
+++ b/src/Yasumi/Provider/Germany/Thuringia.php
@@ -15,6 +15,7 @@ namespace Yasumi\Provider\Germany;
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Provider\Germany;
+use Yasumi\Holiday;
 
 /**
  * Provider for all holidays in Thuringia (Germany).
@@ -48,6 +49,9 @@ class Thuringia extends Germany
 
         // Add custom Christian holidays
         $this->calculateReformationDay();
+
+        // Add custom common holidays
+        $this->calculateChildrensDay();
     }
 
     /**
@@ -66,5 +70,27 @@ class Thuringia extends Germany
         }
 
         $this->addHoliday($this->reformationDay($this->year, $this->timezone, $this->locale));
+    }
+
+    /**
+     * Overrides the children's day from provider Germany.
+     * Sets type to official when the year is 2019 and above.
+     *
+     * @throws \Exception
+     */
+    private function calculateChildrensDay(): void
+    {
+        if ($this->year < 2019) {
+            return;
+        }
+
+        $this->addHoliday($this->childrensDay(
+            $this->year,
+            9,
+            20,
+            $this->locale,
+            $this->timezone,
+            Holiday::TYPE_OFFICIAL
+        ));
     }
 }

--- a/src/Yasumi/Provider/Germany/Thuringia.php
+++ b/src/Yasumi/Provider/Germany/Thuringia.php
@@ -14,8 +14,8 @@ namespace Yasumi\Provider\Germany;
 
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
-use Yasumi\Provider\Germany;
 use Yasumi\Holiday;
+use Yasumi\Provider\Germany;
 
 /**
  * Provider for all holidays in Thuringia (Germany).

--- a/src/Yasumi/data/translations/childrensDay.php
+++ b/src/Yasumi/data/translations/childrensDay.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2020 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+// Translations for Children's Day
+return [
+    'de' => 'Kindertag',
+    'en' => 'children’s day',
+];

--- a/tests/Germany/ChildrensDayTest.php
+++ b/tests/Germany/ChildrensDayTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2020 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\Germany;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the children's day in Germany.
+ */
+class ChildrensDayTest extends GermanyBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'childrensDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(1954);
+        $expectedDate = new DateTime("$year-9-20", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expectedDate);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1954),
+            [self::LOCALE => 'Kindertag']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this tests.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType()
+    {
+        $year = $this->generateRandomYear(1954);
+
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            Holiday::TYPE_SEASON
+        );
+    }
+}

--- a/tests/Germany/ChildrensDayTest.php
+++ b/tests/Germany/ChildrensDayTest.php
@@ -65,7 +65,7 @@ class ChildrensDayTest extends GermanyBaseTestCase implements YasumiTestCaseInte
             self::REGION,
             self::HOLIDAY,
             $year,
-            Holiday::TYPE_SEASON
+            Holiday::TYPE_OTHER
         );
     }
 }

--- a/tests/Germany/Thuringia/ChildrensDayTest.php
+++ b/tests/Germany/Thuringia/ChildrensDayTest.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2020 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\Germany\Thuringia;
+
+use DateTime;
+use DateTimeZone;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the children's day in Germany/Thuringia.
+ */
+class ChildrensDayTest extends ThuringiaBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'childrensDay';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @throws \ReflectionException
+     */
+    public function testHoliday()
+    {
+        $year = $this->generateRandomYear(1954);
+        $expectedDate = new DateTime("$year-9-20", new DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expectedDate);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws \ReflectionException
+     */
+    public function testTranslation()
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1954),
+            [self::LOCALE => 'Kindertag']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this tests.
+     * @throws \ReflectionException
+     */
+    public function testHolidayType()
+    {
+        //before 2019
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1954, 2018),
+            Holiday::TYPE_SEASON
+        );
+
+        //after 2019
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(2019),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Germany/Thuringia/ChildrensDayTest.php
+++ b/tests/Germany/Thuringia/ChildrensDayTest.php
@@ -64,7 +64,7 @@ class ChildrensDayTest extends ThuringiaBaseTestCase implements YasumiTestCaseIn
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(1954, 2018),
-            Holiday::TYPE_SEASON
+            Holiday::TYPE_OTHER
         );
 
         //after 2019


### PR DESCRIPTION
I added the children’s day as a holiday to common holidays.
I made it an seasonal holiday, because it is not a official holiday yet in Germany.
In Germany/Thuringia the children’s day is an official holiday since 2019.