### PR TITLE
Fix easter date calculation :

### DIFF
--- a/src/Yasumi/Provider/ChristianHolidays.php
+++ b/src/Yasumi/Provider/ChristianHolidays.php
@@ -358,7 +358,7 @@ trait ChristianHolidays
                 }
 
                 $solar = (int) (($year - 1600) / 100) - (int) (($year - 1600) / 400); // The solar correction
-                $lunar = (int) (($year - 1400) / 100 * 8 / 25); // The lunar correction
+                $lunar = (int) (((int) (($year - 1400) / 100) * 8) / 25); // The lunar correction
 
                 $pfm = (3 - (11 * $golden) + $solar - $lunar) % 30; // Uncorrected date of the Paschal full moon
             }

--- a/tests/Belgium/EasterTest.php
+++ b/tests/Belgium/EasterTest.php
@@ -41,6 +41,13 @@ class EasterTest extends BelgiumBaseTestCase implements HolidayTestCase
             $year,
             new \DateTime("{$year}-4-4", new \DateTimeZone(self::TIMEZONE))
         );
+        $year = 2025;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-4-20", new \DateTimeZone(self::TIMEZONE))
+        );
     }
 
     /**

--- a/tests/France/EasterMondayTest.php
+++ b/tests/France/EasterMondayTest.php
@@ -41,6 +41,13 @@ class EasterMondayTest extends FranceBaseTestCase implements HolidayTestCase
             $year,
             new \DateTime("{$year}-3-28", new \DateTimeZone(self::TIMEZONE))
         );
+        $year = 2025;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-4-21", new \DateTimeZone(self::TIMEZONE))
+        );
     }
 
     /**


### PR DESCRIPTION
- Fix easter day calculation rounding for the lunar correction when not using calendar extension
- added some phpunit test that checks cases that were incorrects before

The below code show what diff it makes for the lunar correction :
```php
$year = 2025;
$lunar = (int) (((($year - 1400) / 100) * 8) / 25);
$lunarFixed = (int) (((int) (($year - 1400) / 100) * 8) / 25);
echo($lunar . "\n"); // output 2
echo($lunarFixed . "\n"); // output 1
```

In your tests, you have basically the same method in `tests/Randomizer.php`, with no important diff between the two expect the fix was already present in the test one, so I took it from it.

I rollbacked my changes from the issue on the end of the function, there weren't necessary.