### PR TITLE
Add accessors for shortName and substitutedHoliday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - Added American English spelling for Labour Day [\#216](https://github.com/azuyalabs/yasumi/issues/216)
 - Added French translation for Second Christmas Day [\#188](https://github.com/azuyalabs/yasumi/pull/188) ([Arkounay](https://github.com/Arkounay))
 
+- Added accessor methods Holiday::getShortName() and SubstituteHoliday::getSubstitutedHoliday() [\#220](https://github.com/azuyalabs/yasumi/pull/220) ([c960657](https://github.com/c960657))
 - Added missing return (correct) and parameter types in various methods.
 
 ### Changed
@@ -43,6 +44,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - Fixed issue if the previous working day happens to be in the previous year (i.e. not in the year of the Yasumi instance)
 
 - Fixed compound conditions that are always true by simplifying the condition steps.
+
+### Deprecated
+- Deprecated direct access to public properties Holiday::$shortName and SubstituteHoliday::$substitutedHoliday in favor of accessor methods [\#220](https://github.com/azuyalabs/yasumi/pull/220) ([c960657](https://github.com/c960657))
 
 ### Removed
 - PHP 7.1 Support, as it has reached its end of life.

--- a/src/Yasumi/Filters/AbstractFilter.php
+++ b/src/Yasumi/Filters/AbstractFilter.php
@@ -35,10 +35,10 @@ abstract class AbstractFilter extends FilterIterator implements Countable
     {
         $names = \array_map(static function ($holiday) {
             if ($holiday instanceof SubstituteHoliday) {
-                return $holiday->substitutedHoliday->shortName;
+                return $holiday->getSubstitutedHoliday()->getShortName();
             }
 
-            return $holiday->shortName;
+            return $holiday->getShortName();
         }, \iterator_to_array($this));
 
         return \count(\array_unique($names));

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -139,6 +139,16 @@ class Holiday extends DateTime implements JsonSerializable
     }
 
     /**
+     * Returns the short name for this holiday.
+     *
+     * @return string the short name, e.g. "newYearsDay".
+     */
+    public function getShortName(): string
+    {
+        return $this->shortName;
+    }
+
+    /**
      * Returns what type this holiday is.
      *
      * @return string the type of holiday (official, observance, season, bank or other).

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -67,6 +67,8 @@ class Holiday extends DateTime implements JsonSerializable
 
     /**
      * @var string short name (internal name) of this holiday
+     * @deprecated public access to this property is deprecated in favor of getShortName()
+     * @see getShortName()
      */
     public $shortName;
 

--- a/src/Yasumi/Provider/AbstractProvider.php
+++ b/src/Yasumi/Provider/AbstractProvider.php
@@ -158,7 +158,7 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
             $holiday->mergeGlobalTranslations($this->globalTranslations);
         }
 
-        $this->holidays[$holiday->shortName] = $holiday;
+        $this->holidays[$holiday->getShortName()] = $holiday;
         \uasort($this->holidays, [__CLASS__, 'compareDates']);
     }
 
@@ -315,10 +315,10 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
     {
         $names = \array_map(static function ($holiday) {
             if ($holiday instanceof SubstituteHoliday) {
-                return $holiday->substitutedHoliday->shortName;
+                return $holiday->getSubstitutedHoliday()->getShortName();
             }
 
-            return $holiday->shortName;
+            return $holiday->getShortName();
         }, $this->getHolidays());
 
         return \count(\array_unique($names));

--- a/src/Yasumi/Provider/SouthKorea.php
+++ b/src/Yasumi/Provider/SouthKorea.php
@@ -484,7 +484,7 @@ class SouthKorea extends AbstractProvider
         foreach ($holidays as $shortName => $holiday) {
             // Get list of holiday dates except this
             $holidayDates = \array_map(static function ($holiday) use ($shortName) {
-                return $holiday->shortName === $shortName ? false : (string)$holiday;
+                return $holiday->getShortName() === $shortName ? false : (string)$holiday;
             }, $holidays);
 
             // Only process accepted holidays and conditions

--- a/src/Yasumi/SubstituteHoliday.php
+++ b/src/Yasumi/SubstituteHoliday.php
@@ -66,7 +66,7 @@ class SubstituteHoliday extends Holiday
     ) {
         $this->substitutedHoliday = $substitutedHoliday;
 
-        $shortName = 'substituteHoliday:' . $substitutedHoliday->shortName;
+        $shortName = 'substituteHoliday:' . $substitutedHoliday->getShortName();
 
         if ($date == $substitutedHoliday) {
             throw new \InvalidArgumentException('Date must differ from the substituted holiday');
@@ -74,6 +74,16 @@ class SubstituteHoliday extends Holiday
 
         // Construct instance
         parent::__construct($shortName, $names, $date, $displayLocale, $type);
+    }
+
+    /**
+     * Returns the holiday being substituted.
+     *
+     * @return Holiday the holiday being substituted.
+     */
+    public function getSubstitutedHoliday(): Holiday
+    {
+        return $this->substitutedHoliday;
     }
 
     /**
@@ -95,7 +105,7 @@ class SubstituteHoliday extends Holiday
     {
         $name = parent::getName();
 
-        if ($name === $this->shortName) {
+        if ($name === $this->getShortName()) {
             foreach ($this->getLocales($locales) as $locales) {
                 $pattern = $this->substituteHolidayTranslations[$locales] ?? null;
                 if ($pattern) {

--- a/src/Yasumi/SubstituteHoliday.php
+++ b/src/Yasumi/SubstituteHoliday.php
@@ -28,6 +28,8 @@ class SubstituteHoliday extends Holiday
 {
     /**
      * @var Holiday
+     * @deprecated public access to this property is deprecated in favor of getSubstitutedHoliday()
+     * @see getSubstitutedHoliday()
      */
     public $substitutedHoliday;
 

--- a/tests/Base/SubstituteHolidayTest.php
+++ b/tests/Base/SubstituteHolidayTest.php
@@ -67,8 +67,8 @@ class SubstituteHolidayTest extends TestCase
         $holiday = new Holiday('testHoliday', [], new DateTime('2019-01-01'), 'en_US', Holiday::TYPE_BANK);
         $substitute = new SubstituteHoliday($holiday, [], new DateTime('2019-01-02'), 'en_US', Holiday::TYPE_SEASON);
 
-        $this->assertSame($holiday, $substitute->substitutedHoliday);
-        $this->assertEquals('substituteHoliday:testHoliday', $substitute->shortName);
+        $this->assertSame($holiday, $substitute->getSubstitutedHoliday());
+        $this->assertEquals('substituteHoliday:testHoliday', $substitute->getShortName());
         $this->assertEquals(Holiday::TYPE_SEASON, $substitute->getType());
         $this->assertEquals(new DateTime('2019-01-02'), $substitute);
     }

--- a/tests/Base/TypographyTest.php
+++ b/tests/Base/TypographyTest.php
@@ -59,7 +59,7 @@ class TypographyTest extends TestCase
 
             foreach ($provider->getHolidays() as $holiday) {
                 foreach ($holiday->translations as $locale => $name) {
-                    $tests[$name] = [$name, $class, $holiday->shortName, $locale];
+                    $tests[$name] = [$name, $class, $holiday->getShortName(), $locale];
                 }
             }
         }

--- a/tests/Ukraine/SubstitutedHolidayTest.php
+++ b/tests/Ukraine/SubstitutedHolidayTest.php
@@ -87,7 +87,7 @@ class SubstitutedHolidayTest extends UkraineBaseTestCase implements YasumiTestCa
         $this->assertTrue($holidays->isHoliday($holidayOfficial));
         $this->assertEquals(Holiday::TYPE_OFFICIAL, $holidayOfficial->getType());
 
-        $holidaySubstitution = $holidays->getHoliday('substituteHoliday:' . $holidayOfficial->shortName);
+        $holidaySubstitution = $holidays->getHoliday('substituteHoliday:' . $holidayOfficial->getShortName());
         if ($expectedSubstitution === null) {
             // without substitution
             $this->assertNull($holidaySubstitution);


### PR DESCRIPTION
Accessing public properties directly is bad practice and makes refactorings difficult.

This PR adds accessor methods for `$holiday->shortName` and `$substituteHoliday->substitutedHoliday` and deprecates direct access to those two properties.