### PR TITLE
Spring Bank Holiday 2022 (UK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- Moved Spring Bank Holiday to 2nd June and added Platinum Jubilee bank holiday on 3rd June for 2022 (UK) [\#270](https://github.com/azuyalabs/yasumi/issues/270)
+
 ### Fixed
 
 ### Deprecated

--- a/src/Yasumi/Provider/UnitedKingdom.php
+++ b/src/Yasumi/Provider/UnitedKingdom.php
@@ -58,6 +58,9 @@ class UnitedKingdom extends AbstractProvider
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale, Holiday::TYPE_BANK));
         $this->calculateChristmasHolidays();
+
+        // Add additional holidays
+        $this->calculatePlatinumJubileeBankHoliday();
     }
 
     public function getSources(): array
@@ -150,10 +153,50 @@ class UnitedKingdom extends AbstractProvider
             return;
         }
 
+        // Moved to 2 June in 2022 for the celebration of the Platinum Jubilee of Elizabeth II.
+        if (2022 === $this->year) {
+            $this->addHoliday(new Holiday(
+                'springBankHoliday',
+                ['en' => 'Spring Bank Holiday'],
+                new DateTime("$this->year-6-2", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_BANK
+            ));
+
+            return;
+        }
+
         $this->addHoliday(new Holiday(
             'springBankHoliday',
             ['en' => 'Spring Bank Holiday'],
             new DateTime("last monday of may $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $this->locale,
+            Holiday::TYPE_BANK
+        ));
+    }
+
+    /**
+     * The Platinum Jubilee bank holiday is an extra bank holiday added on 3 June 2022
+     * for the celebration of the Platinum Jubilee of Elizabeth II.
+     *
+     * @see https://www.timeanddate.com/holidays/uk/queen-platinum-jubilee
+     * @see https://en.wikipedia.org/wiki/Public_holidays_in_the_United_Kingdom#Special_holidays
+     *
+     * @throws InvalidDateException
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    protected function calculatePlatinumJubileeBankHoliday(): void
+    {
+        if (2022 !== $this->year) {
+            return;
+        }
+
+        $this->addHoliday(new Holiday(
+            'platinumJubileeBankHoliday',
+            ['en' => 'Platinum Jubilee Bank Holiday'],
+            new DateTime("$this->year-6-3", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         ));

--- a/tests/UnitedKingdom/PlatinumJubileeBankHolidayTest.php
+++ b/tests/UnitedKingdom/PlatinumJubileeBankHolidayTest.php
@@ -22,19 +22,24 @@ use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing the Spring Bank Holiday in the United Kingdom.
+ * Class for testing the Platinum Jubilee Bank Holiday in the United Kingdom.
  */
-class SpringBankHolidayTest extends UnitedKingdomBaseTestCase implements HolidayTestCase
+class PlatinumJubileeBankHolidayTest extends UnitedKingdomBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'springBankHoliday';
+    public const HOLIDAY = 'platinumJubileeBankHoliday';
 
     /**
-     * The year in which the holiday was first established.
+     * The year in which the holiday occurred.
      */
-    public const ESTABLISHMENT_YEAR = 1965;
+    public const ACTIVE_YEAR = 2022;
+
+    /**
+     * The date on which the holiday occurred.
+     */
+    public const ACTIVE_DATE = '2022-6-3';
 
     /**
      * Tests the holiday defined in this test.
@@ -44,56 +49,39 @@ class SpringBankHolidayTest extends UnitedKingdomBaseTestCase implements Holiday
      */
     public function testHoliday(): void
     {
-        $year = 1988;
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,
-            $year,
-            new DateTime("$year-5-30", new DateTimeZone(self::TIMEZONE))
+            self::ACTIVE_YEAR,
+            new DateTime(self::ACTIVE_DATE, new DateTimeZone(self::TIMEZONE))
         );
     }
 
     /**
-     * Tests the holiday exceptions in 2002, 2012 and 2022.
-     *
-     * @throws ReflectionException
-     * @throws Exception
-     */
-    public function testHolidayException(): void
-    {
-        $this->assertHoliday(
-            self::REGION,
-            self::HOLIDAY,
-            2002,
-            new DateTime('2002-6-4', new DateTimeZone(self::TIMEZONE))
-        );
-
-        $this->assertHoliday(
-            self::REGION,
-            self::HOLIDAY,
-            2012,
-            new DateTime('2012-6-4', new DateTimeZone(self::TIMEZONE))
-        );
-
-        $this->assertHoliday(
-            self::REGION,
-            self::HOLIDAY,
-            2022,
-            new DateTime('2022-6-2', new DateTimeZone(self::TIMEZONE))
-        );
-    }
-
-    /**
-     * Tests the holiday defined in this test before establishment.
+     * Tests the holiday defined in this test before the year in which it occurred.
      *
      * @throws ReflectionException
      */
-    public function testHolidayBeforeEstablishment(): void
+    public function testHolidayBeforeActive(): void
     {
         $this->assertNotHoliday(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+            $this->generateRandomYear(1000, self::ACTIVE_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test after the year in which it occurred.
+     *
+     * @throws ReflectionException
+     */
+    public function testHolidayAfterActive(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ACTIVE_YEAR + 1)
         );
     }
 
@@ -107,8 +95,8 @@ class SpringBankHolidayTest extends UnitedKingdomBaseTestCase implements Holiday
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
-            [self::LOCALE => 'Spring Bank Holiday']
+            self::ACTIVE_YEAR,
+            [self::LOCALE => 'Platinum Jubilee Bank Holiday']
         );
     }
 
@@ -122,7 +110,7 @@ class SpringBankHolidayTest extends UnitedKingdomBaseTestCase implements Holiday
         $this->assertHolidayType(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            self::ACTIVE_YEAR,
             Holiday::TYPE_BANK
         );
     }


### PR DESCRIPTION
UK Spring Bank Holiday is moved to 2nd June in 2022 for the Platinum Jubilee. An additional bank holiday is added the day after. #270 