### PR TITLE
fix: Spain christmas sunday (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- Christmas day for Spain: if it's on a sunday, the holiday will be on monday [\#267](https://github.com/azuyalabs/yasumi/issues/267)
 - World Children's Day for Thuringia (Germany) [\#260](https://github.com/azuyalabs/yasumi/issues/260)
 - New National Day for Truth and Reconciliation to
   Canada [\#257](https://github.com/azuyalabs/yasumi/pull/257) ([Owen V. Gray](https://github.com/adrx))

--- a/src/Yasumi/Provider/Spain.php
+++ b/src/Yasumi/Provider/Spain.php
@@ -72,6 +72,31 @@ class Spain extends AbstractProvider
     }
 
     /**
+     * In Spain, when Christmas is on a sunday, the holiday will be on Monday.
+     *
+     * @inherits
+     */
+    private function christmasDay(
+        int $year,
+        string $timezone,
+        string $locale,
+        string $type = Holiday::TYPE_OFFICIAL
+    ): Holiday {
+        $christmasDay = new DateTime("$year-12-25", DateTimeZoneFactory::getDateTimeZone($timezone));
+        if (7 === (int) $christmasDay->format('N')) {
+            $christmasDay->add(new \DateInterval('P1D'));
+        }
+
+        return new Holiday(
+            'christmasDay',
+            [],
+            $christmasDay,
+            $locale,
+            $type
+        );
+    }
+
+    /**
      * National Day.
      *
      * The Fiesta Nacional de España is the national day of Spain. It is held annually on October 12 and is a national

--- a/tests/Spain/ChristmasTest.php
+++ b/tests/Spain/ChristmasTest.php
@@ -42,7 +42,27 @@ class ChristmasTest extends SpainBaseTestCase implements HolidayTestCase
      */
     public function testHoliday(int $year, DateTime $expected): void
     {
+        if (7 === (int) $expected->format('N')) {
+            $expected->add(new \DateInterval('P1D'));
+        }
+
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Specific 2022 Christmas day test, it's on a sunday,
+     * we expect to have the monday returned as holiday.
+     *
+     * @throws ReflectionException
+     */
+    public function test2022SundayChristmas(): void
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2022,
+            new \DateTime('2022-12-26', new \DateTimeZone(self::TIMEZONE))
+        );
     }
 
     /**


### PR DESCRIPTION
Fixing the christmas day for Spain, when it's on a sunday, the holiday will be on monday (as it will be the case in 2022)