### PR TITLE
fix(PHPUnit): Increased memory_limit, to be able to run all tests on MacOS

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,10 @@
       verbose="true"
     >
 
+    <php>
+        <ini name="memory_limit" value="512M" />
+    </php>
+
     <coverage processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./src/Yasumi</directory>


### PR DESCRIPTION
Reason:
128M was not enough to run all unit tests

The expected memory usage seems to be between 180M (MacOS M3) and 350M (Github's Workflow Runner)

Previous #335