### PR TITLE
Feature/christmas eve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ## [Unreleased]
 
 ### Added
+- Added christmas eve to Germany (as holidaytype other) [\#222](https://github.com/azuyalabs/yasumi/pull/222)
 - Added Canada Provider [\#215](https://github.com/azuyalabs/yasumi/pull/215) ([lux](https://github.com/lux))
 - Added Luxembourg Provider [\#205](https://github.com/azuyalabs/yasumi/pull/205) ([Arkounay](https://github.com/Arkounay))
 - Catholic Christmas Day is a new official holiday since 2017 in the Ukraine. [\#202](https://github.com/azuyalabs/yasumi/pull/202)

--- a/src/Yasumi/Provider/Germany.php
+++ b/src/Yasumi/Provider/Germany.php
@@ -54,6 +54,7 @@ class Germany extends AbstractProvider
         $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->christmasEve($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
 
         // Calculate other holidays
         $this->calculateGermanUnityDay();

--- a/src/Yasumi/data/translations/christmasEve.php
+++ b/src/Yasumi/data/translations/christmasEve.php
@@ -16,7 +16,7 @@ return [
     'cs' => 'Štědrý den',
     'cy' => 'Noswyl Nadolig',
     'da' => 'juleaften',
-    'de' => 'Heiliger Abend',
+    'de' => 'Heilig Abend',
     'en' => 'Christmas Eve',
     'et' => 'Jõululaupäev',
     'fr' => 'Réveillon de Noël',

--- a/tests/Germany/ChristmasEveTest.php
+++ b/tests/Germany/ChristmasEveTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2020 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\tests\Germany;
+
+use DateTime;
+use Exception;
+use ReflectionException;
+use Yasumi\Holiday;
+use Yasumi\tests\YasumiTestCaseInterface;
+
+/**
+ * Class for testing the Christmas Eve in Germany.
+ */
+class ChristmasEveTest extends GermanyBaseTestCase implements YasumiTestCaseInterface
+{
+    /**
+     * The name of the holiday to be tested
+     */
+    public const HOLIDAY = 'christmasEve';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int $year the year for which the holiday defined in this test needs to be tested
+     * @param DateTime $expected the expected date
+     *
+     * @throws ReflectionException
+     */
+    public function testHoliday($year, $expected)
+    {
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test
+     *
+     * @return array list of test dates for the holiday defined in this test
+     * @throws Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        return $this->generateRandomDates(12, 24, self::TIMEZONE);
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     * @throws ReflectionException
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Heilig Abend']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     * @throws ReflectionException
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
+    }
+}


### PR DESCRIPTION
Added christmas eve to germany as holiday::TYPE_OTHER.
It's not an official holiday, but in germany you get a half-day off.