### PR TITLE
Denmark: Great Prayer Day abolished

### DIFF
--- a/src/Yasumi/Provider/Denmark.php
+++ b/src/Yasumi/Provider/Denmark.php
@@ -103,7 +103,7 @@ class Denmark extends AbstractProvider
     {
         $easter = $this->calculateEaster($this->year, $this->timezone)->format('Y-m-d');
 
-        if ($this->year >= 1686) {
+        if ($this->year >= 1686 && $this->year < 2024) {
             $this->addHoliday(new Holiday(
                 'greatPrayerDay',
                 ['da' => 'store bededag'],

--- a/tests/Denmark/DenmarkTest.php
+++ b/tests/Denmark/DenmarkTest.php
@@ -33,7 +33,7 @@ class DenmarkTest extends DenmarkBaseTestCase implements ProviderTestCase
      */
     protected function setUp(): void
     {
-        $this->year = $this->generateRandomYear(1849);
+        $this->year = $this->generateRandomYear(2024);
     }
 
     /**
@@ -49,7 +49,6 @@ class DenmarkTest extends DenmarkBaseTestCase implements ProviderTestCase
             'goodFriday',
             'easter',
             'easterMonday',
-            'greatPrayerDay',
             'ascensionDay',
             'pentecost',
             'pentecostMonday',

--- a/tests/Denmark/GreatPrayerDayTest.php
+++ b/tests/Denmark/GreatPrayerDayTest.php
@@ -37,6 +37,11 @@ class GreatPrayerDayTest extends DenmarkBaseTestCase implements HolidayTestCase
     public const ESTABLISHMENT_YEAR = 1686;
 
     /**
+     * The first year the holiday was no longer observed.
+     */
+    public const ABOLISHMENT_YEAR = 2024;
+
+    /**
      * Tests the holiday defined in this test on or after establishment.
      *
      * @throws Exception
@@ -68,6 +73,20 @@ class GreatPrayerDayTest extends DenmarkBaseTestCase implements HolidayTestCase
     }
 
     /**
+     * Tests the holiday defined in this test after abolishment.
+     *
+     * @throws ReflectionException
+     */
+    public function testHolidayAfterAbolishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ABOLISHMENT_YEAR)
+        );
+    }
+
+    /**
      * Tests the translated name of the holiday defined in this test.
      *
      * @throws ReflectionException
@@ -77,7 +96,7 @@ class GreatPrayerDayTest extends DenmarkBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ABOLISHMENT_YEAR - 1),
             [self::LOCALE => 'store bededag']
         );
     }
@@ -92,7 +111,7 @@ class GreatPrayerDayTest extends DenmarkBaseTestCase implements HolidayTestCase
         $this->assertHolidayType(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::ABOLISHMENT_YEAR - 1),
             Holiday::TYPE_OFFICIAL
         );
     }


### PR DESCRIPTION
Today the Danish Parliament has passed a bill that will abolish Great Prayer Day (_store bededag_) from 2024.

https://www.thelocal.dk/20230228/great-prayer-day-abolished-by-danish-parliament/
https://www.ft.dk/samling/20222/lovforslag/L13/index.htm