### PR TITLE
Fix BC break add missing method `ProviderInterface::getHolidays`

### DIFF
--- a/src/Yasumi/ProviderInterface.php
+++ b/src/Yasumi/ProviderInterface.php
@@ -70,4 +70,11 @@ interface ProviderInterface
      * @throws \InvalidArgumentException when the given name is blank or empty
      */
     public function getHoliday(string $key): ?Holiday;
+
+    /**
+     * Gets all the holidays defined by this holiday provider (for the given year).
+     *
+     * @return Holiday[] list of all holidays defined for the given year
+     */
+    public function getHolidays(): array;
 }


### PR DESCRIPTION
In the previous version `Yasumi\Yasumi::create` was returning `Yasumi\Provider\AbstractProvider` now its return `Yasumi\ProviderInterface` without method `getHolidays` . Even tests expects that `ProviderInterface::getHolidays` exists for example `Yasumi\tests\Base\YasumiTest::testRemoveHoliday`