### PR TITLE
fix: United Kingdom spring bank holiday 2022 (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- United Kingdom spring bank holiday 2022 is moved to the 2nd june, due to the platinum jubilee [\#270](https://github.com/azuyalabs/yasumi/issues/270)
 - World Children's Day for Thuringia (Germany) [\#260](https://github.com/azuyalabs/yasumi/issues/260)
 - New National Day for Truth and Reconciliation to
   Canada [\#257](https://github.com/azuyalabs/yasumi/pull/257) ([Owen V. Gray](https://github.com/adrx))

--- a/src/Yasumi/Provider/UnitedKingdom.php
+++ b/src/Yasumi/Provider/UnitedKingdom.php
@@ -150,6 +150,19 @@ class UnitedKingdom extends AbstractProvider
             return;
         }
 
+        // Moved to the 2nd June due to the celebration of the Platinum (2022) Jubilee
+        if (2022 === $this->year) {
+            $this->addHoliday(new Holiday(
+                'springBankHoliday',
+                ['en' => 'Spring Bank Holiday'],
+                new DateTime("$this->year-6-2", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_BANK
+            ));
+
+            return;
+        }
+
         $this->addHoliday(new Holiday(
             'springBankHoliday',
             ['en' => 'Spring Bank Holiday'],

--- a/tests/UnitedKingdom/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/SpringBankHolidayTest.php
@@ -54,7 +54,7 @@ class SpringBankHolidayTest extends UnitedKingdomBaseTestCase implements Holiday
     }
 
     /**
-     * Tests the holiday exceptions in 2002 and 2012.
+     * Tests the holiday exceptions in 2002, 2012 and 2022.
      *
      * @throws ReflectionException
      * @throws Exception
@@ -73,6 +73,13 @@ class SpringBankHolidayTest extends UnitedKingdomBaseTestCase implements Holiday
             self::HOLIDAY,
             2012,
             new DateTime('2012-6-4', new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2022,
+            new DateTime('2022-6-2', new DateTimeZone(self::TIMEZONE))
         );
     }
 


### PR DESCRIPTION
United Kingdom spring bank holiday 2022 is moved to the 2nd june, due to the platinum jubilee