### PR TITLE
King Charles III’s Coronation

### DIFF
--- a/src/Yasumi/Provider/UnitedKingdom.php
+++ b/src/Yasumi/Provider/UnitedKingdom.php
@@ -59,6 +59,7 @@ class UnitedKingdom extends AbstractProvider
         $this->calculatePlatinumJubileeBankHoliday();
         $this->calculateMotheringSunday();
         $this->calculateQueenElizabethFuneralBankHoliday();
+        $this->calculateKingCharlesCoronationBankHoliday();
     }
 
     public function getSources(): array
@@ -218,6 +219,32 @@ class UnitedKingdom extends AbstractProvider
             'queenElizabethFuneralBankHoliday',
             ['en' => 'Queen Elizabeth II’s State Funeral Bank Holiday'],
             new \DateTime("$this->year-9-19", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $this->locale,
+            Holiday::TYPE_BANK
+        ));
+    }
+
+    /**
+     * The coronation of King Charles III is an extra bank holiday added on 6 November 2022
+     * to mark the Coronation of His Majesty King Charles III.
+     *
+     * @see https://www.timeanddate.com/holidays/uk/king-coronation-day-holiday
+     * @see https://www.gov.uk/government/news/bank-holiday-proclaimed-in-honour-of-the-coronation-of-his-majesty-king-charles-iii
+     *
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    protected function calculateKingCharlesCoronationBankHoliday(): void
+    {
+        if (2023 !== $this->year) {
+            return;
+        }
+
+        $this->addHoliday(new Holiday(
+            'kingCharlesCoronationBankHoliday',
+            ['en' => 'King Charles III’s Coronation Bank Holiday'],
+            new \DateTime("$this->year-5-8", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         ));

--- a/tests/UnitedKingdom/England/EnglandTest.php
+++ b/tests/UnitedKingdom/England/EnglandTest.php
@@ -92,6 +92,10 @@ class EnglandTest extends EnglandBaseTestCase implements ProviderTestCase
             $holidays[] = 'queenElizabethFuneralBankHoliday';
         }
 
+        if (2023 === $year) {
+            $holidays[] = 'kingCharlesCoronationBankHoliday';
+        }
+
         $this->assertDefinedHolidays($holidays, self::REGION, $year, Holiday::TYPE_BANK);
     }
 

--- a/tests/UnitedKingdom/KingCharlesCoronationBankHolidayTest.php
+++ b/tests/UnitedKingdom/KingCharlesCoronationBankHolidayTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * This file is part of the Yasumi package.
+ *
+ * Copyright (c) 2015 - 2023 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\UnitedKingdom;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing the King Charle's Coronation Bank Holiday in the United Kingdom.
+ */
+class KingCharlesCoronationBankHolidayTest extends UnitedKingdomBaseTestCase implements HolidayTestCase
+{
+    /**
+     * The name of the holiday.
+     */
+    public const HOLIDAY = 'kingCharlesCoronationBankHoliday';
+
+    /**
+     * The year in which the holiday occurred.
+     */
+    public const ACTIVE_YEAR = 2023;
+
+    /**
+     * The date on which the holiday occurred.
+     */
+    public const ACTIVE_DATE = '2023-5-8';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @throws \Exception
+     */
+    public function testHoliday(): void
+    {
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            self::ACTIVE_YEAR,
+            new \DateTime(self::ACTIVE_DATE, new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test before the year in which it occurred.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeActive(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ACTIVE_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the holiday defined in this test after the year in which it occurred.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayAfterActive(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ACTIVE_YEAR + 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            self::ACTIVE_YEAR,
+            [self::LOCALE => 'King Charles III’s Coronation Bank Holiday']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            self::ACTIVE_YEAR,
+            Holiday::TYPE_BANK
+        );
+    }
+}

--- a/tests/UnitedKingdom/NorthernIreland/NorthernIrelandTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/NorthernIrelandTest.php
@@ -96,6 +96,10 @@ class NorthernIrelandTest extends NorthernIrelandBaseTestCase implements Provide
             $holidays[] = 'queenElizabethFuneralBankHoliday';
         }
 
+        if (2023 === $year) {
+            $holidays[] = 'kingCharlesCoronationBankHoliday';
+        }
+
         $this->assertDefinedHolidays($holidays, self::REGION, $year, Holiday::TYPE_BANK);
     }
 

--- a/tests/UnitedKingdom/Scotland/ScotlandTest.php
+++ b/tests/UnitedKingdom/Scotland/ScotlandTest.php
@@ -91,6 +91,10 @@ class ScotlandTest extends ScotlandBaseTestCase implements ProviderTestCase
             $holidays[] = 'queenElizabethFuneralBankHoliday';
         }
 
+        if (2023 === $year) {
+            $holidays[] = 'kingCharlesCoronationBankHoliday';
+        }
+
         $this->assertDefinedHolidays($holidays, self::REGION, $year, Holiday::TYPE_BANK);
     }
 

--- a/tests/UnitedKingdom/UnitedKingdomTest.php
+++ b/tests/UnitedKingdom/UnitedKingdomTest.php
@@ -92,6 +92,10 @@ class UnitedKingdomTest extends UnitedKingdomBaseTestCase implements ProviderTes
             $holidays[] = 'queenElizabethFuneralBankHoliday';
         }
 
+        if (2023 === $year) {
+            $holidays[] = 'kingCharlesCoronationBankHoliday';
+        }
+
         $this->assertDefinedHolidays($holidays, self::REGION, $year, Holiday::TYPE_BANK);
     }
 

--- a/tests/UnitedKingdom/Wales/WalesTest.php
+++ b/tests/UnitedKingdom/Wales/WalesTest.php
@@ -92,6 +92,10 @@ class WalesTest extends WalesBaseTestCase implements ProviderTestCase
             $holidays[] = 'queenElizabethFuneralBankHoliday';
         }
 
+        if (2023 === $year) {
+            $holidays[] = 'kingCharlesCoronationBankHoliday';
+        }
+
         $this->assertDefinedHolidays($holidays, self::REGION, $year, Holiday::TYPE_BANK);
     }
 


### PR DESCRIPTION
A new bank holiday in the UK has been announced to mark the coronation of King Charles III