### PR TITLE
In Japan, Marine Day was rescheduled to July 23 in 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ to [Semantic Versioning](https://semver.org).
   information in a single place.
 - Added bank holiday for Queen Elizabeth II’s State Funeral on 19 September 2022 to United Kingdom
 - Added Public Holiday National Day of Mourning (for Queen Elizabeth II) on 22 September 2022 to Australia
+- In Japan, Marine Day was rescheduled to July 23 as the 2020 Tokyo Olypmics took place. The rescheduled Marine
+  Day for 2021 was included, but not the original rescheduled day for 2020.
 
 ### Changed
 

--- a/src/Yasumi/Provider/Japan.php
+++ b/src/Yasumi/Provider/Japan.php
@@ -373,24 +373,32 @@ class Japan extends AbstractProvider
      */
     private function calculateMarineDay(): void
     {
-        $date = null;
-        if (2021 === $this->year) {
-            // For Olympic 2021 Tokyo (rescheduled due to the COVID-19 pandemic)
-            $date = new \DateTime("$this->year-7-22", DateTimeZoneFactory::getDateTimeZone($this->timezone));
-        } elseif ($this->year >= 2003) {
-            $date = new \DateTime("third monday of july $this->year", DateTimeZoneFactory::getDateTimeZone($this->timezone));
-        } elseif ($this->year >= 1996) {
-            $date = new \DateTime("$this->year-7-20", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        if (1996 > $this->year) {
+            return;
         }
 
-        if ($date instanceof \DateTimeInterface) {
-            $this->addHoliday(new Holiday(
-                'marineDay',
-                ['en' => 'Marine Day', 'ja' => '海の日'],
-                $date,
-                $this->locale
-            ));
+        $date = "$this->year-7-20";
+
+        if ($this->year >= 2003) {
+            $date = "third monday of july $this->year";
         }
+
+        if (2020 === $this->year) {
+            // For the 2020 Tokyo Olympics, Marine Day was rescheduled.
+            $date = "$this->year-7-23";
+        }
+
+        if (2021 === $this->year) {
+            // Due to the COVID-19 pandemic, the 2020 Tokyo Olympics were rescheduled and hence Marine Day as well.
+            $date = "$this->year-7-22";
+        }
+
+        $this->addHoliday(new Holiday(
+            'marineDay',
+            ['en' => 'Marine Day', 'ja' => '海の日'],
+            new \DateTime($date, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $this->locale
+        ));
     }
 
     /**

--- a/tests/Japan/MarineDayTest.php
+++ b/tests/Japan/MarineDayTest.php
@@ -17,23 +17,35 @@ namespace Yasumi\tests\Japan;
 use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
-/**
- * Class for testing Marine Day in Japan.
- */
-class MarineDayTest extends JapanBaseTestCase implements HolidayTestCase
+final class MarineDayTest extends JapanBaseTestCase implements HolidayTestCase
 {
-    /**
-     * The name of the holiday.
-     */
     public const HOLIDAY = 'marineDay';
 
-    /**
-     * The year in which the holiday was first established.
-     */
+    // The year in which the holiday was first established.
     public const ESTABLISHMENT_YEAR = 1996;
 
     /**
+     * Tests Marine Day in 2020. Marine Day in 2020 is July 23th for rescheduled Olympic Games after COVID-19.
+     *
+     * @see https://en.wikipedia.org/wiki/Marine_Day
+     *
+     * @throws \Exception
+     */
+    public function testMarineDayIn2020(): void
+    {
+        $year = 2020;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("$year-7-23", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
      * Tests Marine Day in 2021. Marine Day in 2021 is July 22th for rescheduled Olympic Games after COVID-19.
+     *
+     * @see https://en.wikipedia.org/wiki/Marine_Day
      *
      * @throws \Exception
      */
@@ -58,8 +70,8 @@ class MarineDayTest extends JapanBaseTestCase implements HolidayTestCase
     {
         $year = $this->generateRandomYear(2004);
 
-        if (2021 === $year) {
-            $this->testMarineDayIn2021();
+        if (in_array($year, [2020, 2021])) {
+            return;
         }
 
         $this->assertHoliday(


### PR DESCRIPTION
In Japan, Marine Day was rescheduled to July 23 as the 2020 Tokyo Olypmics took place. The rescheduled Marine Day for 2021 was included, but not the original rescheduled day for 2020.

Signed-off-by: Sacha Telgenhof <me@sachatelgenhof.com>