### PR TITLE
Rename “short name” to “key”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - Added American English spelling for Labour Day [\#216](https://github.com/azuyalabs/yasumi/issues/216)
 - Added French translation for Second Christmas Day [\#188](https://github.com/azuyalabs/yasumi/pull/188) ([Arkounay](https://github.com/Arkounay))
 
-- Added accessor methods Holiday::getShortName() and SubstituteHoliday::getSubstitutedHoliday() [\#220](https://github.com/azuyalabs/yasumi/pull/220) ([c960657](https://github.com/c960657))
+- Added accessor methods Holiday::getKey() and SubstituteHoliday::getSubstitutedHoliday() [\#220](https://github.com/azuyalabs/yasumi/pull/220)+[\#221](https://github.com/azuyalabs/yasumi/pull/221) ([c960657](https://github.com/c960657))
 - Added missing return (correct) and parameter types in various methods.
 
 ### Changed

--- a/src/Yasumi/Exception/MissingTranslationException.php
+++ b/src/Yasumi/Exception/MissingTranslationException.php
@@ -22,11 +22,11 @@ class MissingTranslationException extends BaseException implements Exception
     /**
      * Initializes the Exception instance
      *
-     * @param string $shortName The short name (internal name) of the holiday
+     * @param string $key The holiday key
      * @param array $locales The locales that was searched
      */
-    public function __construct(string $shortName, array $locales)
+    public function __construct(string $key, array $locales)
     {
-        parent::__construct(\sprintf("Translation for '%s' not found for any locale: '%s'", $shortName, \implode("', '", $locales)));
+        parent::__construct(\sprintf("Translation for '%s' not found for any locale: '%s'", $key, \implode("', '", $locales)));
     }
 }

--- a/src/Yasumi/Filters/AbstractFilter.php
+++ b/src/Yasumi/Filters/AbstractFilter.php
@@ -35,10 +35,10 @@ abstract class AbstractFilter extends FilterIterator implements Countable
     {
         $names = \array_map(static function ($holiday) {
             if ($holiday instanceof SubstituteHoliday) {
-                return $holiday->getSubstitutedHoliday()->getShortName();
+                return $holiday->getSubstitutedHoliday()->getKey();
             }
 
-            return $holiday->getShortName();
+            return $holiday->getKey();
         }, \iterator_to_array($this));
 
         return \count(\array_unique($names));

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -56,9 +56,9 @@ class Holiday extends DateTime implements JsonSerializable
     public const DEFAULT_LOCALE = 'en_US';
 
     /**
-     * Pseudo-locale representing the short name (internal name) of the holiday.
+     * Pseudo-locale representing the holiday key.
      */
-    public const LOCALE_SHORT_NAME = 'shortName';
+    public const LOCALE_KEY = '_key';
 
     /**
      * @var array list of all defined locales
@@ -66,9 +66,9 @@ class Holiday extends DateTime implements JsonSerializable
     private static $locales = [];
 
     /**
-     * @var string short name (internal name) of this holiday
-     * @deprecated public access to this property is deprecated in favor of getShortName()
-     * @see getShortName()
+     * @var string holiday key
+     * @deprecated Public access to this property is deprecated in favor of getKey()
+     * @see getKey()
      */
     public $shortName;
 
@@ -93,7 +93,7 @@ class Holiday extends DateTime implements JsonSerializable
      * If a holiday date needs to be defined for a specific timezone, make sure that the date instance
      * (DateTimeInterface) has the correct timezone set. Otherwise the default system timezone is used.
      *
-     * @param string $shortName The short name (internal name) of this holiday
+     * @param string $key Holiday key
      * @param array $names An array containing the name/description of this holiday in various
      *                                          languages. Overrides global translations
      * @param \DateTimeInterface $date A DateTimeInterface instance representing the date of the holiday
@@ -109,14 +109,14 @@ class Holiday extends DateTime implements JsonSerializable
      * @throws \Exception
      */
     public function __construct(
-        string $shortName,
+        string $key,
         array $names,
         \DateTimeInterface $date,
         string $displayLocale = self::DEFAULT_LOCALE,
         string $type = self::TYPE_OFFICIAL
     ) {
-        // Validate if short name is not empty
-        if (empty($shortName)) {
+        // Validate if key is not empty
+        if (empty($key)) {
             throw new InvalidArgumentException('Holiday name can not be blank.');
         }
 
@@ -131,7 +131,7 @@ class Holiday extends DateTime implements JsonSerializable
         }
 
         // Set additional attributes
-        $this->shortName = $shortName;
+        $this->shortName = $key;
         $this->translations = $names;
         $this->displayLocale = $displayLocale;
         $this->type = $type;
@@ -141,11 +141,11 @@ class Holiday extends DateTime implements JsonSerializable
     }
 
     /**
-     * Returns the short name for this holiday.
+     * Returns the key for this holiday.
      *
-     * @return string the short name, e.g. "newYearsDay".
+     * @return string the key, e.g. "newYearsDay".
      */
-    public function getShortName(): string
+    public function getKey(): string
     {
         return $this->shortName;
     }
@@ -176,7 +176,7 @@ class Holiday extends DateTime implements JsonSerializable
      * The provided locales are searched for a translation. The first locale containing a translation will be used.
      *
      * If no locale is provided, proceed as if an array containing the display locale, Holiday::DEFAULT_LOCALE ('en_US'), and
-     * Holiday::LOCALE_SHORT_NAME (the short name (internal name) of this holiday) was provided.
+     * Holiday::LOCALE_KEY (the holiday key) was provided.
      *
      * @param array $locales The locales to search for translations
      *
@@ -184,13 +184,13 @@ class Holiday extends DateTime implements JsonSerializable
      * @throws MissingTranslationException
      *
      * @see Holiday::DEFAULT_LOCALE
-     * @see Holiday::LOCALE_SHORT_NAME
+     * @see Holiday::LOCALE_KEY
      */
     public function getName(array $locales = null): string
     {
         $locales = $this->getLocales($locales);
         foreach ($locales as $locale) {
-            if ($locale === self::LOCALE_SHORT_NAME) {
+            if ($locale === self::LOCALE_KEY) {
                 return $this->shortName;
             }
             if (isset($this->translations[$locale])) {
@@ -208,7 +208,7 @@ class Holiday extends DateTime implements JsonSerializable
      * ['ca_ES_VALENCIA', 'es_ES'] is expanded into ['ca_ES_VALENCIA', 'ca_ES', 'ca', 'es_ES', 'es'].
      *
      * If a string is provided, return as if this string, Holiday::DEFAULT_LOCALE, and Holiday::LOCALE_SHORT_NAM
-     * was provided. E.g. 'de_DE' is expanded into ['de_DE', 'de', 'en_US', 'en', Holiday::LOCALE_SHORT_NAME].
+     * was provided. E.g. 'de_DE' is expanded into ['de_DE', 'de', 'en_US', 'en', Holiday::LOCALE_KEY].
      *
      * If null is provided, return as if the display locale was provided as a string.
      *
@@ -217,7 +217,7 @@ class Holiday extends DateTime implements JsonSerializable
      * @return array
      *
      * @see Holiday::DEFAULT_LOCALE
-     * @see Holiday::LOCALE_SHORT_NAME
+     * @see Holiday::LOCALE_KEY
      */
     protected function getLocales(?array $locales): array
     {
@@ -226,7 +226,7 @@ class Holiday extends DateTime implements JsonSerializable
         } else {
             $locales = [$this->displayLocale];
             // DEFAULT_LOCALE is 'en_US', and its parent is 'en'.
-            $expanded = [self::LOCALE_SHORT_NAME, 'en', 'en_US'];
+            $expanded = [self::LOCALE_KEY, 'en', 'en_US'];
         }
 
         // Expand e.g. ['de_DE', 'en_GB'] into  ['de_DE', 'de', 'en_GB', 'en'].

--- a/src/Yasumi/Provider/AbstractProvider.php
+++ b/src/Yasumi/Provider/AbstractProvider.php
@@ -158,7 +158,7 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
             $holiday->mergeGlobalTranslations($this->globalTranslations);
         }
 
-        $this->holidays[$holiday->getShortName()] = $holiday;
+        $this->holidays[$holiday->getKey()] = $holiday;
         \uasort($this->holidays, [__CLASS__, 'compareDates']);
     }
 
@@ -169,13 +169,13 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
      * This function can be helpful in cases where an existing holiday provider class can be extended but some holidays
      * are not part of the original (extended) provider.
      *
-     * @param string $shortName short name of the holiday
+     * @param string $key holiday key
      *
      * @return void
      */
-    public function removeHoliday(string $shortName): void
+    public function removeHoliday(string $key): void
     {
-        unset($this->holidays[$shortName]);
+        unset($this->holidays[$key]);
     }
 
     /**
@@ -256,34 +256,49 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
     /**
      * On what date is the given holiday?
      *
-     * @param string $shortName short name of the holiday
+     * @param string $key holiday key
      *
      * @return string the date of the requested holiday
      * @throws InvalidArgumentException when the given name is blank or empty.
      *
      */
-    public function whenIs(string $shortName): string
+    public function whenIs(string $key): string
     {
-        $this->isHolidayNameNotEmpty($shortName); // Validate if short name is not empty
+        $this->isHolidayNameNotEmpty($key); // Validate if key is not empty
 
-        return (string)$this->holidays[$shortName];
+        return (string)$this->holidays[$key];
     }
 
     /**
-     * Checks whether the given holiday (short name) is not empty.
+     * Checks whether the given holiday is not empty.
      *
-     * @param string $shortName the name of the holiday to be checked.
+     * @param string $key key of the holiday to be checked.
      *
      * @return true upon success, otherwise an InvalidArgumentException is thrown
      * @throws InvalidArgumentException An InvalidArgumentException is thrown if the given holiday parameter is empty.
      */
-    protected function isHolidayNameNotEmpty(string $shortName): bool
+    protected function isHolidayKeyNotEmpty(string $key): bool
     {
-        if (empty($shortName)) {
-            throw new InvalidArgumentException('Holiday name can not be blank.');
+        if (empty($key)) {
+            throw new InvalidArgumentException('Holiday key can not be blank.');
         }
 
         return true;
+    }
+
+    /**
+     * Checks whether the given holiday is not empty.
+     *
+     * @param string $key key of the holiday to be checked.
+     *
+     * @return true upon success, otherwise an InvalidArgumentException is thrown
+     * @throws InvalidArgumentException An InvalidArgumentException is thrown if the given holiday parameter is empty.
+     * @deprecated deprecated in favor of isHolidayKeyNotEmpty()
+     * @deprecated see isHolidayKeyNotEmpty()
+     */
+    protected function isHolidayNameNotEmpty(string $key): bool
+    {
+        return $this->isHolidayKeyNotEmpty($key);
     }
 
     /**
@@ -292,17 +307,17 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
      * This function returns the index number for the day of the week on which the given holiday falls.
      * The index number is an integer starting with 0 being Sunday, 1 = Monday, etc.
      *
-     * @param string $shortName short name of the holiday
+     * @param string $key key of the holiday
      *
      * @return int the index of the weekdays of the requested holiday (0 = Sunday, 1 = Monday, etc.)
      * @throws InvalidArgumentException when the given name is blank or empty.
      *
      */
-    public function whatWeekDayIs(string $shortName): int
+    public function whatWeekDayIs(string $key): int
     {
-        $this->isHolidayNameNotEmpty($shortName); // Validate if short name is not empty
+        $this->isHolidayNameNotEmpty($key); // Validate if key is not empty
 
-        return (int)$this->holidays[$shortName]->format('w');
+        return (int)$this->holidays[$key]->format('w');
     }
 
     /**
@@ -315,10 +330,10 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
     {
         $names = \array_map(static function ($holiday) {
             if ($holiday instanceof SubstituteHoliday) {
-                return $holiday->getSubstitutedHoliday()->getShortName();
+                return $holiday->getSubstitutedHoliday()->getKey();
             }
 
-            return $holiday->getShortName();
+            return $holiday->getKey();
         }, $this->getHolidays());
 
         return \count(\array_unique($names));
@@ -357,7 +372,7 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
     /**
      * Retrieves the next date (year) the given holiday is going to take place.
      *
-     * @param string $shortName the name of the holiday for which the next occurrence need to be retrieved.
+     * @param string $key key of the holiday for which the next occurrence need to be retrieved.
      *
      * @return Holiday|null a Holiday instance for the given holiday
      *
@@ -368,16 +383,16 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
      *
      * @covers AbstractProvider::anotherTime
      */
-    public function next(string $shortName): ?Holiday
+    public function next(string $key): ?Holiday
     {
-        return $this->anotherTime($this->year + 1, $shortName);
+        return $this->anotherTime($this->year + 1, $key);
     }
 
     /**
      * Determines the date of the given holiday for another year.
      *
      * @param int $year the year to get the holiday date for
-     * @param string $shortName the name of the holiday for which the date needs to be fetched
+     * @param string $key key of the holiday for which the date needs to be fetched
      *
      * @return Holiday|null a Holiday instance for the given holiday and year
      *
@@ -386,38 +401,38 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
      * @throws UnknownLocaleException
      * @throws \RuntimeException
      */
-    private function anotherTime(int $year, string $shortName): ?Holiday
+    private function anotherTime(int $year, string $key): ?Holiday
     {
-        $this->isHolidayNameNotEmpty($shortName); // Validate if short name is not empty
+        $this->isHolidayNameNotEmpty($key); // Validate if key is not empty
 
         // Get calling class name
         $hReflectionClass = new \ReflectionClass(\get_class($this));
 
-        return Yasumi::create($hReflectionClass->getShortName(), $year, $this->locale)->getHoliday($shortName);
+        return Yasumi::create($hReflectionClass->getShortName(), $year, $this->locale)->getHoliday($key);
     }
 
     /**
      * Retrieves the holiday object for the given holiday.
      *
-     * @param string $shortName the name of the holiday.
+     * @param string $key the name of the holiday.
      *
      * @return Holiday|null a Holiday instance for the given holiday
      * @throws InvalidArgumentException when the given name is blank or empty.
      *
      */
-    public function getHoliday(string $shortName): ?Holiday
+    public function getHoliday(string $key): ?Holiday
     {
-        $this->isHolidayNameNotEmpty($shortName); // Validate if short name is not empty
+        $this->isHolidayNameNotEmpty($key); // Validate if key is not empty
 
         $holidays = $this->getHolidays();
 
-        return $holidays[$shortName] ?? null;
+        return $holidays[$key] ?? null;
     }
 
     /**
      * Retrieves the previous date (year) the given holiday took place.
      *
-     * @param string $shortName the name of the holiday for which the previous occurrence need to be retrieved.
+     * @param string $key key of the holiday for which the previous occurrence need to be retrieved.
      *
      * @return Holiday|null a Holiday instance for the given holiday
      *
@@ -428,9 +443,9 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
      *
      * @covers AbstractProvider::anotherTime
      */
-    public function previous(string $shortName): ?Holiday
+    public function previous(string $key): ?Holiday
     {
-        return $this->anotherTime($this->year - 1, $shortName);
+        return $this->anotherTime($this->year - 1, $key);
     }
 
     /**

--- a/src/Yasumi/Provider/SouthKorea.php
+++ b/src/Yasumi/Provider/SouthKorea.php
@@ -481,25 +481,25 @@ class SouthKorea extends AbstractProvider
         ];
 
         // Loop through all holidays
-        foreach ($holidays as $shortName => $holiday) {
+        foreach ($holidays as $key => $holiday) {
             // Get list of holiday dates except this
-            $holidayDates = \array_map(static function ($holiday) use ($shortName) {
-                return $holiday->getShortName() === $shortName ? false : (string)$holiday;
+            $holidayDates = \array_map(static function ($holiday) use ($key) {
+                return $holiday->getKey() === $key ? false : (string)$holiday;
             }, $holidays);
 
             // Only process accepted holidays and conditions
-            if (\in_array($shortName, $acceptedHolidays, true)
+            if (\in_array($key, $acceptedHolidays, true)
                 && (
                     0 === (int)$holiday->format('w')
                     || \in_array($holiday, $holidayDates, false)
-                    || (6 === (int)$holiday->format('w') && 'childrensDay' === $shortName)
+                    || (6 === (int)$holiday->format('w') && 'childrensDay' === $key)
                 )
             ) {
                 $date = clone $holiday;
 
                 // Find next week day (not being another holiday)
                 while (0 === (int)$date->format('w')
-                    || (6 === (int)$date->format('w') && 'childrensDay' === $shortName)
+                    || (6 === (int)$date->format('w') && 'childrensDay' === $key)
                     || \in_array($date, $holidayDates, false)) {
                     $date->add(new DateInterval('P1D'));
                     continue;

--- a/src/Yasumi/SubstituteHoliday.php
+++ b/src/Yasumi/SubstituteHoliday.php
@@ -68,14 +68,14 @@ class SubstituteHoliday extends Holiday
     ) {
         $this->substitutedHoliday = $substitutedHoliday;
 
-        $shortName = 'substituteHoliday:' . $substitutedHoliday->getShortName();
+        $key = 'substituteHoliday:' . $substitutedHoliday->getKey();
 
         if ($date == $substitutedHoliday) {
             throw new \InvalidArgumentException('Date must differ from the substituted holiday');
         }
 
         // Construct instance
-        parent::__construct($shortName, $names, $date, $displayLocale, $type);
+        parent::__construct($key, $names, $date, $displayLocale, $type);
     }
 
     /**
@@ -94,20 +94,20 @@ class SubstituteHoliday extends Holiday
      * The provided locales are searched for a translation. The first locale containing a translation will be used.
      *
      * If no locale is provided, proceed as if an array containing the display locale, Holiday::DEFAULT_LOCALE ('en_US'), and
-     * Holiday::LOCALE_SHORT_NAME (the short name (internal name) of this holiday) was provided.
+     * Holiday::LOCALE_KEY (the holiday key) was provided.
      *
      * @param array $locales The locales to search for translations
      *
      * @throws MissingTranslationException
      *
      * @see Holiday::DEFAULT_LOCALE
-     * @see Holiday::LOCALE_SHORT_NAME
+     * @see Holiday::LOCALE_KEY
      */
     public function getName($locales = null): string
     {
         $name = parent::getName();
 
-        if ($name === $this->getShortName()) {
+        if ($name === $this->getKey()) {
             foreach ($this->getLocales($locales) as $locales) {
                 $pattern = $this->substituteHolidayTranslations[$locales] ?? null;
                 if ($pattern) {

--- a/src/Yasumi/Translations.php
+++ b/src/Yasumi/Translations.php
@@ -23,7 +23,7 @@ use Yasumi\Exception\UnknownLocaleException;
 class Translations implements TranslationsInterface
 {
     /**
-     * @var array translations array: ['<holiday short name>' => ['<locale>' => 'translation', ...], ... ]
+     * @var array translations array: ['<holiday key>' => ['<locale>' => 'translation', ...], ... ]
      */
     public $translations = [];
 
@@ -69,7 +69,7 @@ class Translations implements TranslationsInterface
             }
 
             $filename = $file->getFilename();
-            $shortName = $file->getBasename('.' . $extension);
+            $key = $file->getBasename('.' . $extension);
 
             $translations = require $directoryPath . $filename;
 
@@ -78,7 +78,7 @@ class Translations implements TranslationsInterface
                     $this->isValidLocale($locale); // Validate the given locale
                 }
 
-                $this->translations[$shortName] = $translations;
+                $this->translations[$key] = $translations;
             }
         }
     }
@@ -106,54 +106,60 @@ class Translations implements TranslationsInterface
     /**
      * Adds translation for holiday in specific locale.
      *
-     * @param string $shortName holiday short name
+     * @param string $key holiday key
+
+
      * @param string $locale locale
      * @param string $translation translation
      *
      * @throws UnknownLocaleException
      */
-    public function addTranslation(string $shortName, string $locale, string $translation): void
+    public function addTranslation(string $key, string $locale, string $translation): void
     {
         $this->isValidLocale($locale); // Validate the given locale
 
-        if (!\array_key_exists($shortName, $this->translations)) {
-            $this->translations[$shortName] = [];
+        if (!\array_key_exists($key, $this->translations)) {
+            $this->translations[$key] = [];
         }
 
-        $this->translations[$shortName][$locale] = $translation;
+        $this->translations[$key][$locale] = $translation;
     }
 
     /**
      * Returns translation for holiday in specific locale.
      *
-     * @param string $shortName holiday short name
+     * @param string $key holiday key
+
+
      * @param string $locale locale
      *
      * @return string|null translated holiday name
      */
-    public function getTranslation(string $shortName, string $locale): ?string
+    public function getTranslation(string $key, string $locale): ?string
     {
-        if (!\array_key_exists($shortName, $this->translations)
-            || !\array_key_exists($locale, $this->translations[$shortName])) {
+        if (!\array_key_exists($key, $this->translations)
+            || !\array_key_exists($locale, $this->translations[$key])) {
             return null;
         }
 
-        return $this->translations[$shortName][$locale];
+        return $this->translations[$key][$locale];
     }
 
     /**
      * Returns all available translations for holiday.
      *
-     * @param string $shortName holiday short name
+     * @param string $key holiday key
+
+
      *
      * @return array holiday name translations ['<locale>' => '<translation>', ...]
      */
-    public function getTranslations(string $shortName): array
+    public function getTranslations(string $key): array
     {
-        if (!\array_key_exists($shortName, $this->translations)) {
+        if (!\array_key_exists($key, $this->translations)) {
             return [];
         }
 
-        return $this->translations[$shortName];
+        return $this->translations[$key];
     }
 }

--- a/src/Yasumi/TranslationsInterface.php
+++ b/src/Yasumi/TranslationsInterface.php
@@ -20,19 +20,19 @@ interface TranslationsInterface
     /**
      * Returns translation for holiday in specific locale.
      *
-     * @param string $shortName holiday short name
+     * @param string $key holiday key
      * @param string $locale locale
      *
      * @return string|null translated holiday name
      */
-    public function getTranslation(string $shortName, string $locale): ?string;
+    public function getTranslation(string $key, string $locale): ?string;
 
     /**
      * Returns all available translations for holiday.
      *
-     * @param string $shortName holiday short name
+     * @param string $key holiday key
      *
      * @return array holiday name translations ['<locale>' => '<translation>', ...]
      */
-    public function getTranslations(string $shortName): array;
+    public function getTranslations(string $key): array;
 }

--- a/tests/Base/HolidayTest.php
+++ b/tests/Base/HolidayTest.php
@@ -33,11 +33,11 @@ class HolidayTest extends TestCase
     use YasumiBase;
 
     /**
-     * Tests that an InvalidArgumentException is thrown in case an blank short name is given.
+     * Tests that an InvalidArgumentException is thrown in case a blank key is given.
      *
      * @throws Exception
      */
-    public function testHolidayBlankNameInvalidArgumentException(): void
+    public function testHolidayBlankKeyInvalidArgumentException(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -99,9 +99,9 @@ class HolidayTest extends TestCase
         $method = new \ReflectionMethod(Holiday::class, 'getLocales');
         $method->setAccessible(true);
 
-        $this->assertEquals(['ca_ES_VALENCIA', 'ca_ES', 'ca', 'en_US', 'en', Holiday::LOCALE_SHORT_NAME], $method->invoke($holiday, null));
+        $this->assertEquals(['ca_ES_VALENCIA', 'ca_ES', 'ca', 'en_US', 'en', Holiday::LOCALE_KEY], $method->invoke($holiday, null));
         $this->assertEquals(['de_DE', 'de', 'es_ES', 'es'], $method->invoke($holiday, ['de_DE', 'es_ES']));
-        $this->assertEquals(['de_DE', 'de', Holiday::LOCALE_SHORT_NAME], $method->invoke($holiday, ['de_DE', Holiday::LOCALE_SHORT_NAME]));
+        $this->assertEquals(['de_DE', 'de', Holiday::LOCALE_KEY], $method->invoke($holiday, ['de_DE', Holiday::LOCALE_KEY]));
     }
 
     /**
@@ -181,8 +181,8 @@ class HolidayTest extends TestCase
         $this->assertEquals('Holiday NL', $holiday->getName(['nl']));
         $this->assertEquals('Holiday NL', $holiday->getName(['nl_NL']));
         $this->assertEquals('Holiday IT-IT', $holiday->getName(['it_IT']));
-        $this->assertEquals('Holiday IT-IT', $holiday->getName(['it_IT', Holiday::LOCALE_SHORT_NAME]));
-        $this->assertEquals('testHoliday', $holiday->getName([Holiday::LOCALE_SHORT_NAME]));
+        $this->assertEquals('Holiday IT-IT', $holiday->getName(['it_IT', Holiday::LOCALE_KEY]));
+        $this->assertEquals('testHoliday', $holiday->getName([Holiday::LOCALE_KEY]));
 
         $holiday = new Holiday('testHoliday', $translations, new DateTime(), 'ja');
         $this->assertEquals('Holiday EN-US', $holiday->getName());

--- a/tests/Base/SubstituteHolidayTest.php
+++ b/tests/Base/SubstituteHolidayTest.php
@@ -68,7 +68,7 @@ class SubstituteHolidayTest extends TestCase
         $substitute = new SubstituteHoliday($holiday, [], new DateTime('2019-01-02'), 'en_US', Holiday::TYPE_SEASON);
 
         $this->assertSame($holiday, $substitute->getSubstitutedHoliday());
-        $this->assertEquals('substituteHoliday:testHoliday', $substitute->getShortName());
+        $this->assertEquals('substituteHoliday:testHoliday', $substitute->getKey());
         $this->assertEquals(Holiday::TYPE_SEASON, $substitute->getType());
         $this->assertEquals(new DateTime('2019-01-02'), $substitute);
     }

--- a/tests/Base/TranslationsTest.php
+++ b/tests/Base/TranslationsTest.php
@@ -39,21 +39,21 @@ class TranslationsTest extends TestCase
         $translations = new Translations(self::LOCALES);
 
         $locale = 'en_US';
-        $shortName = 'newYearsDay';
+        $key = 'newYearsDay';
         $translation = 'New Year’s Day';
 
-        $this->assertNull($translations->getTranslation($shortName, $locale));
-        $this->assertEmpty($translations->getTranslations($shortName));
+        $this->assertNull($translations->getTranslation($key, $locale));
+        $this->assertEmpty($translations->getTranslations($key));
 
-        $translations->addTranslation($shortName, $locale, $translation);
+        $translations->addTranslation($key, $locale, $translation);
 
-        $this->assertNotNull($translations->getTranslations($shortName));
-        $this->assertNotEmpty($translations->getTranslations($shortName));
-        $this->assertEquals([$locale => $translation], $translations->getTranslations($shortName));
+        $this->assertNotNull($translations->getTranslations($key));
+        $this->assertNotEmpty($translations->getTranslations($key));
+        $this->assertEquals([$locale => $translation], $translations->getTranslations($key));
 
-        $this->assertNotNull($translations->getTranslation($shortName, $locale));
-        $this->assertIsString($translations->getTranslation($shortName, $locale));
-        $this->assertEquals($translation, $translations->getTranslation($shortName, $locale));
+        $this->assertNotNull($translations->getTranslation($key, $locale));
+        $this->assertIsString($translations->getTranslation($key, $locale));
+        $this->assertEquals($translation, $translations->getTranslation($key, $locale));
     }
 
     /**
@@ -64,49 +64,49 @@ class TranslationsTest extends TestCase
         $translations = new Translations(self::LOCALES);
 
         $firstLocale = 'en_US';
-        $firstShortName = 'newYearsDay';
+        $firstIdentifier = 'newYearsDay';
         $firstTranslation = 'New Year’s Day';
 
-        $translations->addTranslation($firstShortName, $firstLocale, $firstTranslation);
+        $translations->addTranslation($firstIdentifier, $firstLocale, $firstTranslation);
 
-        $this->assertNotNull($translations->getTranslations($firstShortName));
-        $this->assertNotEmpty($translations->getTranslations($firstShortName));
-        $this->assertEquals([$firstLocale => $firstTranslation], $translations->getTranslations($firstShortName));
+        $this->assertNotNull($translations->getTranslations($firstIdentifier));
+        $this->assertNotEmpty($translations->getTranslations($firstIdentifier));
+        $this->assertEquals([$firstLocale => $firstTranslation], $translations->getTranslations($firstIdentifier));
 
-        $this->assertNotNull($translations->getTranslation($firstShortName, $firstLocale));
-        $this->assertIsString($translations->getTranslation($firstShortName, $firstLocale));
-        $this->assertEquals($firstTranslation, $translations->getTranslation($firstShortName, $firstLocale));
+        $this->assertNotNull($translations->getTranslation($firstIdentifier, $firstLocale));
+        $this->assertIsString($translations->getTranslation($firstIdentifier, $firstLocale));
+        $this->assertEquals($firstTranslation, $translations->getTranslation($firstIdentifier, $firstLocale));
 
         $secondLocale = 'nl_NL';
-        $secondShortName = 'easter';
+        $secondIdentifier = 'easter';
         $secondTranslation = 'Eerste paasdag';
 
-        $translations->addTranslation($secondShortName, $secondLocale, $secondTranslation);
+        $translations->addTranslation($secondIdentifier, $secondLocale, $secondTranslation);
 
-        $this->assertNotNull($translations->getTranslations($secondShortName));
-        $this->assertNotEmpty($translations->getTranslations($secondShortName));
-        $this->assertEquals([$secondLocale => $secondTranslation], $translations->getTranslations($secondShortName));
+        $this->assertNotNull($translations->getTranslations($secondIdentifier));
+        $this->assertNotEmpty($translations->getTranslations($secondIdentifier));
+        $this->assertEquals([$secondLocale => $secondTranslation], $translations->getTranslations($secondIdentifier));
 
-        $this->assertNotNull($translations->getTranslation($secondShortName, $secondLocale));
-        $this->assertIsString($translations->getTranslation($secondShortName, $secondLocale));
-        $this->assertEquals($secondTranslation, $translations->getTranslation($secondShortName, $secondLocale));
+        $this->assertNotNull($translations->getTranslation($secondIdentifier, $secondLocale));
+        $this->assertIsString($translations->getTranslation($secondIdentifier, $secondLocale));
+        $this->assertEquals($secondTranslation, $translations->getTranslation($secondIdentifier, $secondLocale));
 
         $thirdLocale = 'en_US';
-        $thirdShortName = 'easter';
+        $thirdIdentifier = 'easter';
         $thirdTranslation = 'Easter Sunday';
 
-        $translations->addTranslation($thirdShortName, $thirdLocale, $thirdTranslation);
+        $translations->addTranslation($thirdIdentifier, $thirdLocale, $thirdTranslation);
 
-        $this->assertNotNull($translations->getTranslations($thirdShortName));
-        $this->assertNotEmpty($translations->getTranslations($thirdShortName));
+        $this->assertNotNull($translations->getTranslations($thirdIdentifier));
+        $this->assertNotEmpty($translations->getTranslations($thirdIdentifier));
         $this->assertEquals(
             [$thirdLocale => $thirdTranslation, $secondLocale => $secondTranslation],
-            $translations->getTranslations($thirdShortName)
+            $translations->getTranslations($thirdIdentifier)
         );
 
-        $this->assertNotNull($translations->getTranslation($thirdShortName, $thirdLocale));
-        $this->assertIsString($translations->getTranslation($thirdShortName, $thirdLocale));
-        $this->assertEquals($thirdTranslation, $translations->getTranslation($thirdShortName, $thirdLocale));
+        $this->assertNotNull($translations->getTranslation($thirdIdentifier, $thirdLocale));
+        $this->assertIsString($translations->getTranslation($thirdIdentifier, $thirdLocale));
+        $this->assertEquals($thirdTranslation, $translations->getTranslation($thirdIdentifier, $thirdLocale));
     }
 
     /**
@@ -120,10 +120,10 @@ class TranslationsTest extends TestCase
         $translations = new Translations(self::LOCALES);
 
         $unknownLocale = 'en_XY';
-        $shortName = 'newYearsDay';
+        $key = 'newYearsDay';
         $translation = 'New Year’s Day';
 
-        $translations->addTranslation($shortName, $unknownLocale, $translation);
+        $translations->addTranslation($key, $unknownLocale, $translation);
     }
 
     /**
@@ -134,15 +134,15 @@ class TranslationsTest extends TestCase
         $translations = new Translations(self::LOCALES);
 
         $locale = 'en_US';
-        $shortName = 'newYearsDay';
+        $key = 'newYearsDay';
         $translation = 'New Year’s Day';
 
-        $unknownShortName = 'unknownHoliday';
+        $unknownIdentifier = 'unknownHoliday';
 
-        $translations->addTranslation($shortName, $locale, $translation);
+        $translations->addTranslation($key, $locale, $translation);
 
-        $this->assertNull($translations->getTranslation($unknownShortName, $locale));
-        $this->assertEmpty($translations->getTranslations($unknownShortName));
+        $this->assertNull($translations->getTranslation($unknownIdentifier, $locale));
+        $this->assertEmpty($translations->getTranslations($unknownIdentifier));
     }
 
     /**
@@ -153,14 +153,14 @@ class TranslationsTest extends TestCase
         $translations = new Translations(self::LOCALES);
 
         $locale = 'en_US';
-        $shortName = 'newYearsDay';
+        $key = 'newYearsDay';
         $translation = 'New Year’s Day';
 
         $unknownLocale = 'pl_PL';
 
-        $translations->addTranslation($shortName, $locale, $translation);
+        $translations->addTranslation($key, $locale, $translation);
 
-        $this->assertNull($translations->getTranslation($shortName, $unknownLocale));
+        $this->assertNull($translations->getTranslation($key, $unknownLocale));
     }
 
     /**
@@ -168,7 +168,7 @@ class TranslationsTest extends TestCase
      */
     public function testLoadingTranslationsFromDirectory(): void
     {
-        $shortName = 'newYearsDay';
+        $key = 'newYearsDay';
         $fileContents = <<<'FILE'
 <?php
 return [
@@ -178,7 +178,7 @@ return [
 ];
 FILE;
 
-        vfsStream::setup('root', null, ['lang' => [$shortName . '.php' => $fileContents]]);
+        vfsStream::setup('root', null, ['lang' => [$key . '.php' => $fileContents]]);
 
         $translations = new Translations(self::LOCALES);
         $translations->loadTranslations(vfsStream::url('root/lang'));
@@ -186,10 +186,10 @@ FILE;
         $locale = 'en_US';
         $translation = 'New Year’s Day';
 
-        $this->assertNotNull($translations->getTranslations($shortName));
-        $this->assertNotEmpty($translations->getTranslations($shortName));
-        $this->assertIsString($translations->getTranslation($shortName, $locale));
-        $this->assertEquals($translation, $translations->getTranslation($shortName, $locale));
+        $this->assertNotNull($translations->getTranslations($key));
+        $this->assertNotEmpty($translations->getTranslations($key));
+        $this->assertIsString($translations->getTranslation($key, $locale));
+        $this->assertEquals($translation, $translations->getTranslation($key, $locale));
     }
 
     /**
@@ -197,7 +197,7 @@ FILE;
      */
     public function testNotLoadingTranslationsFromFileWithInvalidExtension(): void
     {
-        $shortName = 'newYearsDay';
+        $key = 'newYearsDay';
         $fileContents = <<<'FILE'
 <?php
 return [
@@ -207,13 +207,13 @@ return [
 ];
 FILE;
 
-        vfsStream::setup('root', null, ['lang' => [$shortName . '.translation' => $fileContents]]);
+        vfsStream::setup('root', null, ['lang' => [$key . '.translation' => $fileContents]]);
 
         $translations = new Translations(self::LOCALES);
         $translations->loadTranslations(vfsStream::url('root/lang'));
 
-        $this->assertNotNull($translations->getTranslations($shortName));
-        $this->assertEmpty($translations->getTranslations($shortName));
+        $this->assertNotNull($translations->getTranslations($key));
+        $this->assertEmpty($translations->getTranslations($key));
     }
 
     /**
@@ -224,7 +224,7 @@ FILE;
     {
         $this->expectException(UnknownLocaleException::class);
 
-        $shortName = 'newYearsDay';
+        $key = 'newYearsDay';
         $fileContents = <<<'FILE'
 <?php
 return [
@@ -233,7 +233,7 @@ return [
 ];
 FILE;
 
-        vfsStream::setup('root', null, ['lang' => [$shortName . '.php' => $fileContents]]);
+        vfsStream::setup('root', null, ['lang' => [$key . '.php' => $fileContents]]);
 
         $translations = new Translations(self::LOCALES);
         $translations->loadTranslations(vfsStream::url('root/lang'));
@@ -258,7 +258,7 @@ FILE;
      */
     public function testLoadingMultipleTranslationsFromDirectory(): void
     {
-        $firstShortName = 'newYearsDay';
+        $firstIdentifier = 'newYearsDay';
         $firstFileContents = <<<'FILE'
 <?php
 return [
@@ -268,7 +268,7 @@ return [
 ];
 FILE;
 
-        $secondShortName = 'easter';
+        $secondIdentifier = 'easter';
         $secondFileContents = <<<'FILE'
 <?php
 return [
@@ -279,8 +279,8 @@ FILE;
 
         vfsStream::setup('root', null, [
             'lang' => [
-                $firstShortName . '.php' => $firstFileContents,
-                $secondShortName . '.php' => $secondFileContents,
+                $firstIdentifier . '.php' => $firstFileContents,
+                $secondIdentifier . '.php' => $secondFileContents,
             ],
         ]);
 
@@ -291,17 +291,17 @@ FILE;
         $locale = 'en_US';
         $translation = 'New Year’s Day';
 
-        $this->assertNotNull($translations->getTranslations($firstShortName));
-        $this->assertNotEmpty($translations->getTranslations($firstShortName));
-        $this->assertIsString($translations->getTranslation($firstShortName, $locale));
-        $this->assertEquals($translation, $translations->getTranslation($firstShortName, $locale));
+        $this->assertNotNull($translations->getTranslations($firstIdentifier));
+        $this->assertNotEmpty($translations->getTranslations($firstIdentifier));
+        $this->assertIsString($translations->getTranslation($firstIdentifier, $locale));
+        $this->assertEquals($translation, $translations->getTranslation($firstIdentifier, $locale));
 
         $locale = 'nl_NL';
         $translation = 'Eerste Paasdag';
 
-        $this->assertNotNull($translations->getTranslations($secondShortName));
-        $this->assertNotEmpty($translations->getTranslations($secondShortName));
-        $this->assertIsString($translations->getTranslation($secondShortName, $locale));
-        $this->assertEquals($translation, $translations->getTranslation($secondShortName, $locale));
+        $this->assertNotNull($translations->getTranslations($secondIdentifier));
+        $this->assertNotEmpty($translations->getTranslations($secondIdentifier));
+        $this->assertIsString($translations->getTranslation($secondIdentifier, $locale));
+        $this->assertEquals($translation, $translations->getTranslation($secondIdentifier, $locale));
     }
 }

--- a/tests/Base/TypographyTest.php
+++ b/tests/Base/TypographyTest.php
@@ -35,10 +35,10 @@ class TypographyTest extends TestCase
      *
      * @param string $name The localized holiday name
      * @param string $class The provider
-     * @param string $shortName The short name (internal name) of the holiday
+     * @param string $key The holiday key
      * @param string $locale The locale
      */
-    public function testTranslations($name, $class, $shortName, $locale): void
+    public function testTranslations($name, $class, $key, $locale): void
     {
         $this->assertStringNotContainsString("'", $name, 'Translation contains typewriter apostrophe');
         $this->assertStringNotContainsString('"', $name, 'Translation contains typewriter quote');
@@ -59,7 +59,7 @@ class TypographyTest extends TestCase
 
             foreach ($provider->getHolidays() as $holiday) {
                 foreach ($holiday->translations as $locale => $name) {
-                    $tests[$name] = [$name, $class, $holiday->getShortName(), $locale];
+                    $tests[$name] = [$name, $class, $holiday->getKey(), $locale];
                 }
             }
         }

--- a/tests/Base/YasumiTest.php
+++ b/tests/Base/YasumiTest.php
@@ -185,7 +185,7 @@ class YasumiTest extends TestCase
      *
      * @throws ReflectionException
      */
-    public function testNextWithBlankName(): void
+    public function testNextWithBlankKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -223,7 +223,7 @@ class YasumiTest extends TestCase
      *
      * @throws ReflectionException
      */
-    public function testPreviousWithBlankName(): void
+    public function testPreviousWithBlankKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -263,11 +263,11 @@ class YasumiTest extends TestCase
     }
 
     /**
-     * Tests that the WhenIs function throws an InvalidArgumentException when a blank name is given.
+     * Tests that the WhenIs function throws an InvalidArgumentException when a blank key is given.
      *
      * @throws ReflectionException
      */
-    public function testWhenIsWithBlankName(): void
+    public function testWhenIsWithBlankKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -280,7 +280,7 @@ class YasumiTest extends TestCase
      *
      * @throws ReflectionException
      */
-    public function testGetHolidayWithBlankName(): void
+    public function testGetHolidayWithBlankKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -307,7 +307,7 @@ class YasumiTest extends TestCase
      *
      * @throws ReflectionException
      */
-    public function testWhatWeekDayIsWithBlankName(): void
+    public function testWhatWeekDayIsWithBlankKey(): void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/tests/Japan/JapanBaseTestCase.php
+++ b/tests/Japan/JapanBaseTestCase.php
@@ -33,7 +33,7 @@ abstract class JapanBaseTestCase extends TestCase
     public const TIMEZONE = 'Asia/Tokyo';
 
     /**
-     * Prefix for short name used when holiday is substituted
+     * Prefix for holiday key used when holiday is substituted
      */
     public const SUBSTITUTE_PREFIX = 'substituteHoliday:';
 

--- a/tests/Ukraine/SubstitutedHolidayTest.php
+++ b/tests/Ukraine/SubstitutedHolidayTest.php
@@ -59,7 +59,7 @@ class SubstitutedHolidayTest extends UkraineBaseTestCase implements YasumiTestCa
      * Asserts that the expected date is indeed a holiday for that given year and name
      *
      * @param string $provider the holiday provider (i.e. country/state) for which the holiday need to be tested
-     * @param string $shortName string the short name of the holiday to be checked against
+     * @param string $key string the key of the holiday to be checked against
      * @param int $year holiday calendar year
      * @param DateTime $expectedOfficial the official date to be checked against
      * @param DateTime $expectedSubstitution the substituted date to be checked against
@@ -73,21 +73,21 @@ class SubstitutedHolidayTest extends UkraineBaseTestCase implements YasumiTestCa
      */
     public function assertHolidayWithSubstitution(
         string $provider,
-        string $shortName,
+        string $key,
         int $year,
         DateTime $expectedOfficial,
         DateTime $expectedSubstitution = null
     ): void {
         $holidays = Yasumi::create($provider, $year);
 
-        $holidayOfficial = $holidays->getHoliday($shortName);
+        $holidayOfficial = $holidays->getHoliday($key);
         $this->assertInstanceOf(Holiday::class, $holidayOfficial);
         $this->assertNotNull($holidayOfficial);
         $this->assertEquals($expectedOfficial, $holidayOfficial);
         $this->assertTrue($holidays->isHoliday($holidayOfficial));
         $this->assertEquals(Holiday::TYPE_OFFICIAL, $holidayOfficial->getType());
 
-        $holidaySubstitution = $holidays->getHoliday('substituteHoliday:' . $holidayOfficial->getShortName());
+        $holidaySubstitution = $holidays->getHoliday('substituteHoliday:' . $holidayOfficial->getKey());
         if ($expectedSubstitution === null) {
             // without substitution
             $this->assertNull($holidaySubstitution);

--- a/tests/YasumiBase.php
+++ b/tests/YasumiBase.php
@@ -91,7 +91,7 @@ trait YasumiBase
      * Asserts that the expected date is indeed a holiday for that given year and name
      *
      * @param string $provider the holiday provider (i.e. country/state) for which the holiday need to be tested
-     * @param string $shortName string the short name of the holiday to be checked against
+     * @param string $key string the key of the holiday to be checked against
      * @param int $year holiday calendar year
      * @param DateTime $expected the date to be checked against
      *
@@ -104,12 +104,12 @@ trait YasumiBase
      */
     public function assertHoliday(
         string $provider,
-        string $shortName,
+        string $key,
         int $year,
         DateTime $expected
     ): void {
         $holidays = Yasumi::create($provider, $year);
-        $holiday = $holidays->getHoliday($shortName);
+        $holiday = $holidays->getHoliday($key);
 
         $this->assertInstanceOf(Holiday::class, $holiday);
         $this->assertEquals($expected, $holiday);
@@ -120,7 +120,7 @@ trait YasumiBase
      * Asserts that the expected date is indeed a substitute holiday for that given year and name
      *
      * @param string $provider the holiday provider (i.e. country/state) for which the holiday need to be tested
-     * @param string $shortName string the short name of the substituted holiday to be checked against
+     * @param string $key string the key of the substituted holiday to be checked against
      * @param int $year holiday calendar year
      * @param DateTime $expected the date to be checked against
      *
@@ -133,12 +133,12 @@ trait YasumiBase
      */
     public function assertSubstituteHoliday(
         string $provider,
-        string $shortName,
+        string $key,
         int $year,
         DateTime $expected
     ): void {
         $holidays = Yasumi::create($provider, $year);
-        $holiday = $holidays->getHoliday('substituteHoliday:' . $shortName);
+        $holiday = $holidays->getHoliday('substituteHoliday:' . $key);
 
         $this->assertInstanceOf(SubstituteHoliday::class, $holiday);
         $this->assertEquals($expected, $holiday);
@@ -149,7 +149,7 @@ trait YasumiBase
      * Asserts that the given substitute holiday for that given year does not exist.
      *
      * @param string $provider the holiday provider (i.e. country/state) for which the holiday need to be tested
-     * @param string $shortName the short name of the substituted holiday to be checked against
+     * @param string $key the key of the substituted holiday to be checked against
      * @param int $year holiday calendar year
      *
      * @throws InvalidArgumentException
@@ -161,12 +161,12 @@ trait YasumiBase
      */
     public function assertNotSubstituteHoliday(
         string $provider,
-        string $shortName,
+        string $key,
         int $year
     ): void {
         $this->assertNotHoliday(
             $provider,
-            'substituteHoliday:' . $shortName,
+            'substituteHoliday:' . $key,
             $year
         );
     }
@@ -175,7 +175,7 @@ trait YasumiBase
      * Asserts that the given holiday for that given year does not exist.
      *
      * @param string $provider the holiday provider (i.e. country/state) for which the holiday need to be tested
-     * @param string $shortName the short name of the holiday to be checked against
+     * @param string $key the key of the holiday to be checked against
      * @param int $year holiday calendar year
      *
      * @throws InvalidArgumentException
@@ -187,11 +187,11 @@ trait YasumiBase
      */
     public function assertNotHoliday(
         string $provider,
-        string $shortName,
+        string $key,
         int $year
     ): void {
         $holidays = Yasumi::create($provider, $year);
-        $holiday = $holidays->getHoliday($shortName);
+        $holiday = $holidays->getHoliday($key);
 
         $this->assertNull($holiday);
     }
@@ -200,7 +200,7 @@ trait YasumiBase
      * Asserts that the expected name is indeed provided as a translated holiday name for that given year and name
      *
      * @param string $provider the holiday provider (i.e. country/state) for which the holiday need to be tested
-     * @param string $shortName string the short name of the holiday to be checked against
+     * @param string $key string the key of the holiday to be checked against
      * @param int $year holiday calendar year
      * @param array $translations the translations to be checked against
      *
@@ -212,12 +212,12 @@ trait YasumiBase
      */
     public function assertTranslatedHolidayName(
         string $provider,
-        string $shortName,
+        string $key,
         int $year,
         array $translations
     ): void {
         $holidays = Yasumi::create($provider, $year);
-        $holiday = $holidays->getHoliday($shortName);
+        $holiday = $holidays->getHoliday($key);
 
         $this->assertInstanceOf(Holiday::class, $holiday);
         $this->assertTrue($holidays->isHoliday($holiday));
@@ -248,7 +248,7 @@ trait YasumiBase
      * Asserts that the expected type is indeed the associated type of the given holiday
      *
      * @param string $provider the holiday provider (i.e. country/region) for which the holiday need to be tested
-     * @param string $shortName string the short name of the holiday to be checked against
+     * @param string $key string the key of the holiday to be checked against
      * @param int $year holiday calendar year
      * @param string $type the type to be checked against
      *
@@ -260,12 +260,12 @@ trait YasumiBase
      */
     public function assertHolidayType(
         string $provider,
-        string $shortName,
+        string $key,
         int $year,
         string $type
     ): void {
         $holidays = Yasumi::create($provider, $year);
-        $holiday = $holidays->getHoliday($shortName);
+        $holiday = $holidays->getHoliday($key);
 
         $this->assertInstanceOf(Holiday::class, $holiday);
         $this->assertEquals($type, $holiday->getType());
@@ -276,7 +276,7 @@ trait YasumiBase
      *
      * @param string $provider the holiday provider (i.e. country/state) for which the holiday need to be
      *                                  tested
-     * @param string $shortName string the short name of the holiday to be checked against
+     * @param string $key string the key of the holiday to be checked against
      * @param int $year holiday calendar year
      * @param string $expectedDayOfWeek the expected week day (i.e. "Saturday", "Sunday", etc.)
      *
@@ -288,12 +288,12 @@ trait YasumiBase
      */
     public function assertDayOfWeek(
         string $provider,
-        string $shortName,
+        string $key,
         int $year,
         string $expectedDayOfWeek
     ): void {
         $holidays = Yasumi::create($provider, $year);
-        $holiday = $holidays->getHoliday($shortName);
+        $holiday = $holidays->getHoliday($key);
 
         $this->assertInstanceOf(Holiday::class, $holiday);
         $this->assertTrue($holidays->isHoliday($holiday));


### PR DESCRIPTION
I am not a fan of the term “short name”.

- It is not very short. Apart from spaces, it has the same length as the English localised name. 
- It is not the same kind of “name” as is used in the method name `getName()` but rather an identifier/key.

So I suggest renaming the concept to “key”. I have kept the public property `Holiday#shortName` for BC. This is now deprecated and will be renamed to $key (and made private/protected) in a future major release.