### PR TITLE
Japanese holidays in 2021 for COVID-19 rescheduled Olympic Games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - Added Pentecost (Sunday) to Germany [\#225](https://github.com/azuyalabs/yasumi/pull/225)
 
 ### Changed
+- Rescheduled exceptional Japanese holidays for Olympic Games 2020 after COVID-19 [\#240](https://github.com/azuyalabs/yasumi/pull/240) ([tanakahisateru](https://github.com/tanakahisateru))
 
 ### Fixed
 

--- a/src/Yasumi/Provider/Japan.php
+++ b/src/Yasumi/Provider/Japan.php
@@ -367,7 +367,11 @@ class Japan extends AbstractProvider
     private function calculateMarineDay(): void
     {
         $date = null;
-        if (2020 === $this->year) {
+        if (2021 === $this->year) {
+            // For Olympic 2021 Tokyo (after COVID-19)
+            $date = new DateTime("$this->year-7-22", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        } elseif (2020 === $this->year) {
+            // For Olympic 2020 Tokyo
             $date = new DateTime("$this->year-7-23", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 2003) {
             $date = new DateTime("third monday of july $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
@@ -398,7 +402,11 @@ class Japan extends AbstractProvider
     private function calculateMountainDay(): void
     {
         $date = null;
-        if (2020 === $this->year) {
+        if (2021 === $this->year) {
+            // For Olympic 2021 Tokyo (after COVID-19)
+            $date = new DateTime("$this->year-8-8", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        } elseif (2020 === $this->year) {
+            // For Olympic 2020 Tokyo
             $date = new DateTime("$this->year-8-10", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 2016) {
             $date = new DateTime("$this->year-8-11", DateTimeZoneFactory::getDateTimeZone($this->timezone));
@@ -461,7 +469,11 @@ class Japan extends AbstractProvider
     private function calculateSportsDay(): void
     {
         $date = null;
-        if (2020 === $this->year) {
+        if (2021 === $this->year) {
+            // For Olympic 2021 Tokyo (after COVID-19)
+            $date = new DateTime("$this->year-7-23", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        } elseif (2020 === $this->year) {
+            // For Olympic 2020 Tokyo
             $date = new DateTime("$this->year-7-24", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         } elseif ($this->year >= 2000) {
             $date = new DateTime("second monday of october $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));

--- a/tests/Japan/MarineDayTest.php
+++ b/tests/Japan/MarineDayTest.php
@@ -35,6 +35,22 @@ class MarineDayTest extends JapanBaseTestCase implements YasumiTestCaseInterface
     public const ESTABLISHMENT_YEAR = 1996;
 
     /**
+     * Tests Marine Day in 2021. Marine Day in 2021 is July 22th for rescheduled Olympic Games after COVID-19.
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function testMarineDayIn2021(): void
+    {
+        $year = 2021;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-7-22", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
      * Tests Marine Day in 2020. Marine Day in 2020 is July 23th for the Olympic Games.
      * @throws Exception
      * @throws ReflectionException

--- a/tests/Japan/MountainDayTest.php
+++ b/tests/Japan/MountainDayTest.php
@@ -35,6 +35,22 @@ class MountainDayTest extends JapanBaseTestCase implements YasumiTestCaseInterfa
     public const ESTABLISHMENT_YEAR = 2016;
 
     /**
+     * Tests Mountain Day in 2021. Mountain Day in 2021 is August 8th for rescheduled Olympic Games after COVID-19.
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function testMountainDayIn2021(): void
+    {
+        $year = 2021;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-8-8", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
      * Tests Mountain Day in 2020. Mountain Day in 2020 is August 10th for the Olympic Games.
      * @throws Exception
      * @throws ReflectionException

--- a/tests/Japan/SportsDayTest.php
+++ b/tests/Japan/SportsDayTest.php
@@ -35,6 +35,23 @@ class SportsDayTest extends JapanBaseTestCase implements YasumiTestCaseInterface
     public const ESTABLISHMENT_YEAR = 1996;
 
     /**
+     * Tests Health And Sports Day in 2021. Health And Sports Day in 2021 is July 23th for rescheduled Olympic Games
+     * after COVID-19.
+     * @throws Exception
+     * @throws ReflectionException
+     */
+    public function testSportsDayIn2021(): void
+    {
+        $year = 2021;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new DateTime("$year-7-23", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
      * Tests Health And Sports Day in 2020. Health And Sports Day in 2020 is July 24th for the Olympic Games.
      * @throws Exception
      * @throws ReflectionException


### PR DESCRIPTION
Japanese government announced rescheduled holidays for Olympic Games on December 4th.
https://www.kantei.go.jp/jp/headline/tokyo2020/shukujitsu.html