### PR TITLE
Add non-working day flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM php:7.2-cli-alpine
+
+RUN apk add --update --no-cache \
+        git \
+        curl \
+        coreutils \
+        icu-dev \
+        libzip-dev \
+        freetype-dev \
+        libjpeg-turbo-dev \
+        libpng-dev \
+        bash
+
+RUN docker-php-source extract \
+    # ext-opache
+    && docker-php-ext-enable opcache \
+    # ext-calendar
+    && docker-php-ext-install calendar \
+    && docker-php-ext-enable calendar \
+    # ext-others
+    && docker-php-ext-install intl zip json ctype \
+    ## cleanup
+    && docker-php-source delete
+
+# install fixuid
+RUN curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.5/fixuid-0.5-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: www-data\ngroup: www-data\n" > /etc/fixuid/config.yml
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin
+
+WORKDIR /opt/project
+COPY . .
+
+ENTRYPOINT ["fixuid", "-q"]

--- a/dev/composer.sh
+++ b/dev/composer.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "${PWD}/${1#./}"
+}
+
+script_dir=`realpath "$0"`
+bin_dir=`dirname "${script_dir}"`
+root_dir=`dirname "${bin_dir}"`
+
+docker run -t --rm \
+    --mount type=bind,source="${root_dir}",target=//opt/project \
+    --user=$(id -u):$(id -g) \
+    --entrypoint=fixuid \
+    $(docker build -f "${root_dir}/Dockerfile" "${root_dir}" -q) -q composer "$@"

--- a/dev/php.sh
+++ b/dev/php.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "${PWD}/${1#./}"
+}
+
+script_dir=`realpath "$0"`
+bin_dir=`dirname "${script_dir}"`
+root_dir=`dirname "${bin_dir}"`
+
+docker run -t --rm \
+    --mount type=bind,source="${root_dir}",target=//opt/project \
+    --user=$(id -u):$(id -g) \
+    --entrypoint=fixuid \
+    $(docker build -f "${root_dir}/Dockerfile" "${root_dir}" -q) -q php "$@"

--- a/src/Yasumi/Filters/NonWorkingDayFilter.php
+++ b/src/Yasumi/Filters/NonWorkingDayFilter.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2020 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+namespace Yasumi\Filters;
+
+use Yasumi\Holiday;
+
+/**
+ * NonWorkingDayFilter is a class for filtering all non-working holidays.
+ *
+ * NonWorkingDayFilter is a class that returns all holidays that are non-working holiday, which are, usually, the
+ * official ones.
+ *
+ * Example usage:
+ * $holidays = Yasumi::create('Netherlands', 2015);
+ * $nonWorkingDay = new NonWorkingDayFilter($holidays->getIterator());
+ */
+class NonWorkingDayFilter extends AbstractFilter
+{
+    /**
+     * Checks whether the current element of the iterator is an non-working day.
+     *
+     * @return bool
+     */
+    public function accept(): bool
+    {
+        return $this->getInnerIterator()->current()->isNonWorkingDay();
+    }
+}

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -88,6 +88,11 @@ class Holiday extends DateTime implements JsonSerializable
     protected $displayLocale;
 
     /**
+     * @var bool to differentiate between a non-working day and a working day. (Default: if type is official)
+     */
+    protected $nonWorkingDay;
+
+    /**
      * Creates a new Holiday.
      *
      * If a holiday date needs to be defined for a specific timezone, make sure that the date instance
@@ -102,6 +107,8 @@ class Holiday extends DateTime implements JsonSerializable
      * @param string $type The type of holiday. Use the following constants: TYPE_OFFICIAL,
      *                                          TYPE_OBSERVANCE, TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an
      *                                          official holiday is considered.
+     * @param bool $nonWorkingDay Flag that determines if the holiday is a non-working day or not. Usually, the
+     *                                          TYPE_OFFICIAL holiday is considered non-working day.
      *
      * @throws InvalidDateException
      * @throws UnknownLocaleException
@@ -113,7 +120,8 @@ class Holiday extends DateTime implements JsonSerializable
         array $names,
         \DateTimeInterface $date,
         string $displayLocale = self::DEFAULT_LOCALE,
-        string $type = self::TYPE_OFFICIAL
+        string $type = self::TYPE_OFFICIAL,
+        bool $nonWorkingDay = null
     ) {
         // Validate if key is not empty
         if (empty($key)) {
@@ -135,6 +143,7 @@ class Holiday extends DateTime implements JsonSerializable
         $this->translations = $names;
         $this->displayLocale = $displayLocale;
         $this->type = $type;
+        $this->nonWorkingDay = $nonWorkingDay ?? $type === self::TYPE_OFFICIAL;
 
         // Construct instance
         parent::__construct($date->format('Y-m-d'), $date->getTimezone());
@@ -158,6 +167,16 @@ class Holiday extends DateTime implements JsonSerializable
     public function getType(): string
     {
         return $this->type;
+    }
+
+    /**
+     * A boolean flag that determines whether this is a non-working day or not.
+     *
+     * @return bool - true if the holiday is a non-working day, false otherwise.
+     */
+    public function isNonWorkingDay(): bool
+    {
+        return $this->nonWorkingDay;
     }
 
     /**

--- a/tests/Base/YasumiTest.php
+++ b/tests/Base/YasumiTest.php
@@ -151,6 +151,14 @@ class YasumiTest extends TestCase
         self::assertIsString($holiday->getType());
     }
 
+    public function testIsNonWorkingDay(): void
+    {
+        $holidays = Yasumi::create('Romania', Factory::create()->numberBetween(1949, self::YEAR_UPPER_BOUND));
+        $holiday = $holidays->getHoliday('nationalDay');
+
+        self::assertTrue($holiday->isNonWorkingDay());
+    }
+
     /**
      * Tests that the getYear function returns an integer for the test holiday provider
      * @throws ReflectionException


### PR DESCRIPTION
Hello.

I've developed a time tracking app back in 2017 that registers if an employee takes a period of time away from office. Because there are non-working days, we've implemented an entity that needs manual input from those data.

I've been looking for a replacement for a while, to get rid of manual input, then I found this project on Reddit. The integration in our project went flawless. Then I noticed some improvements that I could do to this project, in order to cut some lines of code when determining non-working days.

So I've forked this repository to add an `$nonWorkingDay` flag in `Holiday`, which is typed as `bool $nonWorkingDay = nul` and has a fallback to `$type === Holiday::TYPE_OFFICIAL` and added a filter class. The fallback is made in order to prevent BC, as most official holidays are non-working day (don't know about other countries). At least, this is the case in Romania, I'm don't know about other countries.

This is more like a shortcut to filter out official holidays, which from what I've read on the providers page, it might not be as reliable as it seems, so this little "hack" might do the trick.

Additionally, I've added a Dockerfile with php7.2-cli-alpine as I don't have any PHP runtime installed natively, with two helper scripts: `composer.sh` and `php.sh`. These aren't necessary to be merged with upstream, as I made these for my local development.

Don't know if the tests will pass, as I've ran `composer test` inside a docker container and it fails:
![image](https://user-images.githubusercontent.com/7689151/94376022-7d6feb00-0120-11eb-81d4-4fafa8d697ac.png)

Hopefully, the code works without any issues, so it could be merged asap to upstream.
