### PR TITLE
Belgium: easter & pentecost are not public holidays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org).
 ### Changed
 
 - Included the unit tests directory for checking by PHPStan.
+- Belgium only observes Easter & Pentecost, they're not public holidays. [\#279](https://github.com/azuyalabs/yasumi/pull/279)
 
 ### Fixed
 

--- a/src/Yasumi/Provider/Belgium.php
+++ b/src/Yasumi/Provider/Belgium.php
@@ -50,10 +50,10 @@ class Belgium extends AbstractProvider
         $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
 
         // Add Christian holidays
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->ascensionDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
         $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));

--- a/tests/Belgium/EasterTest.php
+++ b/tests/Belgium/EasterTest.php
@@ -68,6 +68,6 @@ class EasterTest extends BelgiumBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
     }
 }

--- a/tests/Belgium/PentecostTest.php
+++ b/tests/Belgium/PentecostTest.php
@@ -68,6 +68,6 @@ class PentecostTest extends BelgiumBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
     }
 }


### PR DESCRIPTION
marked them as observance.
They're not on the wiki page that's used as source