### PR TITLE
Fronleichnam fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Corpus Christi (German: 'Fronleichnam') was classified as `Other` for states celebrating this day. This was incorrect
+  and has been changed to `Official`. [\#252](https://github.com/azuyalabs/yasumi/issues/252)
 - The test for the USA in that juneteenthDay was considered for all years: it is only celebrated since 2021.
 - Definition of Canada Day in Canada [\#257](https://github.com/azuyalabs/yasumi/pull/257) in that, Canada Day is July 1
   if that day is not Sunday, and July 2 if July 1 is a Sunday.([Owen V. Gray](https://github.com/adrx))

--- a/src/Yasumi/Provider/Germany/BadenWurttemberg.php
+++ b/src/Yasumi/Provider/Germany/BadenWurttemberg.php
@@ -22,8 +22,8 @@ use Yasumi\Provider\Germany;
 /**
  * Provider for all holidays in Baden-Württemberg (Germany).
  *
- * Baden-Württemberg is a state in Germany located in the southwest, east of the Upper Rhine. It is Germany’s third
- * largest state in terms of size and population, with an area of 36,410 square kilometres (14,060 sq mi) and 10.7
+ * Baden-Württemberg is a state in Germany located in the southwest, east of the Upper Rhine. It is Germany’s
+ * third-largest state in terms of size and population, with an area of 36,410 square kilometres (14,060 sq mi) and 10.7
  * million inhabitants. The state capital and largest city is Stuttgart.
  *
  * @see https://en.wikipedia.org/wiki/Baden-W%C3%BCrttemberg
@@ -50,7 +50,7 @@ class BadenWurttemberg extends Germany
 
         // Add custom Christian holidays
         $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
     }
 }

--- a/src/Yasumi/Provider/Germany/Bavaria.php
+++ b/src/Yasumi/Provider/Germany/Bavaria.php
@@ -24,8 +24,8 @@ use Yasumi\Provider\Germany;
  *
  * Bavaria is a federal state of Germany. In the southeast of the country with an area of 70,548 square kilometres
  * (27,200 sq mi), it is the largest state, making up almost a fifth of the total land area of Germany, and, with 12.6
- * million inhabitants, Germany's second most populous state. Munich, Bavaria's capital and largest city, is the third
- * largest city in Germany.
+ * million inhabitants, Germany's second most populous state. Munich, Bavaria's capital and largest city, is the
+ * third-largest city in Germany.
  *
  * @see https://en.wikipedia.org/wiki/Bavaria
  */
@@ -38,8 +38,6 @@ class Bavaria extends Germany
     public const ID = 'DE-BY';
 
     /**
-     * Initialize holidays for Bavaria (Germany).
-     *
      * @throws InvalidDateException
      * @throws \InvalidArgumentException
      * @throws UnknownLocaleException
@@ -51,7 +49,7 @@ class Bavaria extends Germany
 
         // Add custom Christian holidays
         $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
     }
 }

--- a/src/Yasumi/Provider/Germany/Hesse.php
+++ b/src/Yasumi/Provider/Germany/Hesse.php
@@ -16,6 +16,7 @@ namespace Yasumi\Provider\Germany;
 
 use Yasumi\Exception\InvalidDateException;
 use Yasumi\Exception\UnknownLocaleException;
+use Yasumi\Holiday;
 use Yasumi\Provider\Germany;
 
 /**
@@ -50,6 +51,6 @@ class Hesse extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
     }
 }

--- a/src/Yasumi/Provider/Germany/NorthRhineWestphalia.php
+++ b/src/Yasumi/Provider/Germany/NorthRhineWestphalia.php
@@ -23,7 +23,7 @@ use Yasumi\Provider\Germany;
  * Provider for all holidays in North Rhine-Westphalia (Germany).
  *
  * North Rhine-Westphalia (German: Nordrhein-Westfalen), commonly shortened NRW) is the most populous state of Germany,
- * with a population of approximately 18 million, and the fourth largest by area. Its capital is Düsseldorf; the biggest
+ * with a population of approximately 18 million, and the fourth-largest by area. Its capital is Düsseldorf; the biggest
  * city is Cologne. Four of Germany's ten biggest cities—Cologne, Düsseldorf, Dortmund, and Essen—are located within the
  * state, as well as the biggest metropolitan area of the European continent, Rhine-Ruhr.
  *
@@ -50,7 +50,7 @@ class NorthRhineWestphalia extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
     }
 }

--- a/src/Yasumi/Provider/Germany/RhinelandPalatinate.php
+++ b/src/Yasumi/Provider/Germany/RhinelandPalatinate.php
@@ -49,7 +49,7 @@ class RhinelandPalatinate extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
     }
 }

--- a/src/Yasumi/Provider/Germany/Saarland.php
+++ b/src/Yasumi/Provider/Germany/Saarland.php
@@ -50,7 +50,7 @@ class Saarland extends Germany
         parent::initialize();
 
         // Add custom Christian holidays
-        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
         $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
     }

--- a/tests/Germany/BadenWurttemberg/BadenWurttembergTest.php
+++ b/tests/Germany/BadenWurttemberg/BadenWurttembergTest.php
@@ -50,6 +50,7 @@ class BadenWurttembergTest extends BadenWurttembergBaseTestCase implements Provi
             'internationalWorkersDay',
             'ascensionDay',
             'pentecostMonday',
+            'corpusChristi',
             'germanUnityDay',
             'christmasDay',
             'secondChristmasDay',
@@ -94,7 +95,7 @@ class BadenWurttembergTest extends BadenWurttembergBaseTestCase implements Provi
     public function testOtherHolidays(): void
     {
         $this->assertDefinedHolidays(
-            ['epiphany', 'corpusChristi', 'allSaintsDay'],
+            ['epiphany', 'allSaintsDay'],
             self::REGION,
             $this->year,
             Holiday::TYPE_OTHER

--- a/tests/Germany/BadenWurttemberg/CorpusChristiTest.php
+++ b/tests/Germany/BadenWurttemberg/CorpusChristiTest.php
@@ -14,44 +14,41 @@ declare(strict_types=1);
 
 namespace Yasumi\tests\Germany\BadenWurttemberg;
 
-use DateInterval;
 use Exception;
 use ReflectionException;
 use Yasumi\Holiday;
-use Yasumi\Provider\ChristianHolidays;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Corpus Christi in Baden-Württemberg (Germany).
+ * Class for testing Corpus Christi ('Fronleichnam') in Baden-Württemberg (Germany).
  */
 class CorpusChristiTest extends BadenWurttembergBaseTestCase implements HolidayTestCase
 {
-    use ChristianHolidays;
-
     /**
-     * The name of the holiday.
+     * The name of the holiday to be tested.
      */
     public const HOLIDAY = 'corpusChristi';
 
     /**
-     * Tests Corpus Christi.
+     * Tests the holiday defined in this test.
      *
      * @throws Exception
      * @throws ReflectionException
      */
-    public function testCorpusChristi(): void
+    public function testHoliday(): void
     {
-        $year = 2016;
+        $year = $this->generateRandomYear();
+
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
-            $this->calculateEaster($year, self::TIMEZONE)->add(new DateInterval('P60D'))
+            $this->calculateEaster($year, self::TIMEZONE)->add(new \DateInterval('P60D'))
         );
     }
 
     /**
-     * Tests translated name of the holiday defined in this test.
+     * Tests the translated name of the holiday defined in this test.
      *
      * @throws ReflectionException
      */
@@ -72,6 +69,6 @@ class CorpusChristiTest extends BadenWurttembergBaseTestCase implements HolidayT
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/Bavaria/BavariaTest.php
+++ b/tests/Germany/Bavaria/BavariaTest.php
@@ -49,6 +49,7 @@ class BavariaTest extends BavariaBaseTestCase implements ProviderTestCase
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
+            'corpusChristi',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',
@@ -94,7 +95,7 @@ class BavariaTest extends BavariaBaseTestCase implements ProviderTestCase
     public function testOtherHolidays(): void
     {
         $this->assertDefinedHolidays(
-            ['epiphany', 'corpusChristi', 'allSaintsDay'],
+            ['epiphany', 'allSaintsDay'],
             self::REGION,
             $this->year,
             Holiday::TYPE_OTHER

--- a/tests/Germany/Bavaria/CorpusChristiTest.php
+++ b/tests/Germany/Bavaria/CorpusChristiTest.php
@@ -14,44 +14,41 @@ declare(strict_types=1);
 
 namespace Yasumi\tests\Germany\Bavaria;
 
-use DateInterval;
 use Exception;
 use ReflectionException;
 use Yasumi\Holiday;
-use Yasumi\Provider\ChristianHolidays;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Corpus Christi in Bavaria (Germany).
+ * Class for testing Corpus Christi  ('Fronleichnam') in Bavaria (Germany).
  */
 class CorpusChristiTest extends BavariaBaseTestCase implements HolidayTestCase
 {
-    use ChristianHolidays;
-
     /**
-     * The name of the holiday.
+     * The name of the holiday to be tested.
      */
     public const HOLIDAY = 'corpusChristi';
 
     /**
-     * Tests Corpus Christi.
+     * Tests the holiday defined in this test.
      *
      * @throws Exception
      * @throws ReflectionException
      */
-    public function testCorpusChristi(): void
+    public function testHoliday(): void
     {
-        $year = 2016;
+        $year = $this->generateRandomYear();
+
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
-            $this->calculateEaster($year, self::TIMEZONE)->add(new DateInterval('P60D'))
+            $this->calculateEaster($year, self::TIMEZONE)->add(new \DateInterval('P60D'))
         );
     }
 
     /**
-     * Tests translated name of the holiday defined in this test.
+     * Tests the translated name of the holiday defined in this test.
      *
      * @throws ReflectionException
      */
@@ -72,6 +69,6 @@ class CorpusChristiTest extends BavariaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/Hesse/CorpusChristiTest.php
+++ b/tests/Germany/Hesse/CorpusChristiTest.php
@@ -14,44 +14,41 @@ declare(strict_types=1);
 
 namespace Yasumi\tests\Germany\Hesse;
 
-use DateInterval;
 use Exception;
 use ReflectionException;
 use Yasumi\Holiday;
-use Yasumi\Provider\ChristianHolidays;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Corpus Christi in Hesse (Germany).
+ * Class for testing Corpus Christi ('Fronleichnam') in Hesse (Germany).
  */
 class CorpusChristiTest extends HesseBaseTestCase implements HolidayTestCase
 {
-    use ChristianHolidays;
-
     /**
-     * The name of the holiday.
+     * The name of the holiday to be tested.
      */
     public const HOLIDAY = 'corpusChristi';
 
     /**
-     * Tests Corpus Christi.
+     * Tests the holiday defined in this test.
      *
      * @throws Exception
      * @throws ReflectionException
      */
-    public function testCorpusChristi(): void
+    public function testHoliday(): void
     {
-        $year = 2016;
+        $year = $this->generateRandomYear();
+
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
-            $this->calculateEaster($year, self::TIMEZONE)->add(new DateInterval('P60D'))
+            $this->calculateEaster($year, self::TIMEZONE)->add(new \DateInterval('P60D'))
         );
     }
 
     /**
-     * Tests translated name of the holiday defined in this test.
+     * Tests the translated name of the holiday defined in this test.
      *
      * @throws ReflectionException
      */
@@ -72,6 +69,6 @@ class CorpusChristiTest extends HesseBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/Hesse/HesseTest.php
+++ b/tests/Germany/Hesse/HesseTest.php
@@ -49,6 +49,7 @@ class HesseTest extends HesseBaseTestCase implements ProviderTestCase
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
+            'corpusChristi',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',
@@ -93,7 +94,7 @@ class HesseTest extends HesseBaseTestCase implements ProviderTestCase
      */
     public function testOtherHolidays(): void
     {
-        $this->assertDefinedHolidays(['corpusChristi'], self::REGION, $this->year, Holiday::TYPE_OTHER);
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
     }
 
     /**

--- a/tests/Germany/NorthRhineWestphalia/CorpusChristiTest.php
+++ b/tests/Germany/NorthRhineWestphalia/CorpusChristiTest.php
@@ -14,44 +14,41 @@ declare(strict_types=1);
 
 namespace Yasumi\tests\Germany\NorthRhineWestphalia;
 
-use DateInterval;
 use Exception;
 use ReflectionException;
 use Yasumi\Holiday;
-use Yasumi\Provider\ChristianHolidays;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Corpus Christi in North Rhine-Westphalia (Germany).
+ * Class for testing Corpus Christi ('Fronleichnam') in North Rhine-Westphalia (Germany).
  */
 class CorpusChristiTest extends NorthRhineWestphaliaBaseTestCase implements HolidayTestCase
 {
-    use ChristianHolidays;
-
     /**
-     * The name of the holiday.
+     * The name of the holiday to be tested.
      */
     public const HOLIDAY = 'corpusChristi';
 
     /**
-     * Tests Corpus Christi.
+     * Tests the holiday defined in this test.
      *
      * @throws Exception
      * @throws ReflectionException
      */
-    public function testCorpusChristi(): void
+    public function testHoliday(): void
     {
-        $year = 2016;
+        $year = $this->generateRandomYear();
+
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
-            $this->calculateEaster($year, self::TIMEZONE)->add(new DateInterval('P60D'))
+            $this->calculateEaster($year, self::TIMEZONE)->add(new \DateInterval('P60D'))
         );
     }
 
     /**
-     * Tests translated name of the holiday defined in this test.
+     * Tests the translated name of the holiday defined in this test.
      *
      * @throws ReflectionException
      */
@@ -72,6 +69,6 @@ class CorpusChristiTest extends NorthRhineWestphaliaBaseTestCase implements Holi
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/NorthRhineWestphalia/NorthRhineWestphaliaTest.php
+++ b/tests/Germany/NorthRhineWestphalia/NorthRhineWestphaliaTest.php
@@ -49,6 +49,7 @@ class NorthRhineWestphaliaTest extends NorthRhineWestphaliaBaseTestCase implemen
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
+            'corpusChristi',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',
@@ -93,7 +94,7 @@ class NorthRhineWestphaliaTest extends NorthRhineWestphaliaBaseTestCase implemen
      */
     public function testOtherHolidays(): void
     {
-        $this->assertDefinedHolidays(['corpusChristi', 'allSaintsDay'], self::REGION, $this->year, Holiday::TYPE_OTHER);
+        $this->assertDefinedHolidays(['allSaintsDay'], self::REGION, $this->year, Holiday::TYPE_OTHER);
     }
 
     /**

--- a/tests/Germany/RhinelandPalatinate/CorpusChristiTest.php
+++ b/tests/Germany/RhinelandPalatinate/CorpusChristiTest.php
@@ -14,44 +14,41 @@ declare(strict_types=1);
 
 namespace Yasumi\tests\Germany\RhinelandPalatinate;
 
-use DateInterval;
 use Exception;
 use ReflectionException;
 use Yasumi\Holiday;
-use Yasumi\Provider\ChristianHolidays;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Corpus Christi in Rhineland Palatinate (Germany).
+ * Class for testing Corpus Christi ('Fronleichnam') in Rhineland Palatinate (Germany).
  */
 class CorpusChristiTest extends RhinelandPalatinateBaseTestCase implements HolidayTestCase
 {
-    use ChristianHolidays;
-
     /**
-     * The name of the holiday.
+     * The name of the holiday to be tested.
      */
     public const HOLIDAY = 'corpusChristi';
 
     /**
-     * Tests Corpus Christi.
+     * Tests the holiday defined in this test.
      *
      * @throws Exception
      * @throws ReflectionException
      */
-    public function testCorpusChristi(): void
+    public function testHoliday(): void
     {
-        $year = 2016;
+        $year = $this->generateRandomYear();
+
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
-            $this->calculateEaster($year, self::TIMEZONE)->add(new DateInterval('P60D'))
+            $this->calculateEaster($year, self::TIMEZONE)->add(new \DateInterval('P60D'))
         );
     }
 
     /**
-     * Tests translated name of the holiday defined in this test.
+     * Tests the translated name of the holiday defined in this test.
      *
      * @throws ReflectionException
      */
@@ -72,6 +69,6 @@ class CorpusChristiTest extends RhinelandPalatinateBaseTestCase implements Holid
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/RhinelandPalatinate/RhinelandPalatinateTest.php
+++ b/tests/Germany/RhinelandPalatinate/RhinelandPalatinateTest.php
@@ -49,6 +49,7 @@ class RhinelandPalatinateTest extends RhinelandPalatinateBaseTestCase implements
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
+            'corpusChristi',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',
@@ -93,7 +94,7 @@ class RhinelandPalatinateTest extends RhinelandPalatinateBaseTestCase implements
      */
     public function testOtherHolidays(): void
     {
-        $this->assertDefinedHolidays(['corpusChristi', 'allSaintsDay'], self::REGION, $this->year, Holiday::TYPE_OTHER);
+        $this->assertDefinedHolidays(['allSaintsDay'], self::REGION, $this->year, Holiday::TYPE_OTHER);
     }
 
     /**

--- a/tests/Germany/Saarland/CorpusChristiTest.php
+++ b/tests/Germany/Saarland/CorpusChristiTest.php
@@ -14,44 +14,41 @@ declare(strict_types=1);
 
 namespace Yasumi\tests\Germany\Saarland;
 
-use DateInterval;
 use Exception;
 use ReflectionException;
 use Yasumi\Holiday;
-use Yasumi\Provider\ChristianHolidays;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Corpus Christi in Saarland (Germany).
+ * Class for testing Corpus Christi ('Fronleichnam') in Saarland (Germany).
  */
 class CorpusChristiTest extends SaarlandBaseTestCase implements HolidayTestCase
 {
-    use ChristianHolidays;
-
     /**
-     * The name of the holiday.
+     * The name of the holiday to be tested.
      */
     public const HOLIDAY = 'corpusChristi';
 
     /**
-     * Tests Corpus Christi.
+     * Tests the holiday defined in this test.
      *
      * @throws Exception
      * @throws ReflectionException
      */
-    public function testCorpusChristi(): void
+    public function testHoliday(): void
     {
-        $year = 2016;
+        $year = $this->generateRandomYear();
+
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
             $year,
-            $this->calculateEaster($year, self::TIMEZONE)->add(new DateInterval('P60D'))
+            $this->calculateEaster($year, self::TIMEZONE)->add(new \DateInterval('P60D'))
         );
     }
 
     /**
-     * Tests translated name of the holiday defined in this test.
+     * Tests the translated name of the holiday defined in this test.
      *
      * @throws ReflectionException
      */
@@ -72,6 +69,6 @@ class CorpusChristiTest extends SaarlandBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Germany/Saarland/SaarlandTest.php
+++ b/tests/Germany/Saarland/SaarlandTest.php
@@ -49,6 +49,7 @@ class SaarlandTest extends SaarlandBaseTestCase implements ProviderTestCase
             'easterMonday',
             'internationalWorkersDay',
             'ascensionDay',
+            'corpusChristi',
             'pentecostMonday',
             'germanUnityDay',
             'christmasDay',
@@ -94,7 +95,6 @@ class SaarlandTest extends SaarlandBaseTestCase implements ProviderTestCase
     public function testOtherHolidays(): void
     {
         $this->assertDefinedHolidays([
-            'corpusChristi',
             'assumptionOfMary',
             'allSaintsDay',
         ], self::REGION, $this->year, Holiday::TYPE_OTHER);


### PR DESCRIPTION
Corpus Christi (German: 'Fronleichnam') was classified as `Other` for states celebrating this day. This was incorrect
  and has been changed to `Official`.

Closes #252 