### PR TITLE
Adds ext-intl to required extensions

### DIFF
--- a/.github/workflows/coding-standard.yml
+++ b/.github/workflows/coding-standard.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: pcov
+          extensions: intl
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: pcov
+          extensions: intl
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
     "phan/phan": "^5.2",
     "phpstan/phpstan": "^1.4",
     "phpunit/phpunit": "^8.5 | ^9.5",
-    "vimeo/psalm": "^4.30"
+    "vimeo/psalm": "^4.30",
+    "ext-intl": "*"
   },
   "config": {
     "sort-packages": true,


### PR DESCRIPTION
The `ext-intl` extension is required to run tests since 111c2e6931b50d758923ca883aebbc15d83d29f4. Specifically due the to usage of `intltz_get_tz_data_version`