### PR TITLE
Add National Day of Mourning for Australia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org).
 - Added all examples as shown on the documentation site as a convenience to developers who like to have all
   information in a single place.
 - Added bank holiday for Queen Elizabeth II’s State Funeral on 19 September 2022 to United Kingdom
+- Added Public Holiday National Day of Mourning (for Queen Elizabeth II) on 22 September 2022 to Australia
 
 ### Changed
 

--- a/src/Yasumi/Provider/Australia.php
+++ b/src/Yasumi/Provider/Australia.php
@@ -206,7 +206,7 @@ class Australia extends AbstractProvider
     }
 
     /**
-     * National Day of Mourning
+     * National Day of Mourning.
      *
      * An additional, once off, national public holiday was proclaimed on the 10th of September 2022, to be observed on the 22nd of September 2022, as a
      *  National day of mourning for the passing of Queen Elizabeth II
@@ -225,12 +225,12 @@ class Australia extends AbstractProvider
         }
 
         $this->addHoliday(new Holiday(
-                              'nationalDayOfMourning',
-                              ['en' => 'National Day of Mourning'],
-                              new DateTime("$this->year-9-22", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-                              $this->locale,
-                              Holiday::TYPE_OFFICIAL
-                          ));
+            'nationalDayOfMourning',
+            ['en' => 'National Day of Mourning'],
+            new DateTime("$this->year-9-22", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $this->locale,
+            Holiday::TYPE_OFFICIAL
+        ));
     }
 
     /**

--- a/src/Yasumi/Provider/Australia.php
+++ b/src/Yasumi/Provider/Australia.php
@@ -49,6 +49,7 @@ class Australia extends AbstractProvider
         $this->calculateNewYearHolidays();
         $this->calculateAustraliaDay();
         $this->calculateAnzacDay();
+        $this->calculateNationalDayOfMourning();
 
         // Add Christian holidays
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
@@ -202,6 +203,34 @@ class Australia extends AbstractProvider
                 Holiday::TYPE_OFFICIAL
             ));
         }
+    }
+
+    /**
+     * National Day of Mourning
+     *
+     * An additional, once off, national public holiday was proclaimed on the 10th of September 2022, to be observed on the 22nd of September 2022, as a
+     *  National day of mourning for the passing of Queen Elizabeth II
+     *
+     * @see https://www.pm.gov.au/media/commemorating-her-majesty-queen-elizabeth-ii
+     * @see https://www.timeanddate.com/holidays/australia/national-day-of-mourning
+     *
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    private function calculateNationalDayOfMourning(): void
+    {
+        if (2022 !== $this->year) {
+            return;
+        }
+
+        $this->addHoliday(new Holiday(
+                              'nationalDayOfMourning',
+                              ['en' => 'National Day of Mourning'],
+                              new DateTime("$this->year-9-22", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                              $this->locale,
+                              Holiday::TYPE_OFFICIAL
+                          ));
     }
 
     /**

--- a/tests/Australia/AustraliaTest.php
+++ b/tests/Australia/AustraliaTest.php
@@ -53,8 +53,7 @@ class AustraliaTest extends AustraliaBaseTestCase implements ProviderTestCase
             'anzacDay',
         ];
 
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
 

--- a/tests/Australia/AustraliaTest.php
+++ b/tests/Australia/AustraliaTest.php
@@ -43,7 +43,7 @@ class AustraliaTest extends AustraliaBaseTestCase implements ProviderTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -51,7 +51,14 @@ class AustraliaTest extends AustraliaBaseTestCase implements ProviderTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryTest.php
@@ -59,8 +59,7 @@ class AustralianCapitalTerritoryTest extends AustralianCapitalTerritoryBaseTestC
             'reconciliationDay',
         ];
 
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
 

--- a/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryTest.php
@@ -43,7 +43,7 @@ class AustralianCapitalTerritoryTest extends AustralianCapitalTerritoryBaseTestC
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -57,7 +57,14 @@ class AustralianCapitalTerritoryTest extends AustralianCapitalTerritoryBaseTestC
             'labourDay',
             'canberraDay',
             'reconciliationDay',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/AustralianCapitalTerritory/NationalDayOfMourningTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\AustralianCapitalTerritory;
+
+/**
+ * Class for testing National Day of Mourning in Australian Capital Territory (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/NationalDayOfMourningTest.php
+++ b/tests/Australia/NationalDayOfMourningTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia;
+
+use DateTime;
+use DateTimeZone;
+use Exception;
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing National Day of Mourning in Australia.
+ */
+class NationalDayOfMourningTest extends AustraliaBaseTestCase implements HolidayTestCase
+{
+    /**
+     * The name of the holiday.
+     */
+    public const HOLIDAY = 'nationalDayOfMourning';
+
+    /**
+     * The year in which the holiday was first established.
+     */
+    public const ACTIVE_YEAR = 2022;
+
+    /**
+     * The date on which the holiday occurred.
+     */
+    public const ACTIVE_DATE = '2022-9-22';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @throws Exception
+     */
+    public function testHoliday(): void
+    {
+        $this->assertHoliday(
+            $this->region,
+            self::HOLIDAY,
+            self::ACTIVE_YEAR,
+            new DateTime(self::ACTIVE_DATE, new DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before the year in which it occurred.
+     *
+     * @throws Exception
+     */
+    public function testHolidayBeforeActive(): void
+    {
+        $this->assertNotHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ACTIVE_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test after the year in which it occurred.
+     *
+     * @throws Exception
+     */
+    public function testHolidayAfterActive(): void
+    {
+        $this->assertNotHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ACTIVE_YEAR + 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            self::ACTIVE_YEAR,
+            [self::LOCALE => 'National Day of Mourning']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            $this->region,
+            self::HOLIDAY,
+            self::ACTIVE_YEAR,
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Australia/NewSouthWales/NationalDayOfMourningTest.php
+++ b/tests/Australia/NewSouthWales/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\NewSouthWales;
+
+/**
+ * Class for testing National Day of Mourning in New South Wales (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/NewSouthWales/NewSouthWalesTest.php
+++ b/tests/Australia/NewSouthWales/NewSouthWalesTest.php
@@ -57,8 +57,7 @@ class NewSouthWalesTest extends NewSouthWalesBaseTestCase implements ProviderTes
             'labourDay',
         ];
 
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $holidays[] = 'nationalDayOfMourning';
         }
 

--- a/tests/Australia/NewSouthWales/NewSouthWalesTest.php
+++ b/tests/Australia/NewSouthWales/NewSouthWalesTest.php
@@ -43,7 +43,7 @@ class NewSouthWalesTest extends NewSouthWalesBaseTestCase implements ProviderTes
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $holidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -55,7 +55,14 @@ class NewSouthWalesTest extends NewSouthWalesBaseTestCase implements ProviderTes
             'easterSaturday',
             'queensBirthday',
             'labourDay',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+
+        if(2022 == $this->year)
+        {
+            $holidays[] = 'nationalDayOfMourning';
+        }
+
+        $this->assertDefinedHolidays($holidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/NorthernTerritory/NationalDayOfMourningTest.php
+++ b/tests/Australia/NorthernTerritory/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\NorthernTerritory;
+
+/**
+ * Class for testing National Day of Mourning in Northern Territory (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/NorthernTerritory/NorthernTerritoryTest.php
+++ b/tests/Australia/NorthernTerritory/NorthernTerritoryTest.php
@@ -57,8 +57,7 @@ class NorthernTerritoryTest extends NorthernTerritoryBaseTestCase implements Pro
             'picnicDay',
         ];
 
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
 

--- a/tests/Australia/NorthernTerritory/NorthernTerritoryTest.php
+++ b/tests/Australia/NorthernTerritory/NorthernTerritoryTest.php
@@ -43,7 +43,7 @@ class NorthernTerritoryTest extends NorthernTerritoryBaseTestCase implements Pro
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -55,7 +55,14 @@ class NorthernTerritoryTest extends NorthernTerritoryBaseTestCase implements Pro
             'queensBirthday',
             'mayDay',
             'picnicDay',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Queensland/Brisbane/BrisbaneTest.php
+++ b/tests/Australia/Queensland/Brisbane/BrisbaneTest.php
@@ -55,8 +55,7 @@ class BrisbaneTest extends BrisbaneBaseTestCase implements ProviderTestCase
             'labourDay',
             'peoplesDay',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/Queensland/Brisbane/BrisbaneTest.php
+++ b/tests/Australia/Queensland/Brisbane/BrisbaneTest.php
@@ -43,7 +43,7 @@ class BrisbaneTest extends BrisbaneBaseTestCase implements ProviderTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -54,7 +54,12 @@ class BrisbaneTest extends BrisbaneBaseTestCase implements ProviderTestCase
             'queensBirthday',
             'labourDay',
             'peoplesDay',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Queensland/Brisbane/NationalDayOfMourningTest.php
+++ b/tests/Australia/Queensland/Brisbane/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland\Brisbane;
+
+/**
+ * Class for testing National Day of Mourning in Brisbane (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\Queensland\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Queensland/NationalDayOfMourningTest.php
+++ b/tests/Australia/Queensland/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Queensland;
+
+/**
+ * Class for testing National Day of Mourning in Queensland (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Queensland/QueenslandTest.php
+++ b/tests/Australia/Queensland/QueenslandTest.php
@@ -43,7 +43,7 @@ class QueenslandTest extends QueenslandBaseTestCase implements ProviderTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -53,7 +53,12 @@ class QueenslandTest extends QueenslandBaseTestCase implements ProviderTestCase
             'anzacDay',
             'queensBirthday',
             'labourDay',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Queensland/QueenslandTest.php
+++ b/tests/Australia/Queensland/QueenslandTest.php
@@ -54,8 +54,7 @@ class QueenslandTest extends QueenslandBaseTestCase implements ProviderTestCase
             'queensBirthday',
             'labourDay',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/SouthAustralia/NationalDayOfMourningTest.php
+++ b/tests/Australia/SouthAustralia/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\SouthAustralia;
+
+/**
+ * Class for testing National Day of Mourning in South Australia (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/SouthAustralia/SouthAustraliaTest.php
+++ b/tests/Australia/SouthAustralia/SouthAustraliaTest.php
@@ -56,8 +56,7 @@ class SouthAustraliaTest extends SouthAustraliaBaseTestCase implements ProviderT
             'labourDay',
             'adelaideCup',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/SouthAustralia/SouthAustraliaTest.php
+++ b/tests/Australia/SouthAustralia/SouthAustraliaTest.php
@@ -43,7 +43,7 @@ class SouthAustraliaTest extends SouthAustraliaBaseTestCase implements ProviderT
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -55,7 +55,12 @@ class SouthAustraliaTest extends SouthAustraliaBaseTestCase implements ProviderT
             'queensBirthday',
             'labourDay',
             'adelaideCup',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Tasmania/CentralNorth/CentralNorthTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/CentralNorthTest.php
@@ -43,7 +43,7 @@ class CentralNorthTest extends CentralNorthBaseTestCase implements ProviderTestC
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -55,7 +55,12 @@ class CentralNorthTest extends CentralNorthBaseTestCase implements ProviderTestC
             'eightHourDay',
             'recreationDay',
             'devonportShow',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Tasmania/CentralNorth/CentralNorthTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/CentralNorthTest.php
@@ -56,8 +56,7 @@ class CentralNorthTest extends CentralNorthBaseTestCase implements ProviderTestC
             'recreationDay',
             'devonportShow',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/Tasmania/CentralNorth/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
+
+/**
+ * Class for testing National Day of Mourning in central north Tasmania (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\Tasmania\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Tasmania/FlindersIsland/FlindersIslandTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/FlindersIslandTest.php
@@ -43,7 +43,7 @@ class FlindersIslandTest extends FlindersIslandBaseTestCase implements ProviderT
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -55,7 +55,12 @@ class FlindersIslandTest extends FlindersIslandBaseTestCase implements ProviderT
             'eightHourDay',
             'recreationDay',
             'flindersIslandShow',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Tasmania/FlindersIsland/FlindersIslandTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/FlindersIslandTest.php
@@ -56,8 +56,7 @@ class FlindersIslandTest extends FlindersIslandBaseTestCase implements ProviderT
             'recreationDay',
             'flindersIslandShow',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/Tasmania/FlindersIsland/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
+
+/**
+ * Class for testing National Day of Mourning in Flinders Island (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\Tasmania\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Tasmania/KingIsland/KingIslandTest.php
+++ b/tests/Australia/Tasmania/KingIsland/KingIslandTest.php
@@ -43,7 +43,7 @@ class KingIslandTest extends KingIslandBaseTestCase implements ProviderTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -55,7 +55,12 @@ class KingIslandTest extends KingIslandBaseTestCase implements ProviderTestCase
             'eightHourDay',
             'recreationDay',
             'kingIslandShow',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Tasmania/KingIsland/KingIslandTest.php
+++ b/tests/Australia/Tasmania/KingIsland/KingIslandTest.php
@@ -56,8 +56,7 @@ class KingIslandTest extends KingIslandBaseTestCase implements ProviderTestCase
             'recreationDay',
             'kingIslandShow',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/Tasmania/KingIsland/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/KingIsland/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\KingIsland;
+
+/**
+ * Class for testing National Day of Mourning in King Island (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\Tasmania\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Tasmania/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania;
+
+/**
+ * Class for testing National Day of Mourning in Tasmania (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/Northeast/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northeast;
+
+/**
+ * Class for testing National Day of Mourning in northeastern Tasmania (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\Tasmania\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Tasmania/Northeast/NortheastTest.php
+++ b/tests/Australia/Tasmania/Northeast/NortheastTest.php
@@ -56,8 +56,7 @@ class NortheastTest extends NortheastBaseTestCase implements ProviderTestCase
             'recreationDay',
             'launcestonShow',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/Tasmania/Northeast/NortheastTest.php
+++ b/tests/Australia/Tasmania/Northeast/NortheastTest.php
@@ -43,7 +43,7 @@ class NortheastTest extends NortheastBaseTestCase implements ProviderTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -55,7 +55,12 @@ class NortheastTest extends NortheastBaseTestCase implements ProviderTestCase
             'eightHourDay',
             'recreationDay',
             'launcestonShow',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadTest.php
@@ -41,7 +41,7 @@ class CircularHeadTest extends CircularHeadBaseTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -54,6 +54,11 @@ class CircularHeadTest extends CircularHeadBaseTestCase
             'recreationDay',
             'burnieShow',
             'agfest',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadTest.php
@@ -55,8 +55,7 @@ class CircularHeadTest extends CircularHeadBaseTestCase
             'burnieShow',
             'agfest',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/Tasmania/Northwest/CircularHead/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
+
+/**
+ * Class for testing National Day of Mourning in Circular Head (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\Tasmania\Northwest\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/Northwest/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\Northwest;
+
+/**
+ * Class for testing National Day of Mourning in northwestern Tasmania (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\Tasmania\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Tasmania/Northwest/NorthwestTest.php
+++ b/tests/Australia/Tasmania/Northwest/NorthwestTest.php
@@ -43,7 +43,7 @@ class NorthwestTest extends NorthwestBaseTestCase implements ProviderTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -55,7 +55,12 @@ class NorthwestTest extends NorthwestBaseTestCase implements ProviderTestCase
             'eightHourDay',
             'recreationDay',
             'burnieShow',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Tasmania/Northwest/NorthwestTest.php
+++ b/tests/Australia/Tasmania/Northwest/NorthwestTest.php
@@ -56,8 +56,7 @@ class NorthwestTest extends NorthwestBaseTestCase implements ProviderTestCase
             'recreationDay',
             'burnieShow',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/Tasmania/South/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/South/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South;
+
+/**
+ * Class for testing National Day of Mourning in southern Tasmania (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\Tasmania\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Tasmania/South/SouthTest.php
+++ b/tests/Australia/Tasmania/South/SouthTest.php
@@ -43,7 +43,7 @@ class SouthTest extends SouthBaseTestCase implements ProviderTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -55,7 +55,12 @@ class SouthTest extends SouthBaseTestCase implements ProviderTestCase
             'eightHourDay',
             'recreationDay',
             'hobartShow',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Tasmania/South/SouthTest.php
+++ b/tests/Australia/Tasmania/South/SouthTest.php
@@ -56,8 +56,7 @@ class SouthTest extends SouthBaseTestCase implements ProviderTestCase
             'recreationDay',
             'hobartShow',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/Tasmania/South/Southeast/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
+
+/**
+ * Class for testing National Day of Mourning in southeastern Tasmania (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\Tasmania\South\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Tasmania/South/Southeast/SoutheastTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/SoutheastTest.php
@@ -41,7 +41,7 @@ class SoutheastTest extends SoutheastBaseTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -53,6 +53,11 @@ class SoutheastTest extends SoutheastBaseTestCase
             'eightHourDay',
             'hobartShow',
             'hobartRegatta',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/Tasmania/South/Southeast/SoutheastTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/SoutheastTest.php
@@ -54,8 +54,7 @@ class SoutheastTest extends SoutheastBaseTestCase
             'hobartShow',
             'hobartRegatta',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/Tasmania/TasmaniaTest.php
+++ b/tests/Australia/Tasmania/TasmaniaTest.php
@@ -43,7 +43,7 @@ class TasmaniaTest extends TasmaniaBaseTestCase implements ProviderTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -54,7 +54,12 @@ class TasmaniaTest extends TasmaniaBaseTestCase implements ProviderTestCase
             'queensBirthday',
             'eightHourDay',
             'recreationDay',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Tasmania/TasmaniaTest.php
+++ b/tests/Australia/Tasmania/TasmaniaTest.php
@@ -55,8 +55,7 @@ class TasmaniaTest extends TasmaniaBaseTestCase implements ProviderTestCase
             'eightHourDay',
             'recreationDay',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/Victoria/NationalDayOfMourningTest.php
+++ b/tests/Australia/Victoria/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\Victoria;
+
+/**
+ * Class for testing National Day of Mourning in Victoria (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/Victoria/VictoriaTest.php
+++ b/tests/Australia/Victoria/VictoriaTest.php
@@ -43,7 +43,7 @@ class VictoriaTest extends VictoriaBaseTestCase implements ProviderTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -57,7 +57,12 @@ class VictoriaTest extends VictoriaBaseTestCase implements ProviderTestCase
             'labourDay',
             'aflGrandFinalFriday',
             'melbourneCup',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Australia/Victoria/VictoriaTest.php
+++ b/tests/Australia/Victoria/VictoriaTest.php
@@ -58,8 +58,7 @@ class VictoriaTest extends VictoriaBaseTestCase implements ProviderTestCase
             'aflGrandFinalFriday',
             'melbourneCup',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/WesternAustralia/NationalDayOfMourningTest.php
+++ b/tests/Australia/WesternAustralia/NationalDayOfMourningTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2022 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia\WesternAustralia;
+
+/**
+ * Class for testing National Day of Mourning in Western Australia (Australia)..
+ */
+class NationalDayOfMourningTest extends \Yasumi\tests\Australia\NationalDayOfMourningTest
+{
+}

--- a/tests/Australia/WesternAustralia/WesternAustraliaTest.php
+++ b/tests/Australia/WesternAustralia/WesternAustraliaTest.php
@@ -55,8 +55,7 @@ class WesternAustraliaTest extends WesternAustraliaBaseTestCase implements Provi
             'labourDay',
             'westernAustraliaDay',
         ];
-        if(2022 == $this->year)
-        {
+        if (2022 == $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/WesternAustralia/WesternAustraliaTest.php
+++ b/tests/Australia/WesternAustralia/WesternAustraliaTest.php
@@ -43,7 +43,7 @@ class WesternAustraliaTest extends WesternAustraliaBaseTestCase implements Provi
      */
     public function testOfficialHolidays(): void
     {
-        $this->assertDefinedHolidays([
+        $expectedHolidays = [
             'newYearsDay',
             'goodFriday',
             'easterMonday',
@@ -54,7 +54,12 @@ class WesternAustraliaTest extends WesternAustraliaBaseTestCase implements Provi
             'queensBirthday',
             'labourDay',
             'westernAustraliaDay',
-        ], $this->region, $this->year, Holiday::TYPE_OFFICIAL);
+        ];
+        if(2022 == $this->year)
+        {
+            $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+        $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**


### PR DESCRIPTION
Added new national public holiday for Australia in commemoration of Queen Elizabeth II
Based on recent PR by [freshleafmedia](https://github.com/freshleafmedia) for UK holiday