### PR TITLE
Canada provider: fix Canada Day definition and add National Day For Truth And Reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Added
 
 - Added new Juneteenth National Independence Day to USA [\#253](https://github.com/azuyalabs/yasumi/pull/253) ([Mark Heintz](https://github.com/mheintz))
-
+- Added new National Day for Truth and Reconciliation to Canada [\#256](https://github.com/azuyalabs/yasumi/pull/256) ([O.V. Gray](https://github.com/adrx))
 
 ### Changed
 
 ### Fixed
+- Corrected definition of Canada Day in Canada [\#256](https://github.com/azuyalabs/yasumi/pull/256) ([O.V. Gray](https://github.com/adrx))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Added
 
 - Added new Juneteenth National Independence Day to USA [\#253](https://github.com/azuyalabs/yasumi/pull/253) ([Mark Heintz](https://github.com/mheintz))
-- Added new National Day for Truth and Reconciliation to Canada [\#256](https://github.com/azuyalabs/yasumi/pull/256) ([O.V. Gray](https://github.com/adrx))
+- Added new National Day for Truth and Reconciliation to Canada [\#256](https://github.com/azuyalabs/yasumi/pull/256) ([Owen V. Gray](https://github.com/adrx))
 
 ### Changed
 
 ### Fixed
-- Corrected definition of Canada Day in Canada [\#256](https://github.com/azuyalabs/yasumi/pull/256) ([O.V. Gray](https://github.com/adrx))
+- Corrected definition of Canada Day in Canada [\#256](https://github.com/azuyalabs/yasumi/pull/256) ([Owen V. Gray](https://github.com/adrx))
 
 ### Deprecated
 

--- a/src/Yasumi/Provider/Canada.php
+++ b/src/Yasumi/Provider/Canada.php
@@ -138,8 +138,10 @@ class Canada extends AbstractProvider
     /**
      * Canada Day.
      *
-     * @see https://en.wikipedia.org/wiki/Canada_Day and Holidays Act, R.S.C., 1985, c. H-5
-     * by statute, Canada Day is July 1 if that day is not Sunday, and July 2 if July 1 is a Sunday
+     * @see https://en.wikipedia.org/wiki/Canada_Day.
+     * @see Holidays Act, R.S.C., 1985, c. H-5, https://laws-lois.justice.gc.ca/eng/acts/h-5/page-1.html
+     *
+     * by statute, Canada Day is July 1 if that day is not Sunday, and July 2 if July 1 is a Sunday.
      *
      * @throws InvalidDateException
      * @throws \InvalidArgumentException

--- a/src/Yasumi/Provider/Canada.php
+++ b/src/Yasumi/Provider/Canada.php
@@ -60,6 +60,7 @@ class Canada extends AbstractProvider
         $this->calculateLabourDay();
         $this->calculateThanksgivingDay();
         $this->calculateRemembranceDay();
+        $this->calculateNationalDayForTruthAndReconciliation();
     }
 
     /**
@@ -137,7 +138,8 @@ class Canada extends AbstractProvider
     /**
      * Canada Day.
      *
-     * @see https://en.wikipedia.org/wiki/Canada_Day
+     * @see https://en.wikipedia.org/wiki/Canada_Day and Holidays Act, R.S.C., 1985, c. H-5
+     * by statute, Canada Day is July 1 if that day is not Sunday, and July 2 if July 1 is a Sunday
      *
      * @throws InvalidDateException
      * @throws \InvalidArgumentException
@@ -149,11 +151,14 @@ class Canada extends AbstractProvider
         if ($this->year < 1983) {
             return;
         }
-
+        $date = new DateTime($this->year.'-07-01', DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        if (7 === (int) $date->format('N')) {
+            $date = new DateTime($this->year.'-07-02', DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        }
         $this->addHoliday(new Holiday(
             'canadaDay',
             [],
-            new DateTime($this->year.'-07-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $date,
             $this->locale
         ));
     }
@@ -250,6 +255,30 @@ class Canada extends AbstractProvider
             'labourDay',
             [],
             new DateTime("first monday of september $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $this->locale
+        ));
+    }
+
+    /**
+     * National Day For Truth And Reconciliation.
+     *
+     * @see https://parl.ca/Content/Bills/432/Government/C-5/C-5_4/C-5_4.PDF, S. C. 2021, C.11.
+     *
+     * @throws InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    private function calculateNationalDayForTruthAndReconciliation(): void
+    {
+        if ($this->year < 2021) {
+            return;
+        }
+
+        $this->addHoliday(new Holiday(
+            'truthAndReconciliationDay',
+            [],
+            new DateTime("last day of september $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/data/translations/truthAndReconciliationDay.php
+++ b/src/Yasumi/data/translations/truthAndReconciliationDay.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2021 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me@sachatelgenhof.com>
+ */
+
+// Translations for Truth And Reconciliation Day
+return [
+    'en' => 'National Day For Truth And Reconciliation',
+    'fr' => 'la Journée nationale de la vérité et de la réconciliation',
+];

--- a/tests/Canada/TruthAndReconciliationDayTest.php
+++ b/tests/Canada/TruthAndReconciliationDayTest.php
@@ -22,50 +22,45 @@ use Yasumi\Holiday;
 use Yasumi\tests\YasumiTestCaseInterface;
 
 /**
- * Class for testing Canada Day in Canada.
+ * Class for testing National Day For Truth And Reconciliation in Canada.
  */
-class CanadaDayTest extends CanadaBaseTestCase implements YasumiTestCaseInterface
+class TruthAndReconciliationDayTest extends CanadaBaseTestCase implements YasumiTestCaseInterface
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'canadaDay';
+    public const HOLIDAY = 'truthAndReconciliationDay';
 
     /**
      * The year in which the holiday was first established.
      */
-    public const ESTABLISHMENT_YEAR = 1983;
+    public const ESTABLISHMENT_YEAR = 2021;
 
     /**
-     * Tests Canada Day on or after 1983. Canada Day was established in 1983 on July 1st.
+     * Tests TruthAndReconciliationDay on or after 2021. Thanksgiving Day is celebrated since 2021 on the last day
+     * of September.
      *
      * @throws Exception
      * @throws ReflectionException
      */
-    public function testCanadaDayOnAfter1983(): void
+    public function testTruthAndReconciliationDayOnAfter2021(): void
     {
-        $year = 2019; // July 1 is not Sunday
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
-            new DateTime("$year-07-01", new DateTimeZone(self::TIMEZONE))
-        );
-        $year = 2018; // July 1 is Sunday
-        $this->assertHoliday(
-            self::REGION,
-            self::HOLIDAY,
-            $year,
-            new DateTime("$year-07-02", new DateTimeZone(self::TIMEZONE))
+            new DateTime("last day of september $year", new DateTimeZone(self::TIMEZONE))
         );
     }
 
     /**
-     * Tests Canada Day before 1879. Canada Day was established as Dominion Day in 1879 on July 1st.
+     * Tests TruthAndReconciliationDay before 2021. TruthAndReconciliationDay is celebrated since 2021 on the last day
+     * of September.
      *
      * @throws ReflectionException
      */
-    public function testCanadaDayBefore1879(): void
+    public function testTruthAndReconciliationDayBefore2021(): void
     {
         $this->assertNotHoliday(
             self::REGION,
@@ -85,7 +80,7 @@ class CanadaDayTest extends CanadaBaseTestCase implements YasumiTestCaseInterfac
             self::REGION,
             self::HOLIDAY,
             $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            [self::LOCALE => 'Canada Day']
+            [self::LOCALE => 'National Day For Truth And Reconciliation']
         );
     }
 


### PR DESCRIPTION
This PR fixes the definition of Canada Day in the Canada provider and adds National Day For Truth And Reconciliation