### PR TITLE
Fix, Provider\Germany: Pentecost is not an official holiday - except in Brandenburg

### DIFF
--- a/src/Yasumi/Provider/Germany.php
+++ b/src/Yasumi/Provider/Germany.php
@@ -53,7 +53,7 @@ class Germany extends AbstractProvider
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
         $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
 

--- a/tests/Germany/GermanyTest.php
+++ b/tests/Germany/GermanyTest.php
@@ -84,7 +84,10 @@ class GermanyTest extends GermanyBaseTestCase implements ProviderTestCase
      */
     public function testOtherHolidays(): void
     {
-        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+        $this->assertDefinedHolidays([
+            'newYearsEve',
+            'pentecost'
+        ], self::REGION, $this->year, Holiday::TYPE_OTHER);
     }
 
     /**

--- a/tests/Germany/PentecostTest.php
+++ b/tests/Germany/PentecostTest.php
@@ -70,6 +70,6 @@ class PentecostTest extends GermanyBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
     }
 }


### PR DESCRIPTION
Hi,

Pentecost was originally removed from the list of general holidays in #100.
That's because pentecost is not an official holiday (until today) - except in Brandenburg.

I don't know why, it was added again in #225.

So i don't remove pentecost from the list of general holidays again, but it is generally marked as TYPE_OTHER.