### PR TITLE
Allow override WEEKEND_DATA in provider classes

### DIFF
--- a/src/Yasumi/Provider/AbstractProvider.php
+++ b/src/Yasumi/Provider/AbstractProvider.php
@@ -243,7 +243,7 @@ abstract class AbstractProvider implements ProviderInterface, Countable, Iterato
         // If no data is defined for this Holiday Provider, the function falls back to the global weekend definition.
         if (\in_array(
             (int) $date->format('w'),
-            self::WEEKEND_DATA[$this::ID] ?? [0, 6],
+            static::WEEKEND_DATA[$this::ID] ?? [0, 6],
             true
         )
         ) {


### PR DESCRIPTION
Hello,

currently it is not possible to override the WEEKEND_DATA in a provider class. A use-case for this is, if you want to set Saturday as working day