### PR TITLE
handle invalid timezones Australia/ACT and Europe/Kiev

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 /**
- * This file is part of the Yasumi package.
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -13,7 +15,13 @@ declare(strict_types=1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-$config = new AzuyaLabs\PhpCsFixerConfig\Config();
+$config = new AzuyaLabs\PhpCsFixerConfig\Config('2015', null, 'Yasumi');
 $config->getFinder()->in(__DIR__)->notPath('var');
+
+$defaults = $config->getRules();
+
+$config->setRules(array_merge($defaults, [
+    'php_unit_method_casing' => ['case' => 'camel_case'],
+]));
 
 return $config;

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -12,29 +12,8 @@ declare(strict_types=1);
  *
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
-$finder = PhpCsFixer\Finder::create()->in(__DIR__);
 
-$config = new PhpCsFixer\Config();
-$config->setRiskyAllowed(true)->setRules([
-  '@PER' => true,
-  '@Symfony' => true,
-  'combine_consecutive_issets' => true,
-  'combine_consecutive_unsets' => true,
-  'explicit_string_variable' => true,
-  'no_superfluous_elseif' => true,
-  'no_superfluous_phpdoc_tags' => ['remove_inheritdoc' => true],
-  'not_operator_with_successor_space' => true,
-  'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => true ],
-  'ordered_class_elements' => true,
-
-  // Risky
-  'declare_strict_types' => true,
-  'dir_constant' => true,
-  'get_class_to_class_keyword' => true,
-  'is_null' => true,
-  'modernize_strpos' => true,
-  'modernize_types_casting' => true,
-  'self_accessor' => true,
-])->setFinder($finder);
+$config = new AzuyaLabs\PhpCsFixerConfig\Config();
+$config->getFinder()->in(__DIR__)->notPath('var');
 
 return $config;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ changes.
 
 ### Changed
 
+- Holiday calculation methods in providers are now protected instead of private 
+  to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
+  [\#331](https://github.com/azuyalabs/yasumi/issues/331)
+
 ### Fixed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ changes.
 
 ### Changed
 
-- Holiday calculation methods in providers are now protected instead of private 
+- Holiday calculation methods in providers are now protected instead of private
   to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
   [\#331](https://github.com/azuyalabs/yasumi/issues/331)
 
 ### Fixed
+
+- Handle invalid/changed timezones Australia/ACT and Europe/Kiev [\#343](https://github.com/azuyalabs/yasumi/pull/343)
+  ([Kevin Papst](https://github.com/kevinpapst))
 
 ### Removed
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "azuyalabs/yasumi",
-  "description": "The easy PHP Library for calculating holidays.",
+  "description": "The easy PHP Library for calculating holidays",
   "license": "MIT",
   "type": "library",
   "keywords": [
@@ -40,6 +40,7 @@
   },
   "require-dev": {
     "ext-intl": "*",
+    "azuyalabs/php-cs-fixer-config": "^0.1",
     "friendsofphp/php-cs-fixer": "^2.19 || 3.48",
     "mikey179/vfsstream": "^1.6",
     "phan/phan": "^5.4",
@@ -72,7 +73,8 @@
       "@phpstan",
       "@psalm"
     ],
-    "format": "./vendor/bin/php-cs-fixer fix",
+    "cs": "vendor/bin/php-cs-fixer fix -v --diff --dry-run",
+    "cs-fix": "vendor/bin/php-cs-fixer fix -v",
     "phan": "vendor/bin/phan -C",
     "phpstan": "vendor/bin/phpstan analyse",
     "psalm": "vendor/bin/psalm --threads=2",

--- a/composer.json
+++ b/composer.json
@@ -40,12 +40,12 @@
   },
   "require-dev": {
     "ext-intl": "*",
-    "friendsofphp/php-cs-fixer": "^2.19 || 3.46",
+    "friendsofphp/php-cs-fixer": "^2.19 || 3.48",
     "mikey179/vfsstream": "^1.6",
     "phan/phan": "^5.4",
     "phpstan/phpstan": "^1.10",
     "phpunit/phpunit": "^8.5 || ^9.6",
-    "vimeo/psalm": "^5.16"
+    "vimeo/psalm": "^5.20"
   },
   "suggest": {
     "ext-calendar": "For calculating the date of Easter"

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
   },
   "require-dev": {
     "ext-intl": "*",
-    "friendsofphp/php-cs-fixer": "^2.19 || ^3.40",
+    "friendsofphp/php-cs-fixer": "^2.19 || 3.46",
     "mikey179/vfsstream": "^1.6",
     "phan/phan": "^5.4",
     "phpstan/phpstan": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
   },
   "require-dev": {
     "ext-intl": "*",
-    "azuyalabs/php-cs-fixer-config": "^0.1",
-    "friendsofphp/php-cs-fixer": "^2.19 || 3.48",
+    "azuyalabs/php-cs-fixer-config": "^0.3",
     "mikey179/vfsstream": "^1.6",
     "phan/phan": "^5.4",
     "phpstan/phpstan": "^1.10",

--- a/examples/basic.php
+++ b/examples/basic.php
@@ -2,7 +2,20 @@
 
 // This file demonstrates the general use of Yasumi and its basic methods.
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 require 'vendor/autoload.php';
 
@@ -10,20 +23,20 @@ require 'vendor/autoload.php';
 $holidays = Yasumi\Yasumi::create('USA', (int) date('Y'));
 
 // Show the number of defined holidays
-echo 'Number of defined holidays: '.$holidays->count().PHP_EOL;
+echo 'Number of defined holidays: ' . $holidays->count() . PHP_EOL;
 echo PHP_EOL;
 
 // Display a list all of the holiday names (short names)
-echo 'List of all the holiday names: '.PHP_EOL;
+echo 'List of all the holiday names: ' . PHP_EOL;
 foreach ($holidays->getHolidayNames() as $name) {
-    echo $name.PHP_EOL;
+    echo $name . PHP_EOL;
 }
 echo PHP_EOL;
 
 // Display a list all of the holiday dates
-echo 'List of all the holiday dates:'.PHP_EOL;
+echo 'List of all the holiday dates:' . PHP_EOL;
 foreach ($holidays->getHolidayDates() as $date) {
-    echo $date.PHP_EOL;
+    echo $date . PHP_EOL;
 }
 echo PHP_EOL;
 
@@ -31,17 +44,17 @@ echo PHP_EOL;
 $independenceDay = $holidays->getHoliday('independenceDay');
 
 // Show the localized name
-echo 'Name of the holiday : '.$independenceDay->getName().PHP_EOL;
+echo 'Name of the holiday : ' . $independenceDay->getName() . PHP_EOL;
 
 // Show the date
-echo 'Date of the holiday : '.$independenceDay.PHP_EOL;
+echo 'Date of the holiday : ' . $independenceDay . PHP_EOL;
 
 // Show the type of holiday
-echo 'Type of holiday     : '.$independenceDay->getType().PHP_EOL;
+echo 'Type of holiday     : ' . $independenceDay->getType() . PHP_EOL;
 echo PHP_EOL;
 
 // Dump the holiday as a JSON object
-echo 'Holiday as a JSON object:'.PHP_EOL;
+echo 'Holiday as a JSON object:' . PHP_EOL;
 echo json_encode($independenceDay, JSON_PRETTY_PRINT);
 
 echo PHP_EOL;

--- a/examples/between_filter.php
+++ b/examples/between_filter.php
@@ -3,7 +3,20 @@
 // This file demonstrates the use of the `between` filter, selecting only a number of holidays
 // that fall in the given date range.
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 require 'vendor/autoload.php';
 
@@ -12,16 +25,16 @@ $year = (int) date('Y');
 // Use the factory to create a new holiday provider instance
 $holidays = Yasumi\Yasumi::create('Italy', $year);
 $holidaysInDecember = $holidays->between(
-    new DateTime('12/01/'.$year),
-    new DateTime('12/31/'.$year)
+    new DateTime('12/01/' . $year),
+    new DateTime('12/31/' . $year)
 );
 
 // Show all holidays in Italy for December
-echo 'List of all the holidays in December: '.PHP_EOL;
+echo 'List of all the holidays in December: ' . PHP_EOL;
 foreach ($holidaysInDecember as $holiday) {
-    echo $holiday.' - '.$holiday->getName().PHP_EOL;
+    echo $holiday . ' - ' . $holiday->getName() . PHP_EOL;
 }
 echo PHP_EOL;
 
 // Show the number of filtered holidays
-echo 'Number of filtered holidays: '.$holidaysInDecember->count().PHP_EOL;
+echo 'Number of filtered holidays: ' . $holidaysInDecember->count() . PHP_EOL;

--- a/examples/custom_provider.php
+++ b/examples/custom_provider.php
@@ -4,7 +4,20 @@
 // those scenarios where you would need only a subset of holidays of an existing provider. Or, if you you like to
 // extend an existing provider with additional, non-standard holidays.
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 require 'vendor/autoload.php';
 
@@ -33,11 +46,11 @@ class NYSE extends Yasumi\Provider\USA
 $NYSEHolidays = Yasumi\Yasumi::create(NYSE::class, (int) date('Y'));
 
 // We then can retrieve the NYSE observed holidays in the usual manner:
-echo 'List of all the holiday names: '.PHP_EOL;
+echo 'List of all the holiday names: ' . PHP_EOL;
 foreach ($NYSEHolidays->getHolidayNames() as $day) {
-    echo $day.PHP_EOL;
+    echo $day . PHP_EOL;
 }
 echo PHP_EOL;
 
 // Use the count() method to show how many holidays are returned
-echo 'Number of defined holidays: '.$NYSEHolidays->count().PHP_EOL;
+echo 'Number of defined holidays: ' . $NYSEHolidays->count() . PHP_EOL;

--- a/examples/filters.php
+++ b/examples/filters.php
@@ -4,7 +4,20 @@
 // based on certain conditions. In this examples we show only the holidays that are
 // marked as 'official'.
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 require 'vendor/autoload.php';
 
@@ -14,7 +27,7 @@ $holidays = Yasumi\Yasumi::create('Netherlands', (int) date('Y'));
 // Create a filter instance for the official holidays
 $official = new Yasumi\Filters\OfficialHolidaysFilter($holidays->getIterator());
 
-echo 'List of all official holidays: '.PHP_EOL;
+echo 'List of all official holidays: ' . PHP_EOL;
 foreach ($official as $day) {
-    echo $day->getName().PHP_EOL;
+    echo $day->getName() . PHP_EOL;
 }

--- a/phpinsights.php
+++ b/phpinsights.php
@@ -1,6 +1,19 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 return [
     /*

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,10 @@
       verbose="true"
     >
 
+    <php>
+        <ini name="memory_limit" value="512M" />
+    </php>
+
     <coverage processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./src/Yasumi</directory>

--- a/rector.php
+++ b/rector.php
@@ -1,6 +1,19 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
@@ -8,8 +21,8 @@ use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
-        __DIR__.'/src',
-        __DIR__.'/tests',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
     ]);
 
     // single rules

--- a/src/Yasumi/Exception/Exception.php
+++ b/src/Yasumi/Exception/Exception.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Exception/InvalidYearException.php
+++ b/src/Yasumi/Exception/InvalidYearException.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Exception/MissingTranslationException.php
+++ b/src/Yasumi/Exception/MissingTranslationException.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Exception/ProviderNotFoundException.php
+++ b/src/Yasumi/Exception/ProviderNotFoundException.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Exception/UnknownLocaleException.php
+++ b/src/Yasumi/Exception/UnknownLocaleException.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Filters/AbstractFilter.php
+++ b/src/Yasumi/Filters/AbstractFilter.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Filters/BankHolidaysFilter.php
+++ b/src/Yasumi/Filters/BankHolidaysFilter.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Filters/BetweenFilter.php
+++ b/src/Yasumi/Filters/BetweenFilter.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Filters/ObservedHolidaysFilter.php
+++ b/src/Yasumi/Filters/ObservedHolidaysFilter.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Filters/OfficialHolidaysFilter.php
+++ b/src/Yasumi/Filters/OfficialHolidaysFilter.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Filters/OnFilter.php
+++ b/src/Yasumi/Filters/OnFilter.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Filters/OtherHolidaysFilter.php
+++ b/src/Yasumi/Filters/OtherHolidaysFilter.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Filters/SeasonalHolidaysFilter.php
+++ b/src/Yasumi/Filters/SeasonalHolidaysFilter.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Holiday.php
+++ b/src/Yasumi/Holiday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -238,7 +240,7 @@ class Holiday extends \DateTime implements \JsonSerializable
 
             while ($child = strtok('_')) {
                 $expanded[] = $parent;
-                $parent .= '_'.$child;
+                $parent .= '_' . $child;
             }
             $expanded[] = $locale;
         }

--- a/src/Yasumi/Provider/AbstractProvider.php
+++ b/src/Yasumi/Provider/AbstractProvider.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Argentina.php
+++ b/src/Yasumi/Provider/Argentina.php
@@ -88,7 +88,7 @@ class Argentina extends AbstractProvider
      *
      * @see https://en.wikipedia.org/wiki/Brazilian_Carnival
      */
-    private function addCarnvalHolidays(): void
+    protected function addCarnvalHolidays(): void
     {
         if ($this->year >= 1700) {
             $easter = $this->calculateEaster($this->year, $this->timezone);
@@ -138,7 +138,7 @@ class Argentina extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Day_of_Remembrance_for_Truth_and_Justice
      */
-    private function addRemembranceDay(): void
+    protected function addRemembranceDay(): void
     {
         if ($this->year >= 2006) {
             $this->addHoliday(new Holiday(
@@ -164,7 +164,7 @@ class Argentina extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Malvinas_Day
      */
-    private function addMalvinasDay(): void
+    protected function addMalvinasDay(): void
     {
         if ($this->year >= 1982) {
             $this->addHoliday(new Holiday(
@@ -192,7 +192,7 @@ class Argentina extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/First_National_Government
      */
-    private function addMayRevolution(): void
+    protected function addMayRevolution(): void
     {
         if ($this->year >= 1810) {
             $this->addHoliday(new Holiday(
@@ -213,7 +213,7 @@ class Argentina extends AbstractProvider
      * Anniversary of the death of Martín Miguel de Güemes, general of the
      * Argentine War of Independence.
      */
-    private function addGeneralMartinMigueldeGuemesDay(): void
+    protected function addGeneralMartinMigueldeGuemesDay(): void
     {
         if ($this->year >= 1821) {
             $this->addHoliday(new Holiday(
@@ -236,7 +236,7 @@ class Argentina extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Flag_Day_(Argentina)
      */
-    private function addFlagDay(): void
+    protected function addFlagDay(): void
     {
         if ($this->year >= 1938) {
             $this->addHoliday(new Holiday(
@@ -258,7 +258,7 @@ class Argentina extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Argentine_Declaration_of_Independence
      */
-    private function addIndependenceDay(): void
+    protected function addIndependenceDay(): void
     {
         if ($this->year >= self::PROCLAMATION_OF_INDEPENDENCE_YEAR) {
             $this->addHoliday(new Holiday(
@@ -279,7 +279,7 @@ class Argentina extends AbstractProvider
      * Anniversary of the death of José de San Martín, liberator of
      * Argentina, Chile and Peru.
      */
-    private function addGeneralJoseSanMartinDay(): void
+    protected function addGeneralJoseSanMartinDay(): void
     {
         if ($this->year >= 1850) {
             $this->addHoliday(new Holiday(
@@ -302,7 +302,7 @@ class Argentina extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Columbus_Day
      */
-    private function addRaceDay(): void
+    protected function addRaceDay(): void
     {
         if ($this->year >= 1492) {
             $this->addHoliday(new Holiday(
@@ -325,7 +325,7 @@ class Argentina extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/National_Sovereignty_Day
      */
-    private function addNationalSovereigntyDay(): void
+    protected function addNationalSovereigntyDay(): void
     {
         if ($this->year >= 2010) {
             $this->addHoliday(new Holiday(
@@ -348,7 +348,7 @@ class Argentina extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Immaculate_Conception
      */
-    private function addImmaculateConceptionDay(): void
+    protected function addImmaculateConceptionDay(): void
     {
         if ($this->year >= 1900) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Argentina.php
+++ b/src/Yasumi/Provider/Argentina.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Australia.php
+++ b/src/Yasumi/Provider/Australia.php
@@ -77,7 +77,7 @@ class Australia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNewYearHolidays(): void
+    protected function calculateNewYearHolidays(): void
     {
         $newYearsDay = new \DateTime("{$this->year}-01-01", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $this->addHoliday(new Holiday(
@@ -129,7 +129,7 @@ class Australia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateAustraliaDay(): void
+    protected function calculateAustraliaDay(): void
     {
         $date = new \DateTime("{$this->year}-01-26", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
@@ -172,7 +172,7 @@ class Australia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateAnzacDay(): void
+    protected function calculateAnzacDay(): void
     {
         if ($this->year < 1921) {
             return;
@@ -217,7 +217,7 @@ class Australia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalDayOfMourning(): void
+    protected function calculateNationalDayOfMourning(): void
     {
         if (2022 !== $this->year) {
             return;
@@ -244,7 +244,7 @@ class Australia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateChristmasDay(): void
+    protected function calculateChristmasDay(): void
     {
         $christmasDay = new \DateTime("{$this->year}-12-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $boxingDay = new \DateTime("{$this->year}-12-26", DateTimeZoneFactory::getDateTimeZone($this->timezone));

--- a/src/Yasumi/Provider/Australia.php
+++ b/src/Yasumi/Provider/Australia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
+++ b/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -142,7 +144,7 @@ class AustralianCapitalTerritory extends Australia
         $this->addHoliday(new Holiday(
             'queensBirthday',
             [],
-            new \DateTime('second monday of june '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -190,10 +192,10 @@ class AustralianCapitalTerritory extends Australia
             return;
         }
 
-        $date = new \DateTime($this->year.'-05-27', DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime($this->year . '-05-27', DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $day = (int) $date->format('w');
         if (1 !== $day) {
-            $date = $date->add(0 === $day ? new \DateInterval('P1D') : new \DateInterval('P'.(8 - $day).'D'));
+            $date = $date->add(0 === $day ? new \DateInterval('P1D') : new \DateInterval('P' . (8 - $day) . 'D'));
         }
         $this->addHoliday(new Holiday('reconciliationDay', ['en' => 'Reconciliation Day'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
+++ b/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
@@ -33,7 +33,13 @@ class AustralianCapitalTerritory extends Australia
      */
     public const ID = 'AU-ACT';
 
-    public string $timezone = 'Australia/ACT';
+    /**
+     * This was "Australia/ACT" in the past, which is only a link to Australia/Sydney.
+     * In recent versions of PHP "Australia/ACT" was removed, so this is no longer the link version.
+     *
+     * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+     */
+    public string $timezone = 'Australia/Sydney';
 
     /**
      * Initialize holidays for Australian Capital Territory (Australia).

--- a/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
+++ b/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
@@ -34,12 +34,6 @@ class AustralianCapitalTerritory extends Australia
     public const ID = 'AU-ACT';
 
     /**
-     * This was "Australia/ACT" in the past, which is a TZ link to "Australia/Sydney".
-     * Recent builds of PHP removed "Australia/ACT", so this was changed as well.
-     */
-    public string $timezone = 'Australia/Sydney';
-
-    /**
      * Initialize holidays for Australian Capital Territory (Australia).
      *
      * @throws \InvalidArgumentException
@@ -48,6 +42,16 @@ class AustralianCapitalTerritory extends Australia
      */
     public function initialize(): void
     {
+        // This was "Australia/ACT" in the past, which is a TZ link to "Australia/Sydney".
+        // Recent builds of PHP removed "Australia/ACT", so we have to figure out which one is available on the system
+        try {
+            new \DateTimeZone('Australia/Sydney');
+            $this->timezone = 'Australia/Sydney';
+        } catch (\Exception $e) { // @phpstan-ignore-line
+            // DateInvalidTimeZoneException since 8.3
+            $this->timezone = 'Australia/ACT';
+        }
+
         parent::initialize();
 
         $this->addHoliday($this->easterSunday($this->year, $this->timezone, $this->locale));

--- a/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
+++ b/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
@@ -34,10 +34,8 @@ class AustralianCapitalTerritory extends Australia
     public const ID = 'AU-ACT';
 
     /**
-     * This was "Australia/ACT" in the past, which is only a link to Australia/Sydney.
-     * In recent versions of PHP "Australia/ACT" was removed, so this is no longer the link version.
-     *
-     * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+     * This was "Australia/ACT" in the past, which is a TZ link to "Australia/Sydney".
+     * Recent builds of PHP removed "Australia/ACT", so this was changed as well.
      */
     public string $timezone = 'Australia/Sydney';
 

--- a/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
+++ b/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
@@ -69,7 +69,7 @@ class AustralianCapitalTerritory extends Australia
      *
      * @throws \Exception
      */
-    private function easterSunday(
+    protected function easterSunday(
         int $year,
         string $timezone,
         string $locale,
@@ -101,7 +101,7 @@ class AustralianCapitalTerritory extends Australia
      *
      * @throws \Exception
      */
-    private function easterSaturday(
+    protected function easterSaturday(
         int $year,
         string $timezone,
         string $locale,
@@ -137,7 +137,7 @@ class AustralianCapitalTerritory extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateQueensBirthday(): void
+    protected function calculateQueensBirthday(): void
     {
         $this->addHoliday(new Holiday(
             'queensBirthday',
@@ -153,7 +153,7 @@ class AustralianCapitalTerritory extends Australia
      *
      * @throws \Exception
      */
-    private function calculateLabourDay(): void
+    protected function calculateLabourDay(): void
     {
         $date = new \DateTime("first monday of october {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
@@ -165,7 +165,7 @@ class AustralianCapitalTerritory extends Australia
      *
      * @throws \Exception
      */
-    private function calculateCanberraDay(): void
+    protected function calculateCanberraDay(): void
     {
         $datePattern = $this->year < 2007 ? "third monday of march {$this->year}" : "second monday of march {$this->year}";
 
@@ -184,7 +184,7 @@ class AustralianCapitalTerritory extends Australia
      *
      * @throws \Exception
      */
-    private function calculateReconciliationDay(): void
+    protected function calculateReconciliationDay(): void
     {
         if ($this->year < 2018) {
             return;

--- a/src/Yasumi/Provider/Australia/NewSouthWales.php
+++ b/src/Yasumi/Provider/Australia/NewSouthWales.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -109,7 +111,7 @@ class NewSouthWales extends Australia
         $this->addHoliday(new Holiday(
             'queensBirthday',
             [],
-            new \DateTime('second monday of june '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -138,7 +140,7 @@ class NewSouthWales extends Australia
         $this->addHoliday(new Holiday(
             'bankHoliday',
             ['en' => 'Bank Holiday'],
-            new \DateTime('first monday of august '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('first monday of august ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         ));

--- a/src/Yasumi/Provider/Australia/NewSouthWales.php
+++ b/src/Yasumi/Provider/Australia/NewSouthWales.php
@@ -68,7 +68,7 @@ class NewSouthWales extends Australia
      *
      * @throws \Exception
      */
-    private function easterSaturday(
+    protected function easterSaturday(
         int $year,
         string $timezone,
         string $locale,
@@ -104,7 +104,7 @@ class NewSouthWales extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateQueensBirthday(): void
+    protected function calculateQueensBirthday(): void
     {
         $this->addHoliday(new Holiday(
             'queensBirthday',
@@ -120,7 +120,7 @@ class NewSouthWales extends Australia
      *
      * @throws \Exception
      */
-    private function calculateLabourDay(): void
+    protected function calculateLabourDay(): void
     {
         $date = new \DateTime("first monday of october {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
@@ -133,7 +133,7 @@ class NewSouthWales extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateBankHoliday(): void
+    protected function calculateBankHoliday(): void
     {
         $this->addHoliday(new Holiday(
             'bankHoliday',

--- a/src/Yasumi/Provider/Australia/NorthernTerritory.php
+++ b/src/Yasumi/Provider/Australia/NorthernTerritory.php
@@ -67,7 +67,7 @@ class NorthernTerritory extends Australia
      *
      * @throws \Exception
      */
-    private function easterSaturday(
+    protected function easterSaturday(
         int $year,
         string $timezone,
         string $locale,
@@ -103,7 +103,7 @@ class NorthernTerritory extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateQueensBirthday(): void
+    protected function calculateQueensBirthday(): void
     {
         $this->addHoliday(new Holiday(
             'queensBirthday',
@@ -119,7 +119,7 @@ class NorthernTerritory extends Australia
      *
      * @throws \Exception
      */
-    private function calculateMayDay(): void
+    protected function calculateMayDay(): void
     {
         $date = new \DateTime("first monday of may {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
@@ -134,7 +134,7 @@ class NorthernTerritory extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculatePicnicDay(): void
+    protected function calculatePicnicDay(): void
     {
         $this->addHoliday(new Holiday(
             'picnicDay',

--- a/src/Yasumi/Provider/Australia/NorthernTerritory.php
+++ b/src/Yasumi/Provider/Australia/NorthernTerritory.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -108,7 +110,7 @@ class NorthernTerritory extends Australia
         $this->addHoliday(new Holiday(
             'queensBirthday',
             [],
-            new \DateTime('second monday of june '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -139,7 +141,7 @@ class NorthernTerritory extends Australia
         $this->addHoliday(new Holiday(
             'picnicDay',
             ['en' => 'Picnic Day'],
-            new \DateTime('first monday of august '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('first monday of august ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));

--- a/src/Yasumi/Provider/Australia/Queensland.php
+++ b/src/Yasumi/Provider/Australia/Queensland.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -65,10 +67,10 @@ class Queensland extends Australia
      */
     protected function calculateQueensBirthday(): void
     {
-        $birthDay = 'first monday of october '.$this->year;
+        $birthDay = 'first monday of october ' . $this->year;
 
         if ($this->year < 2012 || 2013 === $this->year || 2014 === $this->year || 2015 === $this->year) {
-            $birthDay = 'second monday of june '.$this->year;
+            $birthDay = 'second monday of june ' . $this->year;
         }
 
         $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Australia/Queensland.php
+++ b/src/Yasumi/Provider/Australia/Queensland.php
@@ -63,7 +63,7 @@ class Queensland extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateQueensBirthday(): void
+    protected function calculateQueensBirthday(): void
     {
         $birthDay = 'first monday of october '.$this->year;
 
@@ -85,7 +85,7 @@ class Queensland extends Australia
      *
      * @throws \Exception
      */
-    private function calculateLabourDay(): void
+    protected function calculateLabourDay(): void
     {
         $date = new \DateTime("first monday of may {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         if (2013 === $this->year || 2014 === $this->year || 2015 === $this->year) {

--- a/src/Yasumi/Provider/Australia/Queensland/Brisbane.php
+++ b/src/Yasumi/Provider/Australia/Queensland/Brisbane.php
@@ -65,7 +65,7 @@ class Brisbane extends Queensland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculatePeoplesDay(): void
+    protected function calculatePeoplesDay(): void
     {
         $date = new \DateTime('first friday of august '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         if ($date->format('d') < 5) {

--- a/src/Yasumi/Provider/Australia/Queensland/Brisbane.php
+++ b/src/Yasumi/Provider/Australia/Queensland/Brisbane.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -67,7 +69,7 @@ class Brisbane extends Queensland
      */
     protected function calculatePeoplesDay(): void
     {
-        $date = new \DateTime('first friday of august '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime('first friday of august ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         if ($date->format('d') < 5) {
             $date = $date->add(new \DateInterval('P7D'));
         }

--- a/src/Yasumi/Provider/Australia/SouthAustralia.php
+++ b/src/Yasumi/Provider/Australia/SouthAustralia.php
@@ -75,7 +75,7 @@ class SouthAustralia extends Australia
      *
      * @throws \Exception
      */
-    private function easterSaturday(
+    protected function easterSaturday(
         int $year,
         string $timezone,
         string $locale,
@@ -111,7 +111,7 @@ class SouthAustralia extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateQueensBirthday(): void
+    protected function calculateQueensBirthday(): void
     {
         $this->addHoliday(new Holiday(
             'queensBirthday',
@@ -127,7 +127,7 @@ class SouthAustralia extends Australia
      *
      * @throws \Exception
      */
-    private function calculateLabourDay(): void
+    protected function calculateLabourDay(): void
     {
         $date = new \DateTime("first monday of october {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
@@ -142,7 +142,7 @@ class SouthAustralia extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateAdelaideCupDay(): void
+    protected function calculateAdelaideCupDay(): void
     {
         if ($this->year >= 1973) {
             $cupDay = 'second monday of march '.$this->year;
@@ -166,7 +166,7 @@ class SouthAustralia extends Australia
      *
      * @throws \Exception
      */
-    private function calculateProclamationDay(): void
+    protected function calculateProclamationDay(): void
     {
         $christmasDay = new \DateTime("{$this->year}-12-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 

--- a/src/Yasumi/Provider/Australia/SouthAustralia.php
+++ b/src/Yasumi/Provider/Australia/SouthAustralia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -116,7 +118,7 @@ class SouthAustralia extends Australia
         $this->addHoliday(new Holiday(
             'queensBirthday',
             [],
-            new \DateTime('second monday of june '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -145,10 +147,10 @@ class SouthAustralia extends Australia
     protected function calculateAdelaideCupDay(): void
     {
         if ($this->year >= 1973) {
-            $cupDay = 'second monday of march '.$this->year;
+            $cupDay = 'second monday of march ' . $this->year;
 
             if ($this->year < 2006) {
-                $cupDay = 'third monday of may '.$this->year;
+                $cupDay = 'third monday of may ' . $this->year;
             }
 
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Australia/Tasmania.php
+++ b/src/Yasumi/Provider/Australia/Tasmania.php
@@ -54,7 +54,7 @@ class Tasmania extends Australia
      *
      * @throws \Exception
      */
-    private function calculateEightHoursDay(): void
+    protected function calculateEightHoursDay(): void
     {
         $date = new \DateTime("second monday of march {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
@@ -76,7 +76,7 @@ class Tasmania extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateQueensBirthday(): void
+    protected function calculateQueensBirthday(): void
     {
         $this->addHoliday(new Holiday(
             'queensBirthday',
@@ -95,7 +95,7 @@ class Tasmania extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateRecreationDay(): void
+    protected function calculateRecreationDay(): void
     {
         $this->addHoliday(new Holiday(
             'recreationDay',

--- a/src/Yasumi/Provider/Australia/Tasmania.php
+++ b/src/Yasumi/Provider/Australia/Tasmania.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -81,7 +83,7 @@ class Tasmania extends Australia
         $this->addHoliday(new Holiday(
             'queensBirthday',
             [],
-            new \DateTime('second monday of june '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -100,7 +102,7 @@ class Tasmania extends Australia
         $this->addHoliday(new Holiday(
             'recreationDay',
             ['en' => 'Recreation Day'],
-            new \DateTime('first monday of november '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('first monday of november ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));

--- a/src/Yasumi/Provider/Australia/Tasmania/CentralNorth.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/CentralNorth.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -53,7 +55,7 @@ class CentralNorth extends Tasmania
      */
     protected function calculateDevonportShow(): void
     {
-        $date = new \DateTime($this->year.'-12-02', DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime($this->year . '-12-02', DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->modify('previous friday');
 
         if (! $date instanceof \DateTime) {

--- a/src/Yasumi/Provider/Australia/Tasmania/CentralNorth.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/CentralNorth.php
@@ -51,7 +51,7 @@ class CentralNorth extends Tasmania
      *
      * @throws \Exception
      */
-    private function calculateDevonportShow(): void
+    protected function calculateDevonportShow(): void
     {
         $date = new \DateTime($this->year.'-12-02', DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->modify('previous friday');

--- a/src/Yasumi/Provider/Australia/Tasmania/FlindersIsland.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/FlindersIsland.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -53,7 +55,7 @@ class FlindersIsland extends Tasmania
      */
     protected function calculateFlindersIslandShow(): void
     {
-        $date = new \DateTime('third saturday of october '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime('third saturday of october ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new \DateInterval('P1D'));
         $this->addHoliday(new Holiday('flindersIslandShow', ['en' => 'Flinders Island Show'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/FlindersIsland.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/FlindersIsland.php
@@ -51,7 +51,7 @@ class FlindersIsland extends Tasmania
      *
      * @throws \Exception
      */
-    private function calculateFlindersIslandShow(): void
+    protected function calculateFlindersIslandShow(): void
     {
         $date = new \DateTime('third saturday of october '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new \DateInterval('P1D'));

--- a/src/Yasumi/Provider/Australia/Tasmania/KingIsland.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/KingIsland.php
@@ -51,7 +51,7 @@ class KingIsland extends Tasmania
      *
      * @throws \Exception
      */
-    private function calculateKingIslandShow(): void
+    protected function calculateKingIslandShow(): void
     {
         $this->addHoliday(new Holiday(
             'kingIslandShow',

--- a/src/Yasumi/Provider/Australia/Tasmania/KingIsland.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/KingIsland.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -56,7 +58,7 @@ class KingIsland extends Tasmania
         $this->addHoliday(new Holiday(
             'kingIslandShow',
             ['en' => 'King Island Show'],
-            new \DateTime('first tuesday of march '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('first tuesday of march ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));

--- a/src/Yasumi/Provider/Australia/Tasmania/Northeast.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northeast.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -53,7 +55,7 @@ class Northeast extends Tasmania
      */
     protected function calculateLauncestonShow(): void
     {
-        $date = new \DateTime('second saturday of october '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime('second saturday of october ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new \DateInterval('P2D'));
         $this->addHoliday(new Holiday('launcestonShow', ['en' => 'Royal Launceston Show'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/Northeast.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northeast.php
@@ -51,7 +51,7 @@ class Northeast extends Tasmania
      *
      * @throws \Exception
      */
-    private function calculateLauncestonShow(): void
+    protected function calculateLauncestonShow(): void
     {
         $date = new \DateTime('second saturday of october '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new \DateInterval('P2D'));

--- a/src/Yasumi/Provider/Australia/Tasmania/Northwest.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northwest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -53,7 +55,7 @@ class Northwest extends Tasmania
      */
     protected function calculateBurnieShow(): void
     {
-        $date = new \DateTime('first saturday of october '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime('first saturday of october ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new \DateInterval('P1D'));
         $this->addHoliday(new Holiday('burnieShow', ['en' => 'Burnie Show'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/Northwest.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northwest.php
@@ -51,7 +51,7 @@ class Northwest extends Tasmania
      *
      * @throws \Exception
      */
-    private function calculateBurnieShow(): void
+    protected function calculateBurnieShow(): void
     {
         $date = new \DateTime('first saturday of october '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new \DateInterval('P1D'));

--- a/src/Yasumi/Provider/Australia/Tasmania/Northwest/CircularHead.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northwest/CircularHead.php
@@ -51,7 +51,7 @@ class CircularHead extends Northwest
      *
      * @throws \Exception
      */
-    private function calculateAGFEST(): void
+    protected function calculateAGFEST(): void
     {
         $date = new \DateTime('first thursday of may '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->add(new \DateInterval('P1D'));

--- a/src/Yasumi/Provider/Australia/Tasmania/Northwest/CircularHead.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/Northwest/CircularHead.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -53,7 +55,7 @@ class CircularHead extends Northwest
      */
     protected function calculateAGFEST(): void
     {
-        $date = new \DateTime('first thursday of may '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime('first thursday of may ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->add(new \DateInterval('P1D'));
         $this->addHoliday(new Holiday('agfest', ['en' => 'AGFEST'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/South.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/South.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -53,7 +55,7 @@ class South extends Tasmania
      */
     protected function calculateHobartShow(): void
     {
-        $date = new \DateTime('fourth saturday of october '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime('fourth saturday of october ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new \DateInterval('P2D'));
         $this->addHoliday(new Holiday('hobartShow', ['en' => 'Royal Hobart Show'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Tasmania/South.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/South.php
@@ -51,7 +51,7 @@ class South extends Tasmania
      *
      * @throws \Exception
      */
-    private function calculateHobartShow(): void
+    protected function calculateHobartShow(): void
     {
         $date = new \DateTime('fourth saturday of october '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $date = $date->sub(new \DateInterval('P2D'));

--- a/src/Yasumi/Provider/Australia/Tasmania/South/Southeast.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/South/Southeast.php
@@ -54,7 +54,7 @@ class Southeast extends South
      *
      * @throws \Exception
      */
-    private function calculateHobartRegatta(): void
+    protected function calculateHobartRegatta(): void
     {
         $this->addHoliday(new Holiday(
             'hobartRegatta',

--- a/src/Yasumi/Provider/Australia/Tasmania/South/Southeast.php
+++ b/src/Yasumi/Provider/Australia/Tasmania/South/Southeast.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -59,7 +61,7 @@ class Southeast extends South
         $this->addHoliday(new Holiday(
             'hobartRegatta',
             ['en' => 'Royal Hobart Regatta'],
-            new \DateTime('second monday of february '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('second monday of february ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));

--- a/src/Yasumi/Provider/Australia/Victoria.php
+++ b/src/Yasumi/Provider/Australia/Victoria.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -154,7 +156,7 @@ class Victoria extends Australia
         $this->addHoliday(new Holiday(
             'queensBirthday',
             [],
-            new \DateTime('second monday of june '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('second monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -167,7 +169,7 @@ class Victoria extends Australia
      */
     protected function calculateMelbourneCupDay(): void
     {
-        $date = new \DateTime('first Tuesday of November'." {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime('first Tuesday of November' . " {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday('melbourneCup', ['en' => 'Melbourne Cup'], $date, $this->locale));
     }

--- a/src/Yasumi/Provider/Australia/Victoria.php
+++ b/src/Yasumi/Provider/Australia/Victoria.php
@@ -69,7 +69,7 @@ class Victoria extends Australia
      *
      * @throws \Exception
      */
-    private function easterSunday(
+    protected function easterSunday(
         int $year,
         string $timezone,
         string $locale,
@@ -101,7 +101,7 @@ class Victoria extends Australia
      *
      * @throws \Exception
      */
-    private function easterSaturday(
+    protected function easterSaturday(
         int $year,
         string $timezone,
         string $locale,
@@ -127,7 +127,7 @@ class Victoria extends Australia
      *
      * @throws \Exception
      */
-    private function calculateLabourDay(): void
+    protected function calculateLabourDay(): void
     {
         $date = new \DateTime("second monday of march {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
@@ -149,7 +149,7 @@ class Victoria extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateQueensBirthday(): void
+    protected function calculateQueensBirthday(): void
     {
         $this->addHoliday(new Holiday(
             'queensBirthday',
@@ -165,7 +165,7 @@ class Victoria extends Australia
      *
      * @throws \Exception
      */
-    private function calculateMelbourneCupDay(): void
+    protected function calculateMelbourneCupDay(): void
     {
         $date = new \DateTime('first Tuesday of November'." {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
@@ -177,7 +177,7 @@ class Victoria extends Australia
      *
      * @throws \Exception
      */
-    private function calculateAFLGrandFinalDay(): void
+    protected function calculateAFLGrandFinalDay(): void
     {
         switch ($this->year) {
             case 2015:

--- a/src/Yasumi/Provider/Australia/WesternAustralia.php
+++ b/src/Yasumi/Provider/Australia/WesternAustralia.php
@@ -64,7 +64,7 @@ class WesternAustralia extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateQueensBirthday(): void
+    protected function calculateQueensBirthday(): void
     {
         $birthDay = 'last monday of september '.$this->year;
         if (2011 === $this->year) {
@@ -89,7 +89,7 @@ class WesternAustralia extends Australia
      *
      * @throws \Exception
      */
-    private function calculateLabourDay(): void
+    protected function calculateLabourDay(): void
     {
         $date = new \DateTime("first monday of march {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
@@ -104,7 +104,7 @@ class WesternAustralia extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateWesternAustraliaDay(): void
+    protected function calculateWesternAustraliaDay(): void
     {
         $this->addHoliday(new Holiday(
             'westernAustraliaDay',

--- a/src/Yasumi/Provider/Australia/WesternAustralia.php
+++ b/src/Yasumi/Provider/Australia/WesternAustralia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -66,7 +68,7 @@ class WesternAustralia extends Australia
      */
     protected function calculateQueensBirthday(): void
     {
-        $birthDay = 'last monday of september '.$this->year;
+        $birthDay = 'last monday of september ' . $this->year;
         if (2011 === $this->year) {
             $birthDay = '2011-10-28';
         }
@@ -109,7 +111,7 @@ class WesternAustralia extends Australia
         $this->addHoliday(new Holiday(
             'westernAustraliaDay',
             ['en' => 'Western Australia Day'],
-            new \DateTime('first monday of june '.$this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime('first monday of june ' . $this->year, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));

--- a/src/Yasumi/Provider/Austria.php
+++ b/src/Yasumi/Provider/Austria.php
@@ -116,7 +116,7 @@ class Austria extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalDay(): void
+    protected function calculateNationalDay(): void
     {
         if ($this->year < 1955) {
             return;

--- a/src/Yasumi/Provider/Austria.php
+++ b/src/Yasumi/Provider/Austria.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -97,7 +99,7 @@ class Austria extends AbstractProvider
         $this->addHoliday(new Holiday(
             'stLeopoldsDay',
             [],
-            new \DateTime($this->year.'-11-15', new \DateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-11-15', new \DateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -125,7 +127,7 @@ class Austria extends AbstractProvider
         $this->addHoliday(new Holiday(
             'nationalDay',
             ['de' => 'Nationalfeiertag'],
-            new \DateTime($this->year.'-10-26', new \DateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-10-26', new \DateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/Austria/Burgenland.php
+++ b/src/Yasumi/Provider/Austria/Burgenland.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Austria/Carinthia.php
+++ b/src/Yasumi/Provider/Austria/Carinthia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -71,7 +73,7 @@ class Carinthia extends Austria
         $this->addHoliday(new Holiday(
             'plebisciteDay',
             [],
-            new \DateTime($this->year.'-10-10', new \DateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-10-10', new \DateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/Austria/Carinthia.php
+++ b/src/Yasumi/Provider/Austria/Carinthia.php
@@ -62,7 +62,7 @@ class Carinthia extends Austria
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculatePlebisciteDay(): void
+    protected function calculatePlebisciteDay(): void
     {
         if ($this->year < 1920) {
             return;

--- a/src/Yasumi/Provider/Austria/LowerAustria.php
+++ b/src/Yasumi/Provider/Austria/LowerAustria.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Austria/Salzburg.php
+++ b/src/Yasumi/Provider/Austria/Salzburg.php
@@ -63,7 +63,7 @@ class Salzburg extends Austria
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStRupertsDay(): void
+    protected function calculateStRupertsDay(): void
     {
         if ($this->year < 710) {
             return;

--- a/src/Yasumi/Provider/Austria/Salzburg.php
+++ b/src/Yasumi/Provider/Austria/Salzburg.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -72,7 +74,7 @@ class Salzburg extends Austria
         $this->addHoliday(new Holiday(
             'stRupertsDay',
             [],
-            new \DateTime($this->year.'-9-24', new \DateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-9-24', new \DateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/Austria/Styria.php
+++ b/src/Yasumi/Provider/Austria/Styria.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Austria/Tyrol.php
+++ b/src/Yasumi/Provider/Austria/Tyrol.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Austria/UpperAustria.php
+++ b/src/Yasumi/Provider/Austria/UpperAustria.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -73,7 +75,7 @@ class UpperAustria extends Austria
         $this->addHoliday(new Holiday(
             'stFloriansDay',
             [],
-            new \DateTime($this->year.'-5-4', new \DateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-5-4', new \DateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/Austria/UpperAustria.php
+++ b/src/Yasumi/Provider/Austria/UpperAustria.php
@@ -64,7 +64,7 @@ class UpperAustria extends Austria
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStFloriansDay(): void
+    protected function calculateStFloriansDay(): void
     {
         if ($this->year < 304) {
             return;

--- a/src/Yasumi/Provider/Austria/Vienna.php
+++ b/src/Yasumi/Provider/Austria/Vienna.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Austria/Vorarlberg.php
+++ b/src/Yasumi/Provider/Austria/Vorarlberg.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Belgium.php
+++ b/src/Yasumi/Provider/Belgium.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Bosnia.php
+++ b/src/Yasumi/Provider/Bosnia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Brazil.php
+++ b/src/Yasumi/Provider/Brazil.php
@@ -79,7 +79,7 @@ class Brazil extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Proclamation_of_the_Republic_(Brazil)
      */
-    private function calculateProclamationOfRepublicDay(): void
+    protected function calculateProclamationOfRepublicDay(): void
     {
         if ($this->year >= 1889) {
             $this->addHoliday(new Holiday(
@@ -97,7 +97,7 @@ class Brazil extends AbstractProvider
      *
      * @link http://www.johninbrazil.org/all-souls-day-o-dia-dos-finados/
      */
-    private function calculateAllSoulsDay(): void
+    protected function calculateAllSoulsDay(): void
     {
         if ($this->year >= 1300) {
             $this->addHoliday(new Holiday(
@@ -120,7 +120,7 @@ class Brazil extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Our_Lady_of_Aparecida
      */
-    private function calculateOurLadyOfAparecidaDay(): void
+    protected function calculateOurLadyOfAparecidaDay(): void
     {
         if ($this->year >= 1980) {
             $this->addHoliday(new Holiday(
@@ -140,7 +140,7 @@ class Brazil extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Independence_of_Brazil
      */
-    private function calculateIndependenceDay(): void
+    protected function calculateIndependenceDay(): void
     {
         if ($this->year >= 1822) {
             $this->addHoliday(new Holiday(
@@ -161,7 +161,7 @@ class Brazil extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Tiradentes
      */
-    private function calculateTiradentesDay(): void
+    protected function calculateTiradentesDay(): void
     {
         if ($this->year >= 1792) {
             $this->addHoliday(new Holiday(
@@ -181,7 +181,7 @@ class Brazil extends AbstractProvider
      *
      * @link https://en.wikipedia.org/wiki/Brazilian_Carnival
      */
-    private function calculateCarnival(): void
+    protected function calculateCarnival(): void
     {
         if ($this->year >= 1700) {
             $easter = $this->calculateEaster($this->year, $this->timezone);

--- a/src/Yasumi/Provider/Brazil.php
+++ b/src/Yasumi/Provider/Brazil.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada.php
+++ b/src/Yasumi/Provider/Canada.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -176,9 +178,9 @@ class Canada extends AbstractProvider
         if ($this->year < 1983) {
             return;
         }
-        $date = new \DateTime($this->year.'-07-01', DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime($this->year . '-07-01', DateTimeZoneFactory::getDateTimeZone($this->timezone));
         if (7 === (int) $date->format('N')) {
-            $date = new \DateTime($this->year.'-07-02', DateTimeZoneFactory::getDateTimeZone($this->timezone));
+            $date = new \DateTime($this->year . '-07-02', DateTimeZoneFactory::getDateTimeZone($this->timezone));
         }
         $this->addHoliday(new Holiday(
             'canadaDay',

--- a/src/Yasumi/Provider/Canada.php
+++ b/src/Yasumi/Provider/Canada.php
@@ -171,7 +171,7 @@ class Canada extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateCanadaDay(): void
+    protected function calculateCanadaDay(): void
     {
         if ($this->year < 1983) {
             return;
@@ -197,7 +197,7 @@ class Canada extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateThanksgivingDay(): void
+    protected function calculateThanksgivingDay(): void
     {
         if ($this->year < 1879) {
             return;
@@ -220,7 +220,7 @@ class Canada extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateRemembranceDay(): void
+    protected function calculateRemembranceDay(): void
     {
         if ($this->year < 1919) {
             return;
@@ -243,7 +243,7 @@ class Canada extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateLabourDay(): void
+    protected function calculateLabourDay(): void
     {
         if ($this->year < 1894) {
             return;
@@ -266,7 +266,7 @@ class Canada extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalDayForTruthAndReconciliation(): void
+    protected function calculateNationalDayForTruthAndReconciliation(): void
     {
         if ($this->year < 2021) {
             return;

--- a/src/Yasumi/Provider/Canada/Alberta.php
+++ b/src/Yasumi/Provider/Canada/Alberta.php
@@ -62,7 +62,7 @@ class Alberta extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateHeritageDay(): void
+    protected function calculateHeritageDay(): void
     {
         if ($this->year < 1879) {
             return;

--- a/src/Yasumi/Provider/Canada/Alberta.php
+++ b/src/Yasumi/Provider/Canada/Alberta.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/BritishColumbia.php
+++ b/src/Yasumi/Provider/Canada/BritishColumbia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/Manitoba.php
+++ b/src/Yasumi/Provider/Canada/Manitoba.php
@@ -85,7 +85,7 @@ class Manitoba extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateLouisRielDay(): void
+    protected function calculateLouisRielDay(): void
     {
         if ($this->year < 2008) {
             return;

--- a/src/Yasumi/Provider/Canada/Manitoba.php
+++ b/src/Yasumi/Provider/Canada/Manitoba.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/NewBrunswick.php
+++ b/src/Yasumi/Provider/Canada/NewBrunswick.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/NewfoundlandAndLabrador.php
+++ b/src/Yasumi/Provider/Canada/NewfoundlandAndLabrador.php
@@ -69,7 +69,7 @@ class NewfoundlandAndLabrador extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStPatricksDay(): void
+    protected function calculateStPatricksDay(): void
     {
         if ($this->year < 1971) {
             return;
@@ -113,7 +113,7 @@ class NewfoundlandAndLabrador extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateOrangemensDay(): void
+    protected function calculateOrangemensDay(): void
     {
         if ($this->year < 1926) {
             return;

--- a/src/Yasumi/Provider/Canada/NewfoundlandAndLabrador.php
+++ b/src/Yasumi/Provider/Canada/NewfoundlandAndLabrador.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -78,7 +80,7 @@ class NewfoundlandAndLabrador extends Canada
         $holiday = new Holiday(
             'stPatricksDay',
             ['en' => 'St. Patrick’s Day'],
-            new \DateTime($this->year.'-3-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-3-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         );
@@ -122,7 +124,7 @@ class NewfoundlandAndLabrador extends Canada
         $holiday = new Holiday(
             'orangemensDay',
             [],
-            new \DateTime($this->year.'-7-12', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-7-12', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         );

--- a/src/Yasumi/Provider/Canada/NorthwestTerritories.php
+++ b/src/Yasumi/Provider/Canada/NorthwestTerritories.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/NovaScotia.php
+++ b/src/Yasumi/Provider/Canada/NovaScotia.php
@@ -85,7 +85,7 @@ class NovaScotia extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateHeritageDay(): void
+    protected function calculateHeritageDay(): void
     {
         if ($this->year < 2015) {
             return;

--- a/src/Yasumi/Provider/Canada/NovaScotia.php
+++ b/src/Yasumi/Provider/Canada/NovaScotia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/Nunavut.php
+++ b/src/Yasumi/Provider/Canada/Nunavut.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/Ontario.php
+++ b/src/Yasumi/Provider/Canada/Ontario.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/PrinceEdwardIsland.php
+++ b/src/Yasumi/Provider/Canada/PrinceEdwardIsland.php
@@ -62,7 +62,7 @@ class PrinceEdwardIsland extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateIslanderDay(): void
+    protected function calculateIslanderDay(): void
     {
         if ($this->year < 2009) {
             return;
@@ -85,7 +85,7 @@ class PrinceEdwardIsland extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateGoldCupParadeDay(): void
+    protected function calculateGoldCupParadeDay(): void
     {
         if ($this->year < 1962) {
             return;

--- a/src/Yasumi/Provider/Canada/PrinceEdwardIsland.php
+++ b/src/Yasumi/Provider/Canada/PrinceEdwardIsland.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/Quebec.php
+++ b/src/Yasumi/Provider/Canada/Quebec.php
@@ -73,7 +73,7 @@ class Quebec extends Canada
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function saintJeanBaptisteDay(
+    protected function saintJeanBaptisteDay(
         int $year,
         string $timezone,
         string $locale,
@@ -97,7 +97,7 @@ class Quebec extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalPatriotsDay(): void
+    protected function calculateNationalPatriotsDay(): void
     {
         if ($this->year < 2003) {
             return;

--- a/src/Yasumi/Provider/Canada/Quebec.php
+++ b/src/Yasumi/Provider/Canada/Quebec.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/Saskatchewan.php
+++ b/src/Yasumi/Provider/Canada/Saskatchewan.php
@@ -62,7 +62,7 @@ class Saskatchewan extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSaskatchewanDay(): void
+    protected function calculateSaskatchewanDay(): void
     {
         if ($this->year < 1879) {
             return;

--- a/src/Yasumi/Provider/Canada/Saskatchewan.php
+++ b/src/Yasumi/Provider/Canada/Saskatchewan.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Canada/Yukon.php
+++ b/src/Yasumi/Provider/Canada/Yukon.php
@@ -63,7 +63,7 @@ class Yukon extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDiscoveryDay(): void
+    protected function calculateDiscoveryDay(): void
     {
         if ($this->year < 1897) {
             return;
@@ -86,7 +86,7 @@ class Yukon extends Canada
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateHeritageDay(): void
+    protected function calculateHeritageDay(): void
     {
         if ($this->year < 2009) {
             return;

--- a/src/Yasumi/Provider/Canada/Yukon.php
+++ b/src/Yasumi/Provider/Canada/Yukon.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/ChristianHolidays.php
+++ b/src/Yasumi/Provider/ChristianHolidays.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -382,7 +384,7 @@ trait ChristianHolidays
         }
 
         $easter = new \DateTime("{$year}-3-21", DateTimeZoneFactory::getDateTimeZone($timezone));
-        $easter->add(new \DateInterval('P'.$easterDays.'D'));
+        $easter->add(new \DateInterval('P' . $easterDays . 'D'));
 
         return $easter;
     }

--- a/src/Yasumi/Provider/CommonHolidays.php
+++ b/src/Yasumi/Provider/CommonHolidays.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Croatia.php
+++ b/src/Yasumi/Provider/Croatia.php
@@ -82,7 +82,7 @@ class Croatia extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateStatehoodDay(): void
+    protected function calculateStatehoodDay(): void
     {
         if ($this->year >= 1991) {
             $statehoodDayDate = new \DateTime($this->year >= 2020 ? "{$this->year}-5-30" : "{$this->year}-6-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
@@ -99,7 +99,7 @@ class Croatia extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateHomelandThanksgivingDay(): void
+    protected function calculateHomelandThanksgivingDay(): void
     {
         $names = [];
         if ($this->year >= 1995 && $this->year < 2020) {
@@ -127,7 +127,7 @@ class Croatia extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateIndependenceDay(): void
+    protected function calculateIndependenceDay(): void
     {
         if ($this->year < 1991) {
             return;
@@ -149,7 +149,7 @@ class Croatia extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateRemembranceDayForHomelandWarVictims(): void
+    protected function calculateRemembranceDayForHomelandWarVictims(): void
     {
         if ($this->year >= 2020) {
             $this->addHoliday(new Holiday('remembranceDay', [
@@ -162,7 +162,7 @@ class Croatia extends AbstractProvider
     /*
      * Day of Antifascist Struggle
      */
-    private function calculateAntiFascistsStruggleDay(): void
+    protected function calculateAntiFascistsStruggleDay(): void
     {
         if ($this->year >= 1941) {
             $this->addHoliday(new Holiday('antifascistStruggleDay', [

--- a/src/Yasumi/Provider/Croatia.php
+++ b/src/Yasumi/Provider/Croatia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/CzechRepublic.php
+++ b/src/Yasumi/Provider/CzechRepublic.php
@@ -80,7 +80,7 @@ class CzechRepublic extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateRenewalOfCzechIndependenceDay(): void
+    protected function calculateRenewalOfCzechIndependenceDay(): void
     {
         $this->addHoliday(new Holiday(
             'czechRenewalOfIndependentStateDay',
@@ -113,7 +113,7 @@ class CzechRepublic extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSaintsCyrilAndMethodiusDay(): void
+    protected function calculateSaintsCyrilAndMethodiusDay(): void
     {
         $this->addHoliday(new Holiday(
             'saintsCyrilAndMethodiusDay',
@@ -140,7 +140,7 @@ class CzechRepublic extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateJanHusDay(): void
+    protected function calculateJanHusDay(): void
     {
         $this->addHoliday(new Holiday(
             'janHusDay',
@@ -167,7 +167,7 @@ class CzechRepublic extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateCzechStatehoodDay(): void
+    protected function calculateCzechStatehoodDay(): void
     {
         $this->addHoliday(new Holiday(
             'czechStateHoodDay',
@@ -189,7 +189,7 @@ class CzechRepublic extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateIndependentCzechoslovakStateDay(): void
+    protected function calculateIndependentCzechoslovakStateDay(): void
     {
         $this->addHoliday(new Holiday('independentCzechoslovakStateDay', [
             'cs' => 'Den vzniku samostatného československého státu',
@@ -206,7 +206,7 @@ class CzechRepublic extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStruggleForFreedomAndDemocracyDay(): void
+    protected function calculateStruggleForFreedomAndDemocracyDay(): void
     {
         $this->addHoliday(new Holiday(
             'struggleForFreedomAndDemocracyDay',

--- a/src/Yasumi/Provider/CzechRepublic.php
+++ b/src/Yasumi/Provider/CzechRepublic.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -88,7 +90,7 @@ class CzechRepublic extends AbstractProvider
                 'cs' => 'Den obnovy samostatného českého státu',
                 'en' => 'Day of renewal of the independent Czech state',
             ],
-            new \DateTime($this->year.'-01-01', new \DateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-01-01', new \DateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -121,7 +123,7 @@ class CzechRepublic extends AbstractProvider
                 'cs' => 'Den slovanských věrozvěstů Cyrila a Metoděje',
                 'en' => 'Saints Cyril and Methodius Day',
             ],
-            new \DateTime($this->year.'-07-5', new \DateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-07-5', new \DateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -145,7 +147,7 @@ class CzechRepublic extends AbstractProvider
         $this->addHoliday(new Holiday(
             'janHusDay',
             ['cs' => 'Den upálení mistra Jana Husa', 'en' => 'Jan Hus Day'],
-            new \DateTime($this->year.'-07-6', new \DateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-07-6', new \DateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -175,7 +177,7 @@ class CzechRepublic extends AbstractProvider
                 'cs' => 'Den české státnosti',
                 'en' => 'St. Wenceslas Day (Czech Statehood Day)',
             ],
-            new \DateTime($this->year.'-09-28', new \DateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-09-28', new \DateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -194,7 +196,7 @@ class CzechRepublic extends AbstractProvider
         $this->addHoliday(new Holiday('independentCzechoslovakStateDay', [
             'cs' => 'Den vzniku samostatného československého státu',
             'en' => 'Independent Czechoslovak State Day',
-        ], new \DateTime($this->year.'-10-28', new \DateTimeZone($this->timezone)), $this->locale));
+        ], new \DateTime($this->year . '-10-28', new \DateTimeZone($this->timezone)), $this->locale));
     }
 
     /**
@@ -214,7 +216,7 @@ class CzechRepublic extends AbstractProvider
                 'cs' => 'Den boje za svobodu a demokracii',
                 'en' => 'Struggle for Freedom and Democracy Day',
             ],
-            new \DateTime($this->year.'-11-17', new \DateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-11-17', new \DateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/DateTimeZoneFactory.php
+++ b/src/Yasumi/Provider/DateTimeZoneFactory.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Denmark.php
+++ b/src/Yasumi/Provider/Denmark.php
@@ -87,7 +87,7 @@ class Denmark extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateGreatPrayerDay(): void
+    protected function calculateGreatPrayerDay(): void
     {
         $easter = $this->calculateEaster($this->year, $this->timezone)->format('Y-m-d');
 
@@ -122,7 +122,7 @@ class Denmark extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateConstitutionDay(): void
+    protected function calculateConstitutionDay(): void
     {
         if ($this->year >= 1849) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Denmark.php
+++ b/src/Yasumi/Provider/Denmark.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Estonia.php
+++ b/src/Yasumi/Provider/Estonia.php
@@ -76,7 +76,7 @@ class Estonia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addIndependenceDay(): void
+    protected function addIndependenceDay(): void
     {
         if ($this->year >= self::DECLARATION_OF_INDEPENDENCE_YEAR) {
             $this->addHoliday(new Holiday('independenceDay', [
@@ -90,7 +90,7 @@ class Estonia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addVictoryDay(): void
+    protected function addVictoryDay(): void
     {
         if ($this->year >= self::VICTORY_DAY_START_YEAR) {
             $this->addHoliday(new Holiday('victoryDay', [
@@ -104,7 +104,7 @@ class Estonia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addRestorationOfIndependenceDay(): void
+    protected function addRestorationOfIndependenceDay(): void
     {
         if ($this->year >= self::RESTORATION_OF_INDEPENDENCE_YEAR) {
             $this->addHoliday(new Holiday('restorationOfIndependenceDay', [

--- a/src/Yasumi/Provider/Estonia.php
+++ b/src/Yasumi/Provider/Estonia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Finland.php
+++ b/src/Yasumi/Provider/Finland.php
@@ -90,7 +90,7 @@ class Finland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStJohnsDay(): void
+    protected function calculateStJohnsDay(): void
     {
         $stJohnsDay = $this->year < 1955 ? "{$this->year}-6-24" : "{$this->year}-6-20 this saturday";
 
@@ -123,7 +123,7 @@ class Finland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateAllSaintsDay(): void
+    protected function calculateAllSaintsDay(): void
     {
         $this->addHoliday(new Holiday(
             'allSaintsDay',
@@ -150,7 +150,7 @@ class Finland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateIndependenceDay(): void
+    protected function calculateIndependenceDay(): void
     {
         if ($this->year >= 1917) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Finland.php
+++ b/src/Yasumi/Provider/Finland.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/France.php
+++ b/src/Yasumi/Provider/France.php
@@ -93,7 +93,7 @@ class France extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateBastilleDay(): void
+    protected function calculateBastilleDay(): void
     {
         if ($this->year >= 1790) {
             $this->addHoliday(new Holiday('bastilleDay', [
@@ -115,7 +115,7 @@ class France extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculatePentecostMonday(): void
+    protected function calculatePentecostMonday(): void
     {
         $type = Holiday::TYPE_OFFICIAL;
 

--- a/src/Yasumi/Provider/France.php
+++ b/src/Yasumi/Provider/France.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/France/BasRhin.php
+++ b/src/Yasumi/Provider/France/BasRhin.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/France/HautRhin.php
+++ b/src/Yasumi/Provider/France/HautRhin.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/France/Moselle.php
+++ b/src/Yasumi/Provider/France/Moselle.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Georgia.php
+++ b/src/Yasumi/Provider/Georgia.php
@@ -87,7 +87,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addOrthodoxChristmasDay(): void
+    protected function addOrthodoxChristmasDay(): void
     {
         $date = new \DateTime("{$this->year}-01-07", new \DateTimeZone($this->timezone));
 
@@ -101,7 +101,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addIndependenceDay(): void
+    protected function addIndependenceDay(): void
     {
         if ($this->year >= self::PROCLAMATION_OF_INDEPENDENCE_YEAR) {
             $date = new \DateTime("{$this->year}-05-26", new \DateTimeZone($this->timezone));
@@ -117,7 +117,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addUnityDay(): void
+    protected function addUnityDay(): void
     {
         if ($this->year >= self::APRIL_NINE_TRAGEDY_YEAR) {
             $date = new \DateTime("{$this->year}-04-09", new \DateTimeZone($this->timezone));
@@ -133,7 +133,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addMothersDay(): void
+    protected function addMothersDay(): void
     {
         $date = new \DateTime("{$this->year}-03-03", new \DateTimeZone($this->timezone));
 
@@ -147,7 +147,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addVictoryDay(): void
+    protected function addVictoryDay(): void
     {
         $date = new \DateTime("{$this->year}-05-09", new \DateTimeZone($this->timezone));
 
@@ -161,7 +161,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addStAndrewsDay(): void
+    protected function addStAndrewsDay(): void
     {
         $date = new \DateTime("{$this->year}-05-12", new \DateTimeZone($this->timezone));
 
@@ -175,7 +175,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addOrthodoxEpiphanyDay(): void
+    protected function addOrthodoxEpiphanyDay(): void
     {
         $date = new \DateTime("{$this->year}-01-19", new \DateTimeZone($this->timezone));
 
@@ -189,7 +189,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addStMarysDay(): void
+    protected function addStMarysDay(): void
     {
         $date = new \DateTime("{$this->year}-08-28", new \DateTimeZone($this->timezone));
 
@@ -203,7 +203,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addMtskhetobaDay(): void
+    protected function addMtskhetobaDay(): void
     {
         $date = new \DateTime("{$this->year}-10-14", new \DateTimeZone($this->timezone));
 
@@ -217,7 +217,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addStGeorgesDay(): void
+    protected function addStGeorgesDay(): void
     {
         $date = new \DateTime("{$this->year}-11-23", new \DateTimeZone($this->timezone));
 
@@ -231,7 +231,7 @@ class Georgia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addSecondNewYearDay(): void
+    protected function addSecondNewYearDay(): void
     {
         $date = new \DateTime("{$this->year}-01-02", new \DateTimeZone($this->timezone));
 

--- a/src/Yasumi/Provider/Georgia.php
+++ b/src/Yasumi/Provider/Georgia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany.php
+++ b/src/Yasumi/Provider/Germany.php
@@ -55,7 +55,7 @@ class Germany extends AbstractProvider
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
         $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
 

--- a/src/Yasumi/Provider/Germany.php
+++ b/src/Yasumi/Provider/Germany.php
@@ -90,7 +90,7 @@ class Germany extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateGermanUnityDay(): void
+    protected function calculateGermanUnityDay(): void
     {
         if ($this->year >= 1990) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Germany.php
+++ b/src/Yasumi/Provider/Germany.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -96,7 +98,7 @@ class Germany extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'germanUnityDay',
                 ['de' => 'Tag der Deutschen Einheit'],
-                new \DateTime($this->year.'-10-3', new \DateTimeZone($this->timezone)),
+                new \DateTime($this->year . '-10-3', new \DateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Germany/BadenWurttemberg.php
+++ b/src/Yasumi/Provider/Germany/BadenWurttemberg.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/Bavaria.php
+++ b/src/Yasumi/Provider/Germany/Bavaria.php
@@ -50,5 +50,6 @@ class Bavaria extends Germany
         $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale, Holiday::TYPE_OTHER));
     }
 }

--- a/src/Yasumi/Provider/Germany/Berlin.php
+++ b/src/Yasumi/Provider/Germany/Berlin.php
@@ -74,7 +74,7 @@ class Berlin extends Germany
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function dayOfLiberation(
+    protected function dayOfLiberation(
         string $timezone,
         string $locale,
         string $type = Holiday::TYPE_OFFICIAL

--- a/src/Yasumi/Provider/Germany/Berlin.php
+++ b/src/Yasumi/Provider/Germany/Berlin.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/Brandenburg.php
+++ b/src/Yasumi/Provider/Germany/Brandenburg.php
@@ -61,7 +61,7 @@ class Brandenburg extends Germany
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateReformationDay(): void
+    protected function calculateReformationDay(): void
     {
         if ($this->year < 1517) {
             return;

--- a/src/Yasumi/Provider/Germany/Brandenburg.php
+++ b/src/Yasumi/Provider/Germany/Brandenburg.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/Bremen.php
+++ b/src/Yasumi/Provider/Germany/Bremen.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/Bremen.php
+++ b/src/Yasumi/Provider/Germany/Bremen.php
@@ -57,7 +57,7 @@ class Bremen extends Germany
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateReformationDay(): void
+    protected function calculateReformationDay(): void
     {
         if ($this->year < 2018) {
             return;

--- a/src/Yasumi/Provider/Germany/Hamburg.php
+++ b/src/Yasumi/Provider/Germany/Hamburg.php
@@ -58,7 +58,7 @@ class Hamburg extends Germany
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDayOfReformation(): void
+    protected function calculateDayOfReformation(): void
     {
         if ($this->year < 2018) {
             return;

--- a/src/Yasumi/Provider/Germany/Hamburg.php
+++ b/src/Yasumi/Provider/Germany/Hamburg.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/Hesse.php
+++ b/src/Yasumi/Provider/Germany/Hesse.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/LowerSaxony.php
+++ b/src/Yasumi/Provider/Germany/LowerSaxony.php
@@ -60,7 +60,7 @@ class LowerSaxony extends Germany
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateReformationDay(): void
+    protected function calculateReformationDay(): void
     {
         if ($this->year < 2018) {
             return;

--- a/src/Yasumi/Provider/Germany/LowerSaxony.php
+++ b/src/Yasumi/Provider/Germany/LowerSaxony.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/MecklenburgWesternPomerania.php
+++ b/src/Yasumi/Provider/Germany/MecklenburgWesternPomerania.php
@@ -70,7 +70,7 @@ class MecklenburgWesternPomerania extends Germany
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateReformationDay(): void
+    protected function calculateReformationDay(): void
     {
         if ($this->year < 1517) {
             return;

--- a/src/Yasumi/Provider/Germany/MecklenburgWesternPomerania.php
+++ b/src/Yasumi/Provider/Germany/MecklenburgWesternPomerania.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/NorthRhineWestphalia.php
+++ b/src/Yasumi/Provider/Germany/NorthRhineWestphalia.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/RhinelandPalatinate.php
+++ b/src/Yasumi/Provider/Germany/RhinelandPalatinate.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/Saarland.php
+++ b/src/Yasumi/Provider/Germany/Saarland.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/Saxony.php
+++ b/src/Yasumi/Provider/Germany/Saxony.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/Saxony.php
+++ b/src/Yasumi/Provider/Germany/Saxony.php
@@ -60,7 +60,7 @@ class Saxony extends Germany
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateReformationDay(): void
+    protected function calculateReformationDay(): void
     {
         if ($this->year < 1517) {
             return;
@@ -85,7 +85,7 @@ class Saxony extends Germany
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateRepentanceAndPrayerDay(): void
+    protected function calculateRepentanceAndPrayerDay(): void
     {
         if ($this->year >= 1995) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Germany/SaxonyAnhalt.php
+++ b/src/Yasumi/Provider/Germany/SaxonyAnhalt.php
@@ -58,7 +58,7 @@ class SaxonyAnhalt extends Germany
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateReformationDay(): void
+    protected function calculateReformationDay(): void
     {
         if ($this->year < 1517) {
             return;

--- a/src/Yasumi/Provider/Germany/SaxonyAnhalt.php
+++ b/src/Yasumi/Provider/Germany/SaxonyAnhalt.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/SchleswigHolstein.php
+++ b/src/Yasumi/Provider/Germany/SchleswigHolstein.php
@@ -57,7 +57,7 @@ class SchleswigHolstein extends Germany
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateReformationDay(): void
+    protected function calculateReformationDay(): void
     {
         if ($this->year < 2018) {
             return;

--- a/src/Yasumi/Provider/Germany/SchleswigHolstein.php
+++ b/src/Yasumi/Provider/Germany/SchleswigHolstein.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/Thuringia.php
+++ b/src/Yasumi/Provider/Germany/Thuringia.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Germany/Thuringia.php
+++ b/src/Yasumi/Provider/Germany/Thuringia.php
@@ -63,7 +63,7 @@ class Thuringia extends Germany
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateReformationDay(): void
+    protected function calculateReformationDay(): void
     {
         if ($this->year < 1517) {
             return;
@@ -77,7 +77,7 @@ class Thuringia extends Germany
      *
      * @throws \Exception
      */
-    private function calculateWorldChildrensDay(): void
+    protected function calculateWorldChildrensDay(): void
     {
         if ($this->year < 2019) {
             return;

--- a/src/Yasumi/Provider/Greece.php
+++ b/src/Yasumi/Provider/Greece.php
@@ -87,7 +87,7 @@ class Greece extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateThreeHolyHierarchs(): void
+    protected function calculateThreeHolyHierarchs(): void
     {
         $this->addHoliday(new Holiday(
             'threeHolyHierarchs',
@@ -111,7 +111,7 @@ class Greece extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateCleanMonday(): void
+    protected function calculateCleanMonday(): void
     {
         $holiday = 'cleanMonday';
         $date = $this->calculateEaster($this->year, $this->timezone)->sub(new \DateInterval('P48D'));
@@ -132,7 +132,7 @@ class Greece extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateEaster(int $year, string $timezone): \DateTimeInterface
+    protected function calculateEaster(int $year, string $timezone): \DateTimeInterface
     {
         return $this->calculateOrthodoxEaster($year, $timezone);
     }
@@ -148,7 +148,7 @@ class Greece extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateIndependenceDay(): void
+    protected function calculateIndependenceDay(): void
     {
         if ($this->year >= 1821) {
             $this->addHoliday(new Holiday(
@@ -171,7 +171,7 @@ class Greece extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateOhiDay(): void
+    protected function calculateOhiDay(): void
     {
         if ($this->year >= 1940) {
             $this->addHoliday(new Holiday(
@@ -194,7 +194,7 @@ class Greece extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculatePolytechnio(): void
+    protected function calculatePolytechnio(): void
     {
         if ($this->year >= 1973) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Greece.php
+++ b/src/Yasumi/Provider/Greece.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Hungary.php
+++ b/src/Yasumi/Provider/Hungary.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Iran.php
+++ b/src/Yasumi/Provider/Iran.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\Provider;
+
+use Yasumi\Exception\UnknownLocaleException;
+use Yasumi\Holiday;
+
+/**
+ * Note: Any Islamic holidays are not part of this provider yet. Islamic holidays are quite complex and at first,
+ * only Jalali holidays are implemented.
+ */
+class Iran extends AbstractProvider
+{
+    /** {@inheritdoc} */
+    public const ID = 'IR';
+
+    /**
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize(): void
+    {
+        $this->timezone = 'Asia/Tehran';
+
+        $this->addNowruz();
+        $this->addIslamicRepublicDay();
+        $this->addSizdahBedar();
+        $this->addDeathOfKhomeini();
+        $this->addRevoltOfKhordad15();
+        $this->addAnniversaryOfIslamicRevolution();
+        $this->addNationalizationOfTheIranianOilIndustry();
+    }
+
+    public function getSources(): array
+    {
+        return [
+            'https://en.wikipedia.org/wiki/Public_holidays_in_Iran',
+            'https://fa.wikipedia.org/wiki/%D8%AA%D8%B9%D8%B7%DB%8C%D9%84%D8%A7%D8%AA_%D8%B1%D8%B3%D9%85%DB%8C_%D8%AF%D8%B1_%D8%A7%DB%8C%D8%B1%D8%A7%D9%86',
+        ];
+    }
+
+    protected function addNowruz(): void
+    {
+        foreach ([21, 22, 23, 24] as $index => $day) {
+            ++$index;
+            $this->addHoliday(new Holiday("nowruz{$index}", [
+                'en' => 'Nowruz',
+                'fa' => 'نوروز',
+            ], new \DateTime("{$this->year}-03-{$day}", new \DateTimeZone($this->timezone)), $this->locale));
+        }
+    }
+
+    /**
+     * The day usually falls on 1 April, however, as it is determined by the vernal equinox, the date can change if the equinox does not fall on 21 March.
+     * In 2016, it was on 31 March, and in 2017, 2019, 2021, 2022 and 2023 the date was back to 1 April.
+     *
+     * @see https://en.wikipedia.org/wiki/Iranian_Islamic_Republic_Day
+     *
+     * @throws \Exception
+     */
+    protected function addIslamicRepublicDay(): void
+    {
+        if (1979 > $this->year) {
+            return;
+        }
+
+        $month = '04';
+        $day = '01';
+
+        if (2016 === $this->year) {
+            $month = '03';
+            $day = '31';
+        }
+
+        $this->addHoliday(new Holiday('islamicRepublicDay', [
+            'en' => 'Ruz e Jomhuri ye Eslami',
+            'fa' => 'روز جمهوری اسلامی',
+        ], new \DateTime("{$this->year}-{$month}-{$day}", new \DateTimeZone($this->timezone)), $this->locale));
+    }
+
+    protected function addSizdahBedar(): void
+    {
+        $this->addHoliday(new Holiday('sizdahBedar', [
+            'en' => 'Sizdah be dar',
+            'fa' => 'سیزده بدر',
+        ], new \DateTime("{$this->year}-04-02", new \DateTimeZone($this->timezone)), $this->locale));
+    }
+
+    protected function addDeathOfKhomeini(): void
+    {
+        if (1989 > $this->year) {
+            return;
+        }
+
+        $this->addHoliday(new Holiday('deathOfKhomeini', [
+            'en' => 'Marg e Khomeini',
+            'fa' => 'مرگ خمینی',
+        ], new \DateTime("{$this->year}-06-04", new \DateTimeZone($this->timezone)), $this->locale));
+    }
+
+    protected function addRevoltOfKhordad15(): void
+    {
+        if (1979 > $this->year) {
+            return;
+        }
+
+        $this->addHoliday(new Holiday('revoltOfKhordad15', [
+            'en' => 'Qiam e Panzdah e Khordad',
+            'fa' => 'قیام ۱۵ خرداد',
+        ], new \DateTime("{$this->year}-06-05", new \DateTimeZone($this->timezone)), $this->locale));
+    }
+
+    protected function addAnniversaryOfIslamicRevolution(): void
+    {
+        if (1979 > $this->year) {
+            return;
+        }
+
+        $this->addHoliday(new Holiday('anniversaryOfIslamicRevolution', [
+            'en' => 'Enqelab e Eslami',
+            'fa' => 'انقلاب اسلامی پنجاه و هفت',
+        ], new \DateTime("{$this->year}-02-11", new \DateTimeZone($this->timezone)), $this->locale));
+    }
+
+    protected function addNationalizationOfTheIranianOilIndustry(): void
+    {
+        if (1951 > $this->year) {
+            return;
+        }
+
+        $this->addHoliday(new Holiday('nationalizationOfTheIranianOilIndustry', [
+            'en' => 'Melli Shodan e Saneat e Naft',
+            'fa' => 'ملی شدن صنعت نفت',
+        ], new \DateTime("{$this->year}-03-20", new \DateTimeZone($this->timezone)), $this->locale));
+    }
+}

--- a/src/Yasumi/Provider/Ireland.php
+++ b/src/Yasumi/Provider/Ireland.php
@@ -99,7 +99,7 @@ class Ireland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNewYearsDay(): void
+    protected function calculateNewYearsDay(): void
     {
         if ($this->year < 1974) {
             return;
@@ -134,7 +134,7 @@ class Ireland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculatePentecostMonday(): void
+    protected function calculatePentecostMonday(): void
     {
         if ($this->year > 1973) {
             return;
@@ -155,7 +155,7 @@ class Ireland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateChristmasDay(): void
+    protected function calculateChristmasDay(): void
     {
         $holiday = new Holiday(
             'christmasDay',
@@ -193,7 +193,7 @@ class Ireland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStStephensDay(): void
+    protected function calculateStStephensDay(): void
     {
         $holiday = new Holiday(
             'stStephensDay',
@@ -233,7 +233,7 @@ class Ireland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStPatricksDay(): void
+    protected function calculateStPatricksDay(): void
     {
         if ($this->year < 1903) {
             return;
@@ -276,7 +276,7 @@ class Ireland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateMayDay(): void
+    protected function calculateMayDay(): void
     {
         if ($this->year < 1994) {
             return;
@@ -302,7 +302,7 @@ class Ireland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateJuneHoliday(): void
+    protected function calculateJuneHoliday(): void
     {
         if ($this->year < 1974) {
             return;
@@ -327,7 +327,7 @@ class Ireland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateOctoberHoliday(): void
+    protected function calculateOctoberHoliday(): void
     {
         if ($this->year < 1977) {
             return;

--- a/src/Yasumi/Provider/Ireland.php
+++ b/src/Yasumi/Provider/Ireland.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -160,7 +162,7 @@ class Ireland extends AbstractProvider
         $holiday = new Holiday(
             'christmasDay',
             ['en' => 'Christmas Day', 'ga' => 'Lá Nollag'],
-            new \DateTime($this->year.'-12-25', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-12-25', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         );
 
@@ -198,7 +200,7 @@ class Ireland extends AbstractProvider
         $holiday = new Holiday(
             'stStephensDay',
             [],
-            new \DateTime($this->year.'-12-26', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-12-26', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         );
 
@@ -241,7 +243,7 @@ class Ireland extends AbstractProvider
         $holiday = new Holiday(
             'stPatricksDay',
             ['en' => 'St. Patrick’s Day', 'ga' => 'Lá Fhéile Pádraig'],
-            new \DateTime($this->year.'-3-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-3-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         );
 

--- a/src/Yasumi/Provider/Italy.php
+++ b/src/Yasumi/Provider/Italy.php
@@ -85,7 +85,7 @@ class Italy extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateLiberationDay(): void
+    protected function calculateLiberationDay(): void
     {
         if ($this->year >= 1949) {
             $this->addHoliday(new Holiday(
@@ -111,7 +111,7 @@ class Italy extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateRepublicDay(): void
+    protected function calculateRepublicDay(): void
     {
         if ($this->year >= 1946) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Italy.php
+++ b/src/Yasumi/Provider/Italy.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Japan.php
+++ b/src/Yasumi/Provider/Japan.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -648,7 +650,7 @@ class Japan extends AbstractProvider
                 $bridgeDate = clone $previous;
                 $bridgeDate->add(new \DateInterval('P1D'));
 
-                $this->addHoliday(new Holiday('bridgeDay'.$counter, [
+                $this->addHoliday(new Holiday('bridgeDay' . $counter, [
                     'en' => 'Bridge Public holiday',
                     'ja' => '国民の休日',
                 ], $bridgeDate, $this->locale));

--- a/src/Yasumi/Provider/Japan.php
+++ b/src/Yasumi/Provider/Japan.php
@@ -118,7 +118,7 @@ class Japan extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateNationalFoundationDay(): void
+    protected function calculateNationalFoundationDay(): void
     {
         if ($this->year >= 1966) {
             $this->addHoliday(new Holiday(
@@ -138,7 +138,7 @@ class Japan extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateShowaDay(): void
+    protected function calculateShowaDay(): void
     {
         if ($this->year >= 2007) {
             $this->addHoliday(new Holiday(
@@ -158,7 +158,7 @@ class Japan extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateConstitutionMemorialDay(): void
+    protected function calculateConstitutionMemorialDay(): void
     {
         if ($this->year >= 1948) {
             $this->addHoliday(new Holiday(
@@ -178,7 +178,7 @@ class Japan extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateChildrensDay(): void
+    protected function calculateChildrensDay(): void
     {
         if ($this->year >= 1948) {
             $this->addHoliday(new Holiday(
@@ -198,7 +198,7 @@ class Japan extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateCultureDay(): void
+    protected function calculateCultureDay(): void
     {
         if ($this->year >= 1948) {
             $this->addHoliday(new Holiday(
@@ -215,7 +215,7 @@ class Japan extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateLaborThanksgivingDay(): void
+    protected function calculateLaborThanksgivingDay(): void
     {
         if ($this->year >= 1948) {
             $this->addHoliday(new Holiday(
@@ -235,7 +235,7 @@ class Japan extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateEmperorsBirthday(): void
+    protected function calculateEmperorsBirthday(): void
     {
         $emperorsBirthday = null;
         if ($this->year >= 2020) {
@@ -269,7 +269,7 @@ class Japan extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateVernalEquinoxDay(): void
+    protected function calculateVernalEquinoxDay(): void
     {
         $day = null;
         if ($this->year >= 1948 && $this->year <= 1979) {
@@ -304,7 +304,7 @@ class Japan extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateComingOfAgeDay(): void
+    protected function calculateComingOfAgeDay(): void
     {
         if ($this->year >= 1948) {
             $date = $this->year >= 2000 ?
@@ -329,7 +329,7 @@ class Japan extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateGreeneryDay(): void
+    protected function calculateGreeneryDay(): void
     {
         $date = null;
         if ($this->year >= 2007) {
@@ -358,7 +358,7 @@ class Japan extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateMarineDay(): void
+    protected function calculateMarineDay(): void
     {
         if (1996 > $this->year) {
             return;
@@ -397,7 +397,7 @@ class Japan extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateMountainDay(): void
+    protected function calculateMountainDay(): void
     {
         $date = null;
         if (2021 === $this->year) {
@@ -430,7 +430,7 @@ class Japan extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateRespectForTheAgeDay(): void
+    protected function calculateRespectForTheAgeDay(): void
     {
         $date = null;
         if ($this->year >= 2003) {
@@ -459,7 +459,7 @@ class Japan extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSportsDay(): void
+    protected function calculateSportsDay(): void
     {
         $date = null;
         if (2021 === $this->year) {
@@ -502,7 +502,7 @@ class Japan extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateAutumnalEquinoxDay(): void
+    protected function calculateAutumnalEquinoxDay(): void
     {
         $day = null;
         if ($this->year >= 1948 && $this->year <= 1979) {
@@ -537,7 +537,7 @@ class Japan extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSubstituteHolidays(): void
+    protected function calculateSubstituteHolidays(): void
     {
         // Get initial list of holiday dates
         $dates = $this->getHolidayDates();
@@ -584,7 +584,7 @@ class Japan extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateCoronationDay(): void
+    protected function calculateCoronationDay(): void
     {
         if (2019 === $this->year) {
             $this->addHoliday(new Holiday(
@@ -602,7 +602,7 @@ class Japan extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateEnthronementProclamationCeremony(): void
+    protected function calculateEnthronementProclamationCeremony(): void
     {
         if (2019 === $this->year) {
             $this->addHoliday(new Holiday(
@@ -623,7 +623,7 @@ class Japan extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateBridgeHolidays(): void
+    protected function calculateBridgeHolidays(): void
     {
         // Get initial list of holidays and iterator
         $datesIterator = $this->getIterator();

--- a/src/Yasumi/Provider/Latvia.php
+++ b/src/Yasumi/Provider/Latvia.php
@@ -78,7 +78,7 @@ class Latvia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addRestorationOfIndependenceDay(): void
+    protected function addRestorationOfIndependenceDay(): void
     {
         if ($this->year >= self::RESTORATION_OF_INDEPENDENCE_YEAR) {
             $date = new \DateTime("{$this->year}-05-04", new \DateTimeZone($this->timezone));
@@ -98,7 +98,7 @@ class Latvia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addMidsummerEveDay(): void
+    protected function addMidsummerEveDay(): void
     {
         $this->addHoliday(new Holiday('midsummerEveDay', [
             'en' => 'Midsummer Eve',
@@ -113,7 +113,7 @@ class Latvia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addProclamationDay(): void
+    protected function addProclamationDay(): void
     {
         if ($this->year >= self::PROCLAMATION_OF_INDEPENDENCE_YEAR) {
             $date = new \DateTime("{$this->year}-11-18", new \DateTimeZone($this->timezone));

--- a/src/Yasumi/Provider/Latvia.php
+++ b/src/Yasumi/Provider/Latvia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Lithuania.php
+++ b/src/Yasumi/Provider/Lithuania.php
@@ -94,7 +94,7 @@ class Lithuania extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addRestorationOfTheStateDay(): void
+    protected function addRestorationOfTheStateDay(): void
     {
         if ($this->year >= self::RESTORATION_OF_THE_STATE_YEAR) {
             $this->addHoliday(new Holiday('restorationOfTheStateOfLithuaniaDay', [
@@ -110,7 +110,7 @@ class Lithuania extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addRestorationOfIndependenceDay(): void
+    protected function addRestorationOfIndependenceDay(): void
     {
         if ($this->year >= self::RESTORATION_OF_INDEPENDENCE_YEAR) {
             $this->addHoliday(new Holiday('restorationOfIndependenceOfLithuaniaDay', [
@@ -127,7 +127,7 @@ class Lithuania extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addStatehoodDay(): void
+    protected function addStatehoodDay(): void
     {
         if ($this->year >= self::STATEHOOD_YEAR) {
             $this->addHoliday(new Holiday('statehoodDay', [
@@ -143,7 +143,7 @@ class Lithuania extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addAllSoulsDay(): void
+    protected function addAllSoulsDay(): void
     {
         if ($this->year >= self::ALL_SOULS_DAY) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Lithuania.php
+++ b/src/Yasumi/Provider/Lithuania.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Luxembourg.php
+++ b/src/Yasumi/Provider/Luxembourg.php
@@ -81,7 +81,7 @@ class Luxembourg extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateEuropeDay(): void
+    protected function calculateEuropeDay(): void
     {
         if ($this->year >= 2019) {
             $this->addHoliday(new Holiday('europeDay', [
@@ -106,7 +106,7 @@ class Luxembourg extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalDay(): void
+    protected function calculateNationalDay(): void
     {
         $this->addHoliday(new Holiday('nationalDay', [
             'en_US' => 'National day',

--- a/src/Yasumi/Provider/Luxembourg.php
+++ b/src/Yasumi/Provider/Luxembourg.php
@@ -10,7 +10,20 @@
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 namespace Yasumi\Provider;
 

--- a/src/Yasumi/Provider/Mexico.php
+++ b/src/Yasumi/Provider/Mexico.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 /**
- * Provider for all holidays in Mexico.
+ * This file is part of the 'Yasumi' package.
  *
- * This file is part of the Yasumi package.
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Mexico.php
+++ b/src/Yasumi/Provider/Mexico.php
@@ -92,7 +92,7 @@ class Mexico extends AbstractProvider
     *
     * @link https://en.wikipedia.org/wiki/Mexican_War_of_Independence
     */
-    private function addIndependenceDay(): void
+    protected function addIndependenceDay(): void
     {
         if ($this->year >= 1810) {
             $this->addHoliday(new Holiday(
@@ -112,7 +112,7 @@ class Mexico extends AbstractProvider
     *
     * Anniversary of the Constitution of 1917, originally February 5, observed on the first Monday of February.
     */
-    private function calculateConstitutionDay(): void
+    protected function calculateConstitutionDay(): void
     {
         if ($this->year >= 1917) {
             $this->addHoliday(new Holiday(
@@ -131,7 +131,7 @@ class Mexico extends AbstractProvider
     *
     * Anniversary of the birth of Benito Juárez on March 21, 1806, observed on the third Monday of March.
     */
-    private function calculateBenitoJuarezBirthday(): void
+    protected function calculateBenitoJuarezBirthday(): void
     {
         if ($this->year >= 1806 && $this->year < 2010) {
             $this->addHoliday(new Holiday(
@@ -161,7 +161,7 @@ class Mexico extends AbstractProvider
     *
     * Anniversary of the start of the Mexican Revolution on November 20, 1910, observed on the third Monday of November.
     */
-    private function calculateRevolutionDay(): void
+    protected function calculateRevolutionDay(): void
     {
         if ($this->year >= 1910) {
             $this->addHoliday(new Holiday(
@@ -180,7 +180,7 @@ class Mexico extends AbstractProvider
     *
     * Anniversary of the Discovery of America on October 12, 1492, observed on the second Monday of October.
     */
-    private function calculateDiscoveryOfAmerica(): void
+    protected function calculateDiscoveryOfAmerica(): void
     {
         if ($this->year >= 1492) {
             $this->addHoliday(new Holiday(
@@ -200,7 +200,7 @@ class Mexico extends AbstractProvider
     * Christmas Eve is the day before Christmas Day, which is annually on December 24, according to the Gregorian
     * calendar.
     */
-    private function calculateChristmasEve(): void
+    protected function calculateChristmasEve(): void
     {
         $this->addHoliday(new Holiday(
             'christmasEve',
@@ -217,7 +217,7 @@ class Mexico extends AbstractProvider
     *
     * New Year's Eve is the last day of the year, December 31, in the Gregorian calendar.
     */
-    private function calculateNewYearsEve(): void
+    protected function calculateNewYearsEve(): void
     {
         $this->addHoliday(new Holiday(
             'newYearsEve',
@@ -235,7 +235,7 @@ class Mexico extends AbstractProvider
      * Day of the Deaths is a Mexican holiday celebrated throughout Mexico, in particular the Central and South regions,
      * and by people of Mexican heritage elsewhere.
      */
-    private function calculateDayOfTheDead(): void
+    protected function calculateDayOfTheDead(): void
     {
         if ($this->year >= 1800) {
             $this->addHoliday(new Holiday(
@@ -255,7 +255,7 @@ class Mexico extends AbstractProvider
      * The Virgin of Guadalupe (Día de la Virgen de Guadalupe) is a celebration of the Virgin Mary,
      * who is the patron saint of Mexico. It is observed on December 12th.
      */
-    private function calculateVirginOfGuadalupe(): void
+    protected function calculateVirginOfGuadalupe(): void
     {
         if ($this->year >= 1531) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Netherlands.php
+++ b/src/Yasumi/Provider/Netherlands.php
@@ -101,7 +101,7 @@ class Netherlands extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateCarnival(): void
+    protected function calculateCarnival(): void
     {
         $easter = $this->calculateEaster($this->year, $this->timezone);
 
@@ -140,7 +140,7 @@ class Netherlands extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateStNicholasDay(): void
+    protected function calculateStNicholasDay(): void
     {
         /*
          * St. Nicholas' Day
@@ -166,7 +166,7 @@ class Netherlands extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateHalloween(): void
+    protected function calculateHalloween(): void
     {
         $this->addHoliday(new Holiday(
             'halloween',
@@ -185,7 +185,7 @@ class Netherlands extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculatePrincesDay(): void
+    protected function calculatePrincesDay(): void
     {
         $this->addHoliday(new Holiday(
             'princesDay',
@@ -205,7 +205,7 @@ class Netherlands extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateQueensday(): void
+    protected function calculateQueensday(): void
     {
         if ($this->year >= 1891 && $this->year <= 2013) {
             $date = new \DateTime("{$this->year}-4-30", DateTimeZoneFactory::getDateTimeZone($this->timezone));
@@ -235,7 +235,7 @@ class Netherlands extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateKingsday(): void
+    protected function calculateKingsday(): void
     {
         if ($this->year >= 2014) {
             $date = new \DateTime("{$this->year}-4-27", DateTimeZoneFactory::getDateTimeZone($this->timezone));
@@ -260,7 +260,7 @@ class Netherlands extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateCommemorationLiberationDay(): void
+    protected function calculateCommemorationLiberationDay(): void
     {
         if ($this->year >= 1947) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Netherlands.php
+++ b/src/Yasumi/Provider/Netherlands.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/NewZealand.php
+++ b/src/Yasumi/Provider/NewZealand.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -217,7 +219,7 @@ class NewZealand extends AbstractProvider
         }
 
         $date = new \DateTime(
-            ($this->year < 1910 ? 'second wednesday of october' : 'fourth monday of october')." {$this->year}",
+            ($this->year < 1910 ? 'second wednesday of october' : 'fourth monday of october') . " {$this->year}",
             DateTimeZoneFactory::getDateTimeZone($this->timezone)
         );
 

--- a/src/Yasumi/Provider/NewZealand.php
+++ b/src/Yasumi/Provider/NewZealand.php
@@ -78,7 +78,7 @@ class NewZealand extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNewYearHolidays(): void
+    protected function calculateNewYearHolidays(): void
     {
         $newYearsDay = new \DateTime("{$this->year}-01-01", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $dayAfterNewYearsDay = new \DateTime("{$this->year}-01-02", DateTimeZoneFactory::getDateTimeZone($this->timezone));
@@ -117,7 +117,7 @@ class NewZealand extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateWaitangiDay(): void
+    protected function calculateWaitangiDay(): void
     {
         if ($this->year < 1974) {
             return;
@@ -146,7 +146,7 @@ class NewZealand extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateAnzacDay(): void
+    protected function calculateAnzacDay(): void
     {
         if ($this->year < 1921) {
             return;
@@ -178,7 +178,7 @@ class NewZealand extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateQueensBirthday(): void
+    protected function calculateQueensBirthday(): void
     {
         if ($this->year < 1952) {
             return;
@@ -210,7 +210,7 @@ class NewZealand extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateLabourDay(): void
+    protected function calculateLabourDay(): void
     {
         if ($this->year < 1900) {
             return;
@@ -238,7 +238,7 @@ class NewZealand extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateChristmasHolidays(): void
+    protected function calculateChristmasHolidays(): void
     {
         $christmasDay = new \DateTime("{$this->year}-12-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $boxingDay = new \DateTime("{$this->year}-12-26", DateTimeZoneFactory::getDateTimeZone($this->timezone));

--- a/src/Yasumi/Provider/Norway.php
+++ b/src/Yasumi/Provider/Norway.php
@@ -87,7 +87,7 @@ class Norway extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateConstitutionDay(): void
+    protected function calculateConstitutionDay(): void
     {
         if ($this->year >= 1836) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Norway.php
+++ b/src/Yasumi/Provider/Norway.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Poland.php
+++ b/src/Yasumi/Provider/Poland.php
@@ -85,7 +85,7 @@ class Poland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateIndependenceDay(): void
+    protected function calculateIndependenceDay(): void
     {
         if ($this->year < 1918) {
             return;
@@ -111,7 +111,7 @@ class Poland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateConstitutionDay(): void
+    protected function calculateConstitutionDay(): void
     {
         if ($this->year < 1791) {
             return;

--- a/src/Yasumi/Provider/Poland.php
+++ b/src/Yasumi/Provider/Poland.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -86,7 +86,7 @@ class Portugal extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateCarnationRevolutionDay(): void
+    protected function calculateCarnationRevolutionDay(): void
     {
         if ($this->year >= 1974) {
             $this->addHoliday(new Holiday(
@@ -107,7 +107,7 @@ class Portugal extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateCorpusChristi(): void
+    protected function calculateCorpusChristi(): void
     {
         if ($this->year <= 2012 || $this->year >= 2016) {
             $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
@@ -131,7 +131,7 @@ class Portugal extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculatePortugalDay(): void
+    protected function calculatePortugalDay(): void
     {
         if ($this->year <= 1932 || $this->year >= 1974) {
             $this->addHoliday(new Holiday(
@@ -164,7 +164,7 @@ class Portugal extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculatePortugueseRepublicDay(): void
+    protected function calculatePortugueseRepublicDay(): void
     {
         if (($this->year >= 1910 && $this->year <= 2012) || $this->year >= 2016) {
             $this->addHoliday(new Holiday(
@@ -184,7 +184,7 @@ class Portugal extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateAllSaintsDay(): void
+    protected function calculateAllSaintsDay(): void
     {
         if ($this->year <= 2012 || $this->year >= 2016) {
             $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
@@ -217,7 +217,7 @@ class Portugal extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateRestorationOfIndependenceDay(): void
+    protected function calculateRestorationOfIndependenceDay(): void
     {
         // The Wikipedia article mentions that this has been a holiday since the second of half of the XIX century.
         if (($this->year >= 1850 && $this->year <= 2012) || $this->year >= 2016) {

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Romania.php
+++ b/src/Yasumi/Provider/Romania.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -159,7 +161,7 @@ class Romania extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'stAndrewsDay',
                 [],
-                new \DateTime($this->year.'-11-30', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                new \DateTime($this->year . '-11-30', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }
@@ -222,7 +224,7 @@ class Romania extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'stJohnsDay',
                 [],
-                new \DateTime($this->year.'-01-07', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                new \DateTime($this->year . '-01-07', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale
             ));
         }

--- a/src/Yasumi/Provider/Romania.php
+++ b/src/Yasumi/Provider/Romania.php
@@ -108,7 +108,7 @@ class Romania extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDayAfterNewYearsDay(): void
+    protected function calculateDayAfterNewYearsDay(): void
     {
         $this->addHoliday(new Holiday(
             'dayAfterNewYearsDay',
@@ -131,7 +131,7 @@ class Romania extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateUnitedPrincipalitiesDay(): void
+    protected function calculateUnitedPrincipalitiesDay(): void
     {
         // The law is official since 21.12.2014.
         if ($this->year > 2014) {
@@ -153,7 +153,7 @@ class Romania extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStAndrewDay(): void
+    protected function calculateStAndrewDay(): void
     {
         if ($this->year >= 2012) {
             $this->addHoliday(new Holiday(
@@ -180,7 +180,7 @@ class Romania extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalDay(): void
+    protected function calculateNationalDay(): void
     {
         $nationalDay = null;
 
@@ -216,7 +216,7 @@ class Romania extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStJohnsDay(): void
+    protected function calculateStJohnsDay(): void
     {
         if ($this->year >= 2024) {
             $this->addHoliday(new Holiday(
@@ -239,7 +239,7 @@ class Romania extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateConstantinBrancusiDay(): void
+    protected function calculateConstantinBrancusiDay(): void
     {
         if ($this->year >= 2016) {
             $this->addHoliday(new Holiday(
@@ -267,7 +267,7 @@ class Romania extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateChildrensDay(): void
+    protected function calculateChildrensDay(): void
     {
         if ($this->year >= 1950 && $this->year <= 2016) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Russia.php
+++ b/src/Yasumi/Provider/Russia.php
@@ -72,7 +72,7 @@ class Russia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addNewYearsHolidays(): void
+    protected function addNewYearsHolidays(): void
     {
         $holidayDays = [2, 3, 4, 5, 6, 8];
 
@@ -88,7 +88,7 @@ class Russia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addOrthodoxChristmasDay(): void
+    protected function addOrthodoxChristmasDay(): void
     {
         $this->addHoliday(new Holiday('orthodoxChristmasDay', [
             'en' => 'Orthodox Christmas Day',
@@ -100,7 +100,7 @@ class Russia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addDefenceOfTheFatherlandDay(): void
+    protected function addDefenceOfTheFatherlandDay(): void
     {
         if ($this->year < self::DEFENCE_OF_THE_FATHERLAND_START_YEAR) {
             return;
@@ -116,7 +116,7 @@ class Russia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addInternationalWomensDay(): void
+    protected function addInternationalWomensDay(): void
     {
         $this->addHoliday($this->internationalWomensDay($this->year, $this->timezone, $this->locale));
     }
@@ -125,7 +125,7 @@ class Russia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addSpringAndLabourDay(): void
+    protected function addSpringAndLabourDay(): void
     {
         $this->addHoliday(new Holiday('springAndLabourDay', [
             'en' => 'Spring and Labour Day',
@@ -137,7 +137,7 @@ class Russia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addVictoryDay(): void
+    protected function addVictoryDay(): void
     {
         $this->addHoliday(new Holiday('victoryDay', [
             'en' => 'Victory Day',
@@ -149,7 +149,7 @@ class Russia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addRussiaDay(): void
+    protected function addRussiaDay(): void
     {
         if ($this->year < self::RUSSIA_DAY_START_YEAR) {
             return;
@@ -165,7 +165,7 @@ class Russia extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function addUnityDay(): void
+    protected function addUnityDay(): void
     {
         if ($this->year < self::UNITY_DAY_START_YEAR) {
             return;

--- a/src/Yasumi/Provider/Russia.php
+++ b/src/Yasumi/Provider/Russia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -77,7 +79,7 @@ class Russia extends AbstractProvider
         $holidayDays = [2, 3, 4, 5, 6, 8];
 
         foreach ($holidayDays as $day) {
-            $this->addHoliday(new Holiday('newYearHolidaysDay'.$day, [
+            $this->addHoliday(new Holiday('newYearHolidaysDay' . $day, [
                 'en' => 'New Year’s holidays',
                 'ru' => 'Новогодние каникулы',
             ], new \DateTime("{$this->year}-01-{$day}", new \DateTimeZone($this->timezone)), $this->locale));

--- a/src/Yasumi/Provider/Slovakia.php
+++ b/src/Yasumi/Provider/Slovakia.php
@@ -121,7 +121,7 @@ class Slovakia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSlovakIndependenceDay(): void
+    protected function calculateSlovakIndependenceDay(): void
     {
         $this->addHoliday(new Holiday(
             'slovakIndependenceDay',
@@ -145,7 +145,7 @@ class Slovakia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSaintsCyrilAndMethodiusDay(): void
+    protected function calculateSaintsCyrilAndMethodiusDay(): void
     {
         $this->addHoliday(new Holiday(
             'saintsCyrilAndMethodiusDay',
@@ -169,7 +169,7 @@ class Slovakia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSlovakNationalUprisingDay(): void
+    protected function calculateSlovakNationalUprisingDay(): void
     {
         $this->addHoliday(new Holiday(
             'slovakNationalUprisingDay',
@@ -192,7 +192,7 @@ class Slovakia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSlovakConstitutionDay(): void
+    protected function calculateSlovakConstitutionDay(): void
     {
         $this->addHoliday(new Holiday(
             'slovakConstitutionDay',
@@ -219,7 +219,7 @@ class Slovakia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateOurLadyOfSorrowsDay(): void
+    protected function calculateOurLadyOfSorrowsDay(): void
     {
         $this->addHoliday(new Holiday('ourLadyOfSorrowsDay', [
             'sk' => 'Sviatok Sedembolestnej Panny Márie',
@@ -236,7 +236,7 @@ class Slovakia extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStruggleForFreedomAndDemocracyDay(): void
+    protected function calculateStruggleForFreedomAndDemocracyDay(): void
     {
         $this->addHoliday(new Holiday(
             'struggleForFreedomAndDemocracyDay',

--- a/src/Yasumi/Provider/Slovakia.php
+++ b/src/Yasumi/Provider/Slovakia.php
@@ -86,10 +86,12 @@ class Slovakia extends AbstractProvider
         $this->calculateSaintsCyrilAndMethodiusDay();
         // 29.8.
         $this->calculateSlovakNationalUprisingDay();
-        // 1.9.
+        // 1.9.(<2024)
         $this->calculateSlovakConstitutionDay();
         // 15.9.
         $this->calculateOurLadyOfSorrowsDay();
+        // 30.10.2018
+        $this->calculateDeclarationOfTheSlovakNation();
         // 1.11.
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_BANK));
         // 17.11.
@@ -112,6 +114,31 @@ class Slovakia extends AbstractProvider
             'https://en.wikipedia.org/wiki/Public_holidays_in_Slovakia',
             'https://cs.wikipedia.org/wiki/St%C3%A1tn%C3%AD_sv%C3%A1tky_Slovenska',
         ];
+    }
+
+    /**
+     * Anniversary of the Declaration of the Slovak Nation.
+     * In 2018, October 30 was a one-time public holiday. For this reason, it was not a commemorative day in 2018.
+     *
+     * @see https://sk.wikipedia.org/wiki/Zoznam_sviatkov_na_Slovensku#endnote_pozn-01
+     *
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    protected function calculateDeclarationOfTheSlovakNation(): void
+    {
+        if (2018 === $this->year) {
+            $this->addHoliday(new Holiday(
+                'declarationOfTheSlovakNation',
+                [
+                    'sk' => 'Výročie Deklarácie slovenského národa',
+                    'en' => 'Anniversary of the Declaration of the Slovak Nation',
+                ],
+                new \DateTime($this->year . '-10-30', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
     }
 
     /**
@@ -189,6 +216,8 @@ class Slovakia extends AbstractProvider
      * Day of the Constitution of the Slovak Republic.
      *
      * @see https://en.wikipedia.org/wiki/Constitution_of_Slovakia
+     * Removed since 2024
+     * @see https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1993/241/
      *
      * @throws \InvalidArgumentException
      * @throws UnknownLocaleException
@@ -196,16 +225,18 @@ class Slovakia extends AbstractProvider
      */
     protected function calculateSlovakConstitutionDay(): void
     {
-        $this->addHoliday(new Holiday(
-            'slovakConstitutionDay',
-            [
-                'sk' => 'Deň Ústavy Slovenskej republiky',
-                'en' => 'Day of the Constitution of the Slovak Republic',
-            ],
-            new \DateTime($this->year . '-09-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_OFFICIAL
-        ));
+        if ($this->year < 2024) {
+            $this->addHoliday(new Holiday(
+                'slovakConstitutionDay',
+                [
+                    'sk' => 'Deň Ústavy Slovenskej republiky',
+                    'en' => 'Day of the Constitution of the Slovak Republic',
+                ],
+                new \DateTime($this->year . '-09-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_OFFICIAL
+            ));
+        }
     }
 
     /**

--- a/src/Yasumi/Provider/Slovakia.php
+++ b/src/Yasumi/Provider/Slovakia.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -129,7 +131,7 @@ class Slovakia extends AbstractProvider
                 'sk' => 'Deň vzniku Slovenskej republiky',
                 'en' => 'Day of the Establishment of the Slovak Republic',
             ],
-            new \DateTime($this->year.'-01-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-01-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -154,7 +156,7 @@ class Slovakia extends AbstractProvider
                 'cs' => 'Den slovanských věrozvěstů Cyrila a Metoděje',
                 'en' => 'Saints Cyril and Methodius Day',
             ],
-            new \DateTime($this->year.'-07-05', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-07-05', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -177,7 +179,7 @@ class Slovakia extends AbstractProvider
                 'sk' => 'Výročie Slovenského národného povstania',
                 'en' => 'Slovak National Uprising Day',
             ],
-            new \DateTime($this->year.'-08-29', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-08-29', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -200,7 +202,7 @@ class Slovakia extends AbstractProvider
                 'sk' => 'Deň Ústavy Slovenskej republiky',
                 'en' => 'Day of the Constitution of the Slovak Republic',
             ],
-            new \DateTime($this->year.'-09-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-09-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
@@ -224,7 +226,7 @@ class Slovakia extends AbstractProvider
         $this->addHoliday(new Holiday('ourLadyOfSorrowsDay', [
             'sk' => 'Sviatok Sedembolestnej Panny Márie',
             'en' => 'Our Lady of Sorrows Day',
-        ], new \DateTime($this->year.'-09-15', DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_BANK));
+        ], new \DateTime($this->year . '-09-15', DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_BANK));
     }
 
     /**
@@ -245,7 +247,7 @@ class Slovakia extends AbstractProvider
                 'cs' => 'Den boje za svobodu a demokracii',
                 'en' => 'Struggle for Freedom and Democracy Day',
             ],
-            new \DateTime($this->year.'-11-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-11-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));

--- a/src/Yasumi/Provider/SouthAfrica.php
+++ b/src/Yasumi/Provider/SouthAfrica.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -106,7 +108,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'humanRightsDay',
             ['en' => 'Human Rights Day'],
-            new \DateTime($this->year.'-3-21', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-3-21', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -149,7 +151,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'freedomDay',
             ['en' => 'Freedom Day'],
-            new \DateTime($this->year.'-4-27', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-4-27', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -175,7 +177,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'youthDay',
             ['en' => 'Youth Day'],
-            new \DateTime($this->year.'-6-16', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-6-16', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -225,7 +227,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'nationalWomensDay',
             ['en' => 'National Women’s Day'],
-            new \DateTime($this->year.'-8-9', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-8-9', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -249,7 +251,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'heritageDay',
             ['en' => 'Heritage Day'],
-            new \DateTime($this->year.'-9-24', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-9-24', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }
@@ -275,7 +277,7 @@ class SouthAfrica extends AbstractProvider
         $this->addHoliday(new Holiday(
             'reconciliationDay',
             ['en' => 'Day of Reconciliation'],
-            new \DateTime($this->year.'-12-16', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-12-16', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/SouthAfrica.php
+++ b/src/Yasumi/Provider/SouthAfrica.php
@@ -101,7 +101,7 @@ class SouthAfrica extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateHumanRightsDay(): void
+    protected function calculateHumanRightsDay(): void
     {
         $this->addHoliday(new Holiday(
             'humanRightsDay',
@@ -122,7 +122,7 @@ class SouthAfrica extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateFamilyDay(): void
+    protected function calculateFamilyDay(): void
     {
         $this->addHoliday(new Holiday(
             'familyDay',
@@ -144,7 +144,7 @@ class SouthAfrica extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateFreedomDay(): void
+    protected function calculateFreedomDay(): void
     {
         $this->addHoliday(new Holiday(
             'freedomDay',
@@ -170,7 +170,7 @@ class SouthAfrica extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateYouthDay(): void
+    protected function calculateYouthDay(): void
     {
         $this->addHoliday(new Holiday(
             'youthDay',
@@ -192,7 +192,7 @@ class SouthAfrica extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculate2016MunicipalElectionsDay(): void
+    protected function calculate2016MunicipalElectionsDay(): void
     {
         if (2016 !== $this->year) {
             return;
@@ -220,7 +220,7 @@ class SouthAfrica extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalWomensDay(): void
+    protected function calculateNationalWomensDay(): void
     {
         $this->addHoliday(new Holiday(
             'nationalWomensDay',
@@ -244,7 +244,7 @@ class SouthAfrica extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateHeritageDay(): void
+    protected function calculateHeritageDay(): void
     {
         $this->addHoliday(new Holiday(
             'heritageDay',
@@ -270,7 +270,7 @@ class SouthAfrica extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDayOfReconciliation(): void
+    protected function calculateDayOfReconciliation(): void
     {
         $this->addHoliday(new Holiday(
             'reconciliationDay',
@@ -295,7 +295,7 @@ class SouthAfrica extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSubstituteDayOfGoodwill(): void
+    protected function calculateSubstituteDayOfGoodwill(): void
     {
         if (2016 !== $this->year) {
             return;
@@ -319,7 +319,7 @@ class SouthAfrica extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSubstituteHolidays(): void
+    protected function calculateSubstituteHolidays(): void
     {
         // Loop through all defined holidays
         foreach ($this->getHolidays() as $holiday) {

--- a/src/Yasumi/Provider/SouthKorea.php
+++ b/src/Yasumi/Provider/SouthKorea.php
@@ -725,7 +725,7 @@ class SouthKorea extends AbstractProvider
      *
      * @return array<string> list of holidays
      */
-    private function calculateBefore2013(int $year): array
+    protected function calculateBefore2013(int $year): array
     {
         $officialHolidays = [];
 
@@ -797,7 +797,7 @@ class SouthKorea extends AbstractProvider
      *
      * @return array<string> list of holidays
      */
-    private function calculateCurrent(): array
+    protected function calculateCurrent(): array
     {
         return [
             'newYearsDay',
@@ -832,7 +832,7 @@ class SouthKorea extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateOldSubstituteHolidays(int $year): void
+    protected function calculateOldSubstituteHolidays(int $year): void
     {
         // Add substitute holidays by fixed entries.
         switch ($year) {
@@ -891,7 +891,7 @@ class SouthKorea extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateSubstituteHolidays(int $year): void
+    protected function calculateSubstituteHolidays(int $year): void
     {
         if ($year < 2023) {
             $this->calculateOldSubstituteHolidays($year);
@@ -949,7 +949,7 @@ class SouthKorea extends AbstractProvider
      *
      * @return array<string, array<int>>
      */
-    private function calculateAcceptedSubstituteHolidays(int $year): array
+    protected function calculateAcceptedSubstituteHolidays(int $year): array
     {
         // List of holidays allowed for substitution.
         // This dictionary has key => value mappings.
@@ -981,7 +981,7 @@ class SouthKorea extends AbstractProvider
     /**
      * Helper method to find a first working day after specific date.
      */
-    private function nextWorkingDay(\DateTime $date): \DateTime
+    protected function nextWorkingDay(\DateTime $date): \DateTime
     {
         $interval = new \DateInterval('P1D');
         $next = clone $date;
@@ -999,7 +999,7 @@ class SouthKorea extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function addSubstituteHoliday(?Holiday $origin, string $date_str): void
+    protected function addSubstituteHoliday(?Holiday $origin, string $date_str): void
     {
         if (! $origin instanceof Holiday) {
             return;

--- a/src/Yasumi/Provider/SouthKorea.php
+++ b/src/Yasumi/Provider/SouthKorea.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -918,7 +920,7 @@ class SouthKorea extends AbstractProvider
 
             $dayOfWeek = (int) $holiday->format('w');
             if (\in_array($dayOfWeek, $acceptedHolidays[$name], true)) {
-                $dates[$day]['weekend:'.$day] = $name;
+                $dates[$day]['weekend:' . $day] = $name;
             }
         }
 

--- a/src/Yasumi/Provider/Spain.php
+++ b/src/Yasumi/Provider/Spain.php
@@ -84,7 +84,7 @@ class Spain extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalDay(): void
+    protected function calculateNationalDay(): void
     {
         if ($this->year >= 1981) {
             $this->addHoliday(new Holiday(
@@ -112,7 +112,7 @@ class Spain extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateConstitutionDay(): void
+    protected function calculateConstitutionDay(): void
     {
         if ($this->year >= 1978) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain.php
+++ b/src/Yasumi/Provider/Spain.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/Andalusia.php
+++ b/src/Yasumi/Provider/Spain/Andalusia.php
@@ -71,7 +71,7 @@ class Andalusia extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateAndalusiaDay(): void
+    protected function calculateAndalusiaDay(): void
     {
         if ($this->year >= 1980) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain/Andalusia.php
+++ b/src/Yasumi/Provider/Spain/Andalusia.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/Aragon.php
+++ b/src/Yasumi/Provider/Spain/Aragon.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/Asturias.php
+++ b/src/Yasumi/Provider/Spain/Asturias.php
@@ -73,7 +73,7 @@ class Asturias extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateAsturiasDay(): void
+    protected function calculateAsturiasDay(): void
     {
         if ($this->year >= 1984) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain/Asturias.php
+++ b/src/Yasumi/Provider/Spain/Asturias.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/BalearicIslands.php
+++ b/src/Yasumi/Provider/Spain/BalearicIslands.php
@@ -73,7 +73,7 @@ class BalearicIslands extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateBalearicIslandsDay(): void
+    protected function calculateBalearicIslandsDay(): void
     {
         if ($this->year >= 1983) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain/BalearicIslands.php
+++ b/src/Yasumi/Provider/Spain/BalearicIslands.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/BasqueCountry.php
+++ b/src/Yasumi/Provider/Spain/BasqueCountry.php
@@ -73,7 +73,7 @@ class BasqueCountry extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateBasqueCountryDay(): void
+    protected function calculateBasqueCountryDay(): void
     {
         if ($this->year < 2011) {
             return;

--- a/src/Yasumi/Provider/Spain/BasqueCountry.php
+++ b/src/Yasumi/Provider/Spain/BasqueCountry.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/CanaryIslands.php
+++ b/src/Yasumi/Provider/Spain/CanaryIslands.php
@@ -72,7 +72,7 @@ class CanaryIslands extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateCanaryIslandsDay(): void
+    protected function calculateCanaryIslandsDay(): void
     {
         if ($this->year >= 1984) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain/CanaryIslands.php
+++ b/src/Yasumi/Provider/Spain/CanaryIslands.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/Cantabria.php
+++ b/src/Yasumi/Provider/Spain/Cantabria.php
@@ -76,7 +76,7 @@ class Cantabria extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateCantabriaDay(): void
+    protected function calculateCantabriaDay(): void
     {
         if ($this->year >= 1967) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain/Cantabria.php
+++ b/src/Yasumi/Provider/Spain/Cantabria.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/CastileAndLeon.php
+++ b/src/Yasumi/Provider/Spain/CastileAndLeon.php
@@ -73,7 +73,7 @@ class CastileAndLeon extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateCastileAndLeonDay(): void
+    protected function calculateCastileAndLeonDay(): void
     {
         if ($this->year >= 1976) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain/CastileAndLeon.php
+++ b/src/Yasumi/Provider/Spain/CastileAndLeon.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/CastillaLaMancha.php
+++ b/src/Yasumi/Provider/Spain/CastillaLaMancha.php
@@ -76,7 +76,7 @@ class CastillaLaMancha extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateCastillaLaManchaDay(): void
+    protected function calculateCastillaLaManchaDay(): void
     {
         if ($this->year >= 1984) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain/CastillaLaMancha.php
+++ b/src/Yasumi/Provider/Spain/CastillaLaMancha.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/Catalonia.php
+++ b/src/Yasumi/Provider/Spain/Catalonia.php
@@ -76,7 +76,7 @@ class Catalonia extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalDayOfCatalonia(): void
+    protected function calculateNationalDayOfCatalonia(): void
     {
         if ($this->year >= 1886) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain/Catalonia.php
+++ b/src/Yasumi/Provider/Spain/Catalonia.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/Ceuta.php
+++ b/src/Yasumi/Provider/Spain/Ceuta.php
@@ -70,7 +70,7 @@ class Ceuta extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDayOfCeuta(): void
+    protected function calculateDayOfCeuta(): void
     {
         if ($this->year >= 1416) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain/Ceuta.php
+++ b/src/Yasumi/Provider/Spain/Ceuta.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/CommunityOfMadrid.php
+++ b/src/Yasumi/Provider/Spain/CommunityOfMadrid.php
@@ -77,7 +77,7 @@ class CommunityOfMadrid extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDosdeMayoUprisingDay(): void
+    protected function calculateDosdeMayoUprisingDay(): void
     {
         $this->addHoliday(new Holiday(
             'dosdeMayoUprisingDay',

--- a/src/Yasumi/Provider/Spain/CommunityOfMadrid.php
+++ b/src/Yasumi/Provider/Spain/CommunityOfMadrid.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/Extremadura.php
+++ b/src/Yasumi/Provider/Spain/Extremadura.php
@@ -73,7 +73,7 @@ class Extremadura extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDayOfExtremadura(): void
+    protected function calculateDayOfExtremadura(): void
     {
         if ($this->year >= 1985) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Spain/Extremadura.php
+++ b/src/Yasumi/Provider/Spain/Extremadura.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/Galicia.php
+++ b/src/Yasumi/Provider/Spain/Galicia.php
@@ -74,7 +74,7 @@ class Galicia extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateGalicianLiteratureDay(): void
+    protected function calculateGalicianLiteratureDay(): void
     {
         if ($this->year >= 1991) {
             $this->addHoliday(new Holiday('galicianLiteratureDay', [
@@ -101,7 +101,7 @@ class Galicia extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStJamesDay(): void
+    protected function calculateStJamesDay(): void
     {
         if ($this->year >= 2000) {
             $this->addHoliday(new Holiday('stJamesDay', [

--- a/src/Yasumi/Provider/Spain/Galicia.php
+++ b/src/Yasumi/Provider/Spain/Galicia.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/LaRioja.php
+++ b/src/Yasumi/Provider/Spain/LaRioja.php
@@ -70,7 +70,7 @@ class LaRioja extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateLaRiojaDay(): void
+    protected function calculateLaRiojaDay(): void
     {
         if ($this->year >= 1983) {
             $this->addHoliday(new Holiday('laRiojaDay', [

--- a/src/Yasumi/Provider/Spain/LaRioja.php
+++ b/src/Yasumi/Provider/Spain/LaRioja.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/Melilla.php
+++ b/src/Yasumi/Provider/Spain/Melilla.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/RegionOfMurcia.php
+++ b/src/Yasumi/Provider/Spain/RegionOfMurcia.php
@@ -71,7 +71,7 @@ class RegionOfMurcia extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDayOfMurcia(): void
+    protected function calculateDayOfMurcia(): void
     {
         if ($this->year >= 1983) {
             $this->addHoliday(new Holiday('murciaDay', [

--- a/src/Yasumi/Provider/Spain/RegionOfMurcia.php
+++ b/src/Yasumi/Provider/Spain/RegionOfMurcia.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/ValencianCommunity.php
+++ b/src/Yasumi/Provider/Spain/ValencianCommunity.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Spain/ValencianCommunity.php
+++ b/src/Yasumi/Provider/Spain/ValencianCommunity.php
@@ -78,7 +78,7 @@ class ValencianCommunity extends Spain
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateValencianCommunityDay(): void
+    protected function calculateValencianCommunityDay(): void
     {
         if ($this->year >= 1239) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Sweden.php
+++ b/src/Yasumi/Provider/Sweden.php
@@ -91,7 +91,7 @@ class Sweden extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateEpiphanyEve(): void
+    protected function calculateEpiphanyEve(): void
     {
         $this->addHoliday(new Holiday(
             'epiphanyEve',
@@ -117,7 +117,7 @@ class Sweden extends AbstractProvider
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    private function calculateWalpurgisEve(): void
+    protected function calculateWalpurgisEve(): void
     {
         $this->addHoliday(new Holiday(
             'walpurgisEve',
@@ -146,7 +146,7 @@ class Sweden extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStJohnsHolidays(): void
+    protected function calculateStJohnsHolidays(): void
     {
         $date = new \DateTime("{$this->year}-6-20 this saturday", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $this->addHoliday(new Holiday(
@@ -186,7 +186,7 @@ class Sweden extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateAllSaintsHolidays(): void
+    protected function calculateAllSaintsHolidays(): void
     {
         $date = new \DateTime("{$this->year}-10-31 this saturday", DateTimeZoneFactory::getDateTimeZone($this->timezone));
         $this->addHoliday(new Holiday(
@@ -219,7 +219,7 @@ class Sweden extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalDay(): void
+    protected function calculateNationalDay(): void
     {
         if ($this->year < 1916) {
             return;

--- a/src/Yasumi/Provider/Sweden.php
+++ b/src/Yasumi/Provider/Sweden.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland.php
+++ b/src/Yasumi/Provider/Switzerland.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -77,7 +79,7 @@ class Switzerland extends AbstractProvider
                 'fr' => 'Jour de la Saint-Berthold',
                 'en' => 'Berchtoldstag',
             ],
-            new \DateTime($this->year.'-01-02', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-01-02', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OTHER
         ));
@@ -101,7 +103,7 @@ class Switzerland extends AbstractProvider
     {
         if ($this->year >= 1832) {
             // Find third Sunday of September
-            $date = new \DateTime('Third Sunday of '.$this->year.'-09', DateTimeZoneFactory::getDateTimeZone($this->timezone));
+            $date = new \DateTime('Third Sunday of ' . $this->year . '-09', DateTimeZoneFactory::getDateTimeZone($this->timezone));
             // Go to next Thursday
             $date->add(new \DateInterval('P1D'));
 
@@ -139,7 +141,7 @@ class Switzerland extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'swissNationalDay',
                 $translations,
-                new \DateTime($this->year.'-08-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                new \DateTime($this->year . '-08-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OFFICIAL
             ));
@@ -147,7 +149,7 @@ class Switzerland extends AbstractProvider
             $this->addHoliday(new Holiday(
                 'swissNationalDay',
                 $translations,
-                new \DateTime($this->year.'-08-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                new \DateTime($this->year . '-08-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OBSERVANCE
             ));

--- a/src/Yasumi/Provider/Switzerland.php
+++ b/src/Yasumi/Provider/Switzerland.php
@@ -126,7 +126,7 @@ class Switzerland extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNationalDay(): void
+    protected function calculateNationalDay(): void
     {
         $translations = [
             'en' => 'National Day',

--- a/src/Yasumi/Provider/Switzerland/Aargau.php
+++ b/src/Yasumi/Provider/Switzerland/Aargau.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/AppenzellAusserrhoden.php
+++ b/src/Yasumi/Provider/Switzerland/AppenzellAusserrhoden.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/AppenzellInnerrhoden.php
+++ b/src/Yasumi/Provider/Switzerland/AppenzellInnerrhoden.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/BaselLandschaft.php
+++ b/src/Yasumi/Provider/Switzerland/BaselLandschaft.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/BaselStadt.php
+++ b/src/Yasumi/Provider/Switzerland/BaselStadt.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Bern.php
+++ b/src/Yasumi/Provider/Switzerland/Bern.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Fribourg.php
+++ b/src/Yasumi/Provider/Switzerland/Fribourg.php
@@ -73,7 +73,7 @@ class Fribourg extends Switzerland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDecember26th(): void
+    protected function calculateDecember26th(): void
     {
         $this->addHoliday(new Holiday(
             'december26th',

--- a/src/Yasumi/Provider/Switzerland/Fribourg.php
+++ b/src/Yasumi/Provider/Switzerland/Fribourg.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -81,7 +84,7 @@ class Fribourg extends Switzerland
                 'en' => 'December 26th',
                 'fr' => '26 décembre',
             ],
-            new \DateTime($this->year.'-12-26', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-12-26', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OTHER
         ));

--- a/src/Yasumi/Provider/Switzerland/Geneva.php
+++ b/src/Yasumi/Provider/Switzerland/Geneva.php
@@ -72,7 +72,7 @@ class Geneva extends Switzerland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateJeuneGenevois(): void
+    protected function calculateJeuneGenevois(): void
     {
         if (self::JEUNE_GENEVOIS_ESTABLISHMENT_YEAR > $this->year) {
             return;
@@ -107,7 +107,7 @@ class Geneva extends Switzerland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateRestaurationGenevoise(): void
+    protected function calculateRestaurationGenevoise(): void
     {
         if ($this->year > 1813) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Switzerland/Geneva.php
+++ b/src/Yasumi/Provider/Switzerland/Geneva.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -79,7 +82,7 @@ class Geneva extends Switzerland
         }
 
         // Find first Sunday of September
-        $date = new \DateTime('First Sunday of '.$this->year.'-09', DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $date = new \DateTime('First Sunday of ' . $this->year . '-09', DateTimeZoneFactory::getDateTimeZone($this->timezone));
         // Go to next Thursday
         $date->add(new \DateInterval('P4D'));
 
@@ -115,7 +118,7 @@ class Geneva extends Switzerland
                 [
                     'fr' => 'Restauration de la République',
                 ],
-                new \DateTime($this->year.'-12-31', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                new \DateTime($this->year . '-12-31', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));

--- a/src/Yasumi/Provider/Switzerland/Glarus.php
+++ b/src/Yasumi/Provider/Switzerland/Glarus.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -75,7 +78,7 @@ class Glarus extends Switzerland
     protected function calculateNafelserFahrt(): void
     {
         if ($this->year >= 1389) {
-            $date = new \DateTime('First Thursday of '.$this->year.'-04', DateTimeZoneFactory::getDateTimeZone($this->timezone));
+            $date = new \DateTime('First Thursday of ' . $this->year . '-04', DateTimeZoneFactory::getDateTimeZone($this->timezone));
             $this->addHoliday(new Holiday('nafelserFahrt', [
                 'de' => 'Näfelser Fahrt',
             ], $date, $this->locale, Holiday::TYPE_OTHER));

--- a/src/Yasumi/Provider/Switzerland/Glarus.php
+++ b/src/Yasumi/Provider/Switzerland/Glarus.php
@@ -72,7 +72,7 @@ class Glarus extends Switzerland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNafelserFahrt(): void
+    protected function calculateNafelserFahrt(): void
     {
         if ($this->year >= 1389) {
             $date = new \DateTime('First Thursday of '.$this->year.'-04', DateTimeZoneFactory::getDateTimeZone($this->timezone));

--- a/src/Yasumi/Provider/Switzerland/Grisons.php
+++ b/src/Yasumi/Provider/Switzerland/Grisons.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Jura.php
+++ b/src/Yasumi/Provider/Switzerland/Jura.php
@@ -79,7 +79,7 @@ class Jura extends Switzerland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculatePlebisciteJurassien(): void
+    protected function calculatePlebisciteJurassien(): void
     {
         if ($this->year > 1974) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Switzerland/Jura.php
+++ b/src/Yasumi/Provider/Switzerland/Jura.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -87,7 +90,7 @@ class Jura extends Switzerland
                 [
                     'fr' => 'Commémoration du plébiscite jurassien',
                 ],
-                new \DateTime($this->year.'-06-23', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                new \DateTime($this->year . '-06-23', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));

--- a/src/Yasumi/Provider/Switzerland/Lucerne.php
+++ b/src/Yasumi/Provider/Switzerland/Lucerne.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Neuchatel.php
+++ b/src/Yasumi/Provider/Switzerland/Neuchatel.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -94,7 +97,7 @@ class Neuchatel extends Switzerland
                 [
                     'fr' => 'Instauration de la République',
                 ],
-                new \DateTime($this->year.'-03-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                new \DateTime($this->year . '-03-01', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));
@@ -116,7 +119,7 @@ class Neuchatel extends Switzerland
                 'en' => 'January 2nd',
                 'fr' => '2 janvier',
             ],
-            new \DateTime($this->year.'-01-02', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-01-02', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OTHER
         ));
@@ -137,7 +140,7 @@ class Neuchatel extends Switzerland
                 'en' => 'December 26th',
                 'fr' => '26 décembre',
             ],
-            new \DateTime($this->year.'-12-26', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-12-26', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OTHER
         ));

--- a/src/Yasumi/Provider/Switzerland/Neuchatel.php
+++ b/src/Yasumi/Provider/Switzerland/Neuchatel.php
@@ -86,7 +86,7 @@ class Neuchatel extends Switzerland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateInstaurationRepublique(): void
+    protected function calculateInstaurationRepublique(): void
     {
         if ($this->year > 1848) {
             $this->addHoliday(new Holiday(
@@ -108,7 +108,7 @@ class Neuchatel extends Switzerland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateJanuary2nd(): void
+    protected function calculateJanuary2nd(): void
     {
         $this->addHoliday(new Holiday(
             'january2nd',
@@ -129,7 +129,7 @@ class Neuchatel extends Switzerland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDecember26th(): void
+    protected function calculateDecember26th(): void
     {
         $this->addHoliday(new Holiday(
             'december26th',

--- a/src/Yasumi/Provider/Switzerland/Nidwalden.php
+++ b/src/Yasumi/Provider/Switzerland/Nidwalden.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Obwalden.php
+++ b/src/Yasumi/Provider/Switzerland/Obwalden.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -84,7 +87,7 @@ class Obwalden extends Switzerland
                 [
                     'de' => 'Bruder-Klausen-Fest',
                 ],
-                new \DateTime($this->year.'-09-25', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                new \DateTime($this->year . '-09-25', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));
@@ -94,7 +97,7 @@ class Obwalden extends Switzerland
                 [
                     'de' => 'Bruder-Klausen-Fest',
                 ],
-                new \DateTime($this->year.'-09-21', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                new \DateTime($this->year . '-09-21', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 Holiday::TYPE_OTHER
             ));

--- a/src/Yasumi/Provider/Switzerland/Obwalden.php
+++ b/src/Yasumi/Provider/Switzerland/Obwalden.php
@@ -76,7 +76,7 @@ class Obwalden extends Switzerland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateBruderKlausenFest(): void
+    protected function calculateBruderKlausenFest(): void
     {
         if ($this->year >= 1947) {
             $this->addHoliday(new Holiday(

--- a/src/Yasumi/Provider/Switzerland/Schaffhausen.php
+++ b/src/Yasumi/Provider/Switzerland/Schaffhausen.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Schwyz.php
+++ b/src/Yasumi/Provider/Switzerland/Schwyz.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Solothurn.php
+++ b/src/Yasumi/Provider/Switzerland/Solothurn.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/StGallen.php
+++ b/src/Yasumi/Provider/Switzerland/StGallen.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Thurgau.php
+++ b/src/Yasumi/Provider/Switzerland/Thurgau.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Ticino.php
+++ b/src/Yasumi/Provider/Switzerland/Ticino.php
@@ -82,7 +82,7 @@ class Ticino extends Switzerland
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStPeterPaul(): void
+    protected function calculateStPeterPaul(): void
     {
         $this->addHoliday(new Holiday(
             'stPeterPaul',

--- a/src/Yasumi/Provider/Switzerland/Ticino.php
+++ b/src/Yasumi/Provider/Switzerland/Ticino.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -92,7 +95,7 @@ class Ticino extends Switzerland
                 'fr' => 'Solennité des saints Pierre et Paul',
                 'de' => 'St. Peter und Paul',
             ],
-            new \DateTime($this->year.'-06-29', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-06-29', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OTHER
         ));

--- a/src/Yasumi/Provider/Switzerland/Uri.php
+++ b/src/Yasumi/Provider/Switzerland/Uri.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Valais.php
+++ b/src/Yasumi/Provider/Switzerland/Valais.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Vaud.php
+++ b/src/Yasumi/Provider/Switzerland/Vaud.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Zug.php
+++ b/src/Yasumi/Provider/Switzerland/Zug.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Switzerland/Zurich.php
+++ b/src/Yasumi/Provider/Switzerland/Zurich.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/Turkey.php
+++ b/src/Yasumi/Provider/Turkey.php
@@ -59,7 +59,7 @@ class Turkey extends AbstractProvider
     /**
      * @throws \Exception
      */
-    private function addLabourDay(): void
+    protected function addLabourDay(): void
     {
         $this->addHoliday(new Holiday('labourDay', [
             'tr' => 'Emek ve Dayanışma Günü',
@@ -77,7 +77,7 @@ class Turkey extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function addCommemorationOfAtaturk(): void
+    protected function addCommemorationOfAtaturk(): void
     {
         if (1920 > $this->year) {
             return;
@@ -97,7 +97,7 @@ class Turkey extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function addNationalSovereigntyDay(): void
+    protected function addNationalSovereigntyDay(): void
     {
         if (1922 > $this->year) {
             return;
@@ -123,7 +123,7 @@ class Turkey extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function addDemocracyDay(): void
+    protected function addDemocracyDay(): void
     {
         if (2017 > $this->year) {
             return;
@@ -142,7 +142,7 @@ class Turkey extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function addVictoryDay(): void
+    protected function addVictoryDay(): void
     {
         if (1923 > $this->year) {
             return;
@@ -172,7 +172,7 @@ class Turkey extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function addRepublicDay(): void
+    protected function addRepublicDay(): void
     {
         if (1924 > $this->year) {
             return;

--- a/src/Yasumi/Provider/Turkey.php
+++ b/src/Yasumi/Provider/Turkey.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/USA.php
+++ b/src/Yasumi/Provider/USA.php
@@ -81,7 +81,7 @@ class USA extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateMartinLutherKingday(): void
+    protected function calculateMartinLutherKingday(): void
     {
         if ($this->year >= 1986) {
             $this->addHoliday(new Holiday('martinLutherKingDay', [
@@ -105,7 +105,7 @@ class USA extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateWashingtonsBirthday(): void
+    protected function calculateWashingtonsBirthday(): void
     {
         if ($this->year >= 1879) {
             $date = new \DateTime("{$this->year}-2-22", DateTimeZoneFactory::getDateTimeZone($this->timezone));
@@ -130,7 +130,7 @@ class USA extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateMemorialDay(): void
+    protected function calculateMemorialDay(): void
     {
         if ($this->year >= 1865) {
             $date = new \DateTime("{$this->year}-5-30", DateTimeZoneFactory::getDateTimeZone($this->timezone));
@@ -155,7 +155,7 @@ class USA extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateJuneteenth(): void
+    protected function calculateJuneteenth(): void
     {
         if ($this->year >= 2021) {
             $date = new \DateTime("{$this->year}-6-19", DateTimeZoneFactory::getDateTimeZone($this->timezone));
@@ -200,7 +200,7 @@ class USA extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateIndependenceDay(): void
+    protected function calculateIndependenceDay(): void
     {
         if ($this->year >= 1776) {
             $this->addHoliday(new Holiday('independenceDay', [
@@ -219,7 +219,7 @@ class USA extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateLabourDay(): void
+    protected function calculateLabourDay(): void
     {
         if ($this->year >= 1887) {
             $this->addHoliday(new Holiday(
@@ -246,7 +246,7 @@ class USA extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateColumbusDay(): void
+    protected function calculateColumbusDay(): void
     {
         if ($this->year >= 1937) {
             $date = new \DateTime("{$this->year}-10-12", DateTimeZoneFactory::getDateTimeZone($this->timezone));
@@ -270,7 +270,7 @@ class USA extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateVeteransDay(): void
+    protected function calculateVeteransDay(): void
     {
         if ($this->year >= 1919) {
             $name = $this->year < 1954 ? 'Armistice Day' : 'Veterans Day';
@@ -293,7 +293,7 @@ class USA extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateThanksgivingDay(): void
+    protected function calculateThanksgivingDay(): void
     {
         if ($this->year >= 1863) {
             $this->addHoliday(new Holiday(
@@ -317,7 +317,7 @@ class USA extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSubstituteHolidays(): void
+    protected function calculateSubstituteHolidays(): void
     {
         // Loop through all defined holidays
         foreach ($this->getHolidays() as $holiday) {

--- a/src/Yasumi/Provider/USA.php
+++ b/src/Yasumi/Provider/USA.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -179,7 +181,7 @@ class USA extends AbstractProvider
                 $this->addHoliday(new SubstituteHoliday(
                     $holiday,
                     [
-                        'en' => $label.' (observed)',
+                        'en' => $label . ' (observed)',
                     ],
                     $date,
                     $this->locale

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -53,7 +53,8 @@ class Ukraine extends AbstractProvider
         try {
             new \DateTimeZone('Europe/Kyiv');
             $this->timezone = 'Europe/Kyiv';
-        } catch (\Exception $e) { // DateInvalidTimeZoneException since 8.3
+        } catch (\Exception $e) { // @phpstan-ignore-line
+            // DateInvalidTimeZoneException since 8.3
             $this->timezone = 'Europe/Kiev';
         }
 

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -51,12 +51,10 @@ class Ukraine extends AbstractProvider
         // the name of the timezone changed at some point and some systems support both names,
         // while others only support the old or the new one -> try out, which version is actually working
         try {
-            new \DateTimeZone('Europe/Kiev');
-            $this->timezone = 'Europe/Kiev';
-        } catch (\Exception $e) {
-            // this is an DateInvalidTimeZoneException only since 8.3
-            // see https://www.php.net/manual/en/datetimezone.construct.php
+            new \DateTimeZone('Europe/Kyiv');
             $this->timezone = 'Europe/Kyiv';
+        } catch (\Exception $e) { // DateInvalidTimeZoneException since 8.3
+            $this->timezone = 'Europe/Kiev';
         }
 
         // Add common holidays

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -48,7 +48,16 @@ class Ukraine extends AbstractProvider
      */
     public function initialize(): void
     {
-        $this->timezone = 'Europe/Kiev';
+        // the name of the timezone changed at some point and some systems support both names,
+        // while others only support the old or the new one -> try out, which version is actually working
+        try {
+            new \DateTimeZone('Europe/Kiev');
+            $this->timezone = 'Europe/Kiev';
+        } catch (\Exception $e) {
+            // this is an DateInvalidTimeZoneException only since 8.3
+            // see https://www.php.net/manual/en/datetimezone.construct.php
+            $this->timezone = 'Europe/Kyiv';
+        }
 
         // Add common holidays
         // New Years Day will not be substituted to an monday if it's on a weekend!

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -127,7 +127,7 @@ class Ukraine extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateChristmasDay(): void
+    protected function calculateChristmasDay(): void
     {
         $this->addHoliday(new Holiday(
             'christmasDay',
@@ -147,7 +147,7 @@ class Ukraine extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSecondInternationalWorkersDay(): void
+    protected function calculateSecondInternationalWorkersDay(): void
     {
         if ($this->year >= 2018) {
             return;
@@ -174,7 +174,7 @@ class Ukraine extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateVictoryDay(): void
+    protected function calculateVictoryDay(): void
     {
         $this->addHoliday(new Holiday(
             'victoryDay',
@@ -195,7 +195,7 @@ class Ukraine extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateConstitutionDay(): void
+    protected function calculateConstitutionDay(): void
     {
         if ($this->year < 1996) {
             return;
@@ -222,7 +222,7 @@ class Ukraine extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateIndependenceDay(): void
+    protected function calculateIndependenceDay(): void
     {
         if ($this->year < 1991) {
             return;
@@ -250,7 +250,7 @@ class Ukraine extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateDefenderOfUkraineDay(): void
+    protected function calculateDefenderOfUkraineDay(): void
     {
         if ($this->year < 2015) {
             return;
@@ -274,7 +274,7 @@ class Ukraine extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateCatholicChristmasDay(): void
+    protected function calculateCatholicChristmasDay(): void
     {
         if ($this->year < 2017) {
             return;

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/UnitedKingdom.php
+++ b/src/Yasumi/Provider/UnitedKingdom.php
@@ -321,7 +321,7 @@ class UnitedKingdom extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNewYearsDay(): void
+    protected function calculateNewYearsDay(): void
     {
         // Before 1871 it was not an observed or statutory holiday
         if ($this->year < 1871) {
@@ -358,7 +358,7 @@ class UnitedKingdom extends AbstractProvider
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSummerBankHoliday(): void
+    protected function calculateSummerBankHoliday(): void
     {
         if ($this->year < 1871) {
             return;
@@ -409,7 +409,7 @@ class UnitedKingdom extends AbstractProvider
      *
      * @throws \Exception
      */
-    private function calculateMotheringSunday(): void
+    protected function calculateMotheringSunday(): void
     {
         $date = $this->calculateEaster($this->year, $this->timezone);
         $date->sub(new \DateInterval('P3W'));

--- a/src/Yasumi/Provider/UnitedKingdom.php
+++ b/src/Yasumi/Provider/UnitedKingdom.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/UnitedKingdom/England.php
+++ b/src/Yasumi/Provider/UnitedKingdom/England.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -76,7 +79,7 @@ class NorthernIreland extends UnitedKingdom
         $holiday = new Holiday(
             'stPatricksDay',
             ['en' => 'St. Patrick’s Day'],
-            new \DateTime($this->year.'-3-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-3-17', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         );
@@ -120,7 +123,7 @@ class NorthernIreland extends UnitedKingdom
         $holiday = new Holiday(
             'battleOfTheBoyne',
             ['en' => 'Battle of the Boyne'],
-            new \DateTime($this->year.'-7-12', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-7-12', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         );

--- a/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/NorthernIreland.php
@@ -67,7 +67,7 @@ class NorthernIreland extends UnitedKingdom
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStPatricksDay(): void
+    protected function calculateStPatricksDay(): void
     {
         if ($this->year < 1971) {
             return;
@@ -111,7 +111,7 @@ class NorthernIreland extends UnitedKingdom
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateBattleOfTheBoyne(): void
+    protected function calculateBattleOfTheBoyne(): void
     {
         if ($this->year < 1926) {
             return;

--- a/src/Yasumi/Provider/UnitedKingdom/Scotland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/Scotland.php
@@ -80,7 +80,7 @@ class Scotland extends UnitedKingdom
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateSummerBankHoliday(): void
+    protected function calculateSummerBankHoliday(): void
     {
         if ($this->year < 1871) {
             return;
@@ -109,7 +109,7 @@ class Scotland extends UnitedKingdom
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateNewYearsHolidays(): void
+    protected function calculateNewYearsHolidays(): void
     {
         // Before 1871 it was not an observed or statutory holiday
         if ($this->year < 1871) {
@@ -169,7 +169,7 @@ class Scotland extends UnitedKingdom
      * @throws UnknownLocaleException
      * @throws \Exception
      */
-    private function calculateStAndrewsDay(): void
+    protected function calculateStAndrewsDay(): void
     {
         if ($this->year < 2007) {
             return;

--- a/src/Yasumi/Provider/UnitedKingdom/Scotland.php
+++ b/src/Yasumi/Provider/UnitedKingdom/Scotland.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -177,7 +180,7 @@ class Scotland extends UnitedKingdom
         $holiday = new Holiday(
             'stAndrewsDay',
             [],
-            new \DateTime($this->year.'-11-30', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            new \DateTime($this->year . '-11-30', DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_BANK
         );

--- a/src/Yasumi/Provider/UnitedKingdom/Wales.php
+++ b/src/Yasumi/Provider/UnitedKingdom/Wales.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/ProviderInterface.php
+++ b/src/Yasumi/ProviderInterface.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/SubstituteHoliday.php
+++ b/src/Yasumi/SubstituteHoliday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -68,7 +70,7 @@ class SubstituteHoliday extends Holiday
     ) {
         $this->substitutedHoliday = $substitutedHoliday;
 
-        $key = 'substituteHoliday:'.$substitutedHoliday->getKey();
+        $key = 'substituteHoliday:' . $substitutedHoliday->getKey();
 
         if ($date == $substitutedHoliday) {
             throw new \InvalidArgumentException('Date must differ from the substituted holiday');

--- a/src/Yasumi/Translations.php
+++ b/src/Yasumi/Translations.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -48,7 +50,7 @@ class Translations implements TranslationsInterface
             throw new \InvalidArgumentException('Directory with translations not found');
         }
 
-        $directoryPath = rtrim($directoryPath, '/\\').\DIRECTORY_SEPARATOR;
+        $directoryPath = rtrim($directoryPath, '/\\') . \DIRECTORY_SEPARATOR;
         $extension = 'php';
 
         foreach (new \DirectoryIterator($directoryPath) as $file) {
@@ -65,9 +67,9 @@ class Translations implements TranslationsInterface
             }
 
             $filename = $file->getFilename();
-            $key = $file->getBasename('.'.$extension);
+            $key = $file->getBasename('.' . $extension);
 
-            $translations = require $directoryPath.$filename;
+            $translations = require $directoryPath . $filename;
 
             if (\is_array($translations)) {
                 foreach (array_keys($translations) as $locale) {

--- a/src/Yasumi/TranslationsInterface.php
+++ b/src/Yasumi/TranslationsInterface.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/Yasumi.php
+++ b/src/Yasumi/Yasumi.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -140,7 +142,7 @@ class Yasumi
         // Load internal translations variable
         if (! self::$globalTranslations instanceof Translations) {
             self::$globalTranslations = new Translations(self::$locales);
-            self::$globalTranslations->loadTranslations(__DIR__.'/data/translations');
+            self::$globalTranslations->loadTranslations(__DIR__ . '/data/translations');
         }
 
         // Assert locale input
@@ -158,7 +160,7 @@ class Yasumi
      */
     public static function getAvailableLocales(): array
     {
-        return require __DIR__.'/data/locales.php';
+        return require __DIR__ . '/data/locales.php';
     }
 
     /**
@@ -212,7 +214,7 @@ class Yasumi
 
         $providers = [];
         $filesIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(
-            __DIR__.\DIRECTORY_SEPARATOR.'Provider',
+            __DIR__ . \DIRECTORY_SEPARATOR . 'Provider',
             \FilesystemIterator::SKIP_DOTS
         ), \RecursiveIteratorIterator::SELF_FIRST);
 

--- a/src/Yasumi/data/locales.php
+++ b/src/Yasumi/data/locales.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/allSaintsDay.php
+++ b/src/Yasumi/data/translations/allSaintsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/allSaintsEve.php
+++ b/src/Yasumi/data/translations/allSaintsEve.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/allSoulsDay.php
+++ b/src/Yasumi/data/translations/allSoulsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/annunciation.php
+++ b/src/Yasumi/data/translations/annunciation.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/anzacDay.php
+++ b/src/Yasumi/data/translations/anzacDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/armisticeDay.php
+++ b/src/Yasumi/data/translations/armisticeDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/ascensionDay.php
+++ b/src/Yasumi/data/translations/ascensionDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/ashWednesday.php
+++ b/src/Yasumi/data/translations/ashWednesday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/assumptionOfMary.php
+++ b/src/Yasumi/data/translations/assumptionOfMary.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/australiaDay.php
+++ b/src/Yasumi/data/translations/australiaDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/canadaDay.php
+++ b/src/Yasumi/data/translations/canadaDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/carnationRevolutionDay.php
+++ b/src/Yasumi/data/translations/carnationRevolutionDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/christmasDay.php
+++ b/src/Yasumi/data/translations/christmasDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/christmasEve.php
+++ b/src/Yasumi/data/translations/christmasEve.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/civicHoliday.php
+++ b/src/Yasumi/data/translations/civicHoliday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/corpusChristi.php
+++ b/src/Yasumi/data/translations/corpusChristi.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/dayAfterNewYearsDay.php
+++ b/src/Yasumi/data/translations/dayAfterNewYearsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/dayOfLiberation.php
+++ b/src/Yasumi/data/translations/dayOfLiberation.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/dayOfReformation.php
+++ b/src/Yasumi/data/translations/dayOfReformation.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/discoveryDay.php
+++ b/src/Yasumi/data/translations/discoveryDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/easter.php
+++ b/src/Yasumi/data/translations/easter.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/easterMonday.php
+++ b/src/Yasumi/data/translations/easterMonday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/epiphany.php
+++ b/src/Yasumi/data/translations/epiphany.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/epiphanyEve.php
+++ b/src/Yasumi/data/translations/epiphanyEve.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/familyDay.php
+++ b/src/Yasumi/data/translations/familyDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/fathersDay.php
+++ b/src/Yasumi/data/translations/fathersDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/goldCupParadeDay.php
+++ b/src/Yasumi/data/translations/goldCupParadeDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/goodFriday.php
+++ b/src/Yasumi/data/translations/goodFriday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/heritageDay.php
+++ b/src/Yasumi/data/translations/heritageDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/immaculateConception.php
+++ b/src/Yasumi/data/translations/immaculateConception.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/internationalWomensDay.php
+++ b/src/Yasumi/data/translations/internationalWomensDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/internationalWorkersDay.php
+++ b/src/Yasumi/data/translations/internationalWorkersDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/islanderDay.php
+++ b/src/Yasumi/data/translations/islanderDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/labourDay.php
+++ b/src/Yasumi/data/translations/labourDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/louisRielDay.php
+++ b/src/Yasumi/data/translations/louisRielDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/maundyThursday.php
+++ b/src/Yasumi/data/translations/maundyThursday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/mothersDay.php
+++ b/src/Yasumi/data/translations/mothersDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/natalHoliday.php
+++ b/src/Yasumi/data/translations/natalHoliday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/nationalIndigenousPeoplesDay.php
+++ b/src/Yasumi/data/translations/nationalIndigenousPeoplesDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/nationalPatriotsDay.php
+++ b/src/Yasumi/data/translations/nationalPatriotsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/newYearsDay.php
+++ b/src/Yasumi/data/translations/newYearsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/newYearsEve.php
+++ b/src/Yasumi/data/translations/newYearsEve.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/novaScotiaHeritageDay.php
+++ b/src/Yasumi/data/translations/novaScotiaHeritageDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/orangemensDay.php
+++ b/src/Yasumi/data/translations/orangemensDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/pentecost.php
+++ b/src/Yasumi/data/translations/pentecost.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/pentecostMonday.php
+++ b/src/Yasumi/data/translations/pentecostMonday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/plebisciteDay.php
+++ b/src/Yasumi/data/translations/plebisciteDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/portugalDay.php
+++ b/src/Yasumi/data/translations/portugalDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/portugueseRepublicDay.php
+++ b/src/Yasumi/data/translations/portugueseRepublicDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/queensBirthday.php
+++ b/src/Yasumi/data/translations/queensBirthday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/reformationDay.php
+++ b/src/Yasumi/data/translations/reformationDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/remembranceDay.php
+++ b/src/Yasumi/data/translations/remembranceDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/restorationOfIndepence.php
+++ b/src/Yasumi/data/translations/restorationOfIndepence.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/saintJeanBaptisteDay.php
+++ b/src/Yasumi/data/translations/saintJeanBaptisteDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/saskatchewanDay.php
+++ b/src/Yasumi/data/translations/saskatchewanDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/secondChristmasDay.php
+++ b/src/Yasumi/data/translations/secondChristmasDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/secondNewYearsDay.php
+++ b/src/Yasumi/data/translations/secondNewYearsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stAndrewsDay.php
+++ b/src/Yasumi/data/translations/stAndrewsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stDavidsDay.php
+++ b/src/Yasumi/data/translations/stDavidsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stFloriansDay.php
+++ b/src/Yasumi/data/translations/stFloriansDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stGeorgesDay.php
+++ b/src/Yasumi/data/translations/stGeorgesDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stJohnsDay.php
+++ b/src/Yasumi/data/translations/stJohnsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stJohnsEve.php
+++ b/src/Yasumi/data/translations/stJohnsEve.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stJosephsDay.php
+++ b/src/Yasumi/data/translations/stJosephsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stLeopoldsDay.php
+++ b/src/Yasumi/data/translations/stLeopoldsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stMartinsDay.php
+++ b/src/Yasumi/data/translations/stMartinsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stRupertsDay.php
+++ b/src/Yasumi/data/translations/stRupertsDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/stStephensDay.php
+++ b/src/Yasumi/data/translations/stStephensDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/substituteHoliday.php
+++ b/src/Yasumi/data/translations/substituteHoliday.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/summerTime.php
+++ b/src/Yasumi/data/translations/summerTime.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/terryFoxDay.php
+++ b/src/Yasumi/data/translations/terryFoxDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/thanksgivingDay.php
+++ b/src/Yasumi/data/translations/thanksgivingDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/truthAndReconciliationDay.php
+++ b/src/Yasumi/data/translations/truthAndReconciliationDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/valentinesDay.php
+++ b/src/Yasumi/data/translations/valentinesDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/victoriaDay.php
+++ b/src/Yasumi/data/translations/victoriaDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/victoryInEuropeDay.php
+++ b/src/Yasumi/data/translations/victoryInEuropeDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/waitangiDay.php
+++ b/src/Yasumi/data/translations/waitangiDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/walpurgisEve.php
+++ b/src/Yasumi/data/translations/walpurgisEve.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/winterTime.php
+++ b/src/Yasumi/data/translations/winterTime.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/worldAnimalDay.php
+++ b/src/Yasumi/data/translations/worldAnimalDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/src/Yasumi/data/translations/yukonHeritageDay.php
+++ b/src/Yasumi/data/translations/yukonHeritageDay.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/ArgentinaBaseTestCase.php
+++ b/tests/Argentina/ArgentinaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/ArgentinaTest.php
+++ b/tests/Argentina/ArgentinaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/CarnavalMondayTest.php
+++ b/tests/Argentina/CarnavalMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/CarnavalTuesdayTest.php
+++ b/tests/Argentina/CarnavalTuesdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/ChristmasDayTest.php
+++ b/tests/Argentina/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/EasterTest.php
+++ b/tests/Argentina/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/FlagDayTest.php
+++ b/tests/Argentina/FlagDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/GeneralJoseSanMartinDayTest.php
+++ b/tests/Argentina/GeneralJoseSanMartinDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/GeneralMartinMigueldeGuemesDayTest.php
+++ b/tests/Argentina/GeneralMartinMigueldeGuemesDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/GoodFridayTest.php
+++ b/tests/Argentina/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/ImmaculateConceptionDayTest.php
+++ b/tests/Argentina/ImmaculateConceptionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/IndependenceDayTest.php
+++ b/tests/Argentina/IndependenceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/InternationalWorkersDayTest.php
+++ b/tests/Argentina/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/MalvinasDayTest.php
+++ b/tests/Argentina/MalvinasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/MayRevolutionTest.php
+++ b/tests/Argentina/MayRevolutionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/NationalSovereigntyDayTest.php
+++ b/tests/Argentina/NationalSovereigntyDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/NewYearsDayTest.php
+++ b/tests/Argentina/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/RaceDayTest.php
+++ b/tests/Argentina/RaceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Argentina/RemembranceDayTest.php
+++ b/tests/Argentina/RemembranceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AnzacDayTest.php
+++ b/tests/Australia/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustraliaBaseTestCase.php
+++ b/tests/Australia/AustraliaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustraliaDayTest.php
+++ b/tests/Australia/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustraliaTest.php
+++ b/tests/Australia/AustraliaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/AnzacDayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/AustraliaDayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryBaseTestCase.php
+++ b/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/BoxingDayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/CanberraDayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/CanberraDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/ChristmasDayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/EasterMondayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/EasterSaturdayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/EasterSaturdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/EasterSundayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/EasterSundayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/GoodFridayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/LabourDayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/NationalDayOfMourningTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/NewYearsDayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/QueensBirthdayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/AustralianCapitalTerritory/ReconciliationDayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/ReconciliationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/BoxingDayTest.php
+++ b/tests/Australia/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/ChristmasDayTest.php
+++ b/tests/Australia/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/EasterMondayTest.php
+++ b/tests/Australia/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/GoodFridayTest.php
+++ b/tests/Australia/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NationalDayOfMourningTest.php
+++ b/tests/Australia/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/AnzacDayTest.php
+++ b/tests/Australia/NewSouthWales/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/AustraliaDayTest.php
+++ b/tests/Australia/NewSouthWales/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/BankHolidayTest.php
+++ b/tests/Australia/NewSouthWales/BankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/BoxingDayTest.php
+++ b/tests/Australia/NewSouthWales/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/ChristmasDayTest.php
+++ b/tests/Australia/NewSouthWales/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/EasterMondayTest.php
+++ b/tests/Australia/NewSouthWales/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/EasterSaturdayTest.php
+++ b/tests/Australia/NewSouthWales/EasterSaturdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/EasterSundayTest.php
+++ b/tests/Australia/NewSouthWales/EasterSundayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/GoodFridayTest.php
+++ b/tests/Australia/NewSouthWales/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/LabourDayTest.php
+++ b/tests/Australia/NewSouthWales/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/NationalDayOfMourningTest.php
+++ b/tests/Australia/NewSouthWales/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/NewSouthWalesBaseTestCase.php
+++ b/tests/Australia/NewSouthWales/NewSouthWalesBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/NewSouthWalesTest.php
+++ b/tests/Australia/NewSouthWales/NewSouthWalesTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/NewYearsDayTest.php
+++ b/tests/Australia/NewSouthWales/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewSouthWales/QueensBirthdayTest.php
+++ b/tests/Australia/NewSouthWales/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NewYearsDayTest.php
+++ b/tests/Australia/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/AnzacDayTest.php
+++ b/tests/Australia/NorthernTerritory/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/AustraliaDayTest.php
+++ b/tests/Australia/NorthernTerritory/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/BoxingDayTest.php
+++ b/tests/Australia/NorthernTerritory/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/ChristmasDayTest.php
+++ b/tests/Australia/NorthernTerritory/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/EasterMondayTest.php
+++ b/tests/Australia/NorthernTerritory/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/EasterSaturdayTest.php
+++ b/tests/Australia/NorthernTerritory/EasterSaturdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/GoodFridayTest.php
+++ b/tests/Australia/NorthernTerritory/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/MayDayTest.php
+++ b/tests/Australia/NorthernTerritory/MayDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/NationalDayOfMourningTest.php
+++ b/tests/Australia/NorthernTerritory/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/NewYearsDayTest.php
+++ b/tests/Australia/NorthernTerritory/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/NorthernTerritoryBaseTestCase.php
+++ b/tests/Australia/NorthernTerritory/NorthernTerritoryBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/NorthernTerritoryTest.php
+++ b/tests/Australia/NorthernTerritory/NorthernTerritoryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/PicnicDayTest.php
+++ b/tests/Australia/NorthernTerritory/PicnicDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/NorthernTerritory/QueensBirthdayTest.php
+++ b/tests/Australia/NorthernTerritory/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/AnzacDayTest.php
+++ b/tests/Australia/Queensland/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/AustraliaDayTest.php
+++ b/tests/Australia/Queensland/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/BoxingDayTest.php
+++ b/tests/Australia/Queensland/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/AnzacDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/AustraliaDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/BoxingDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/BrisbaneBaseTestCase.php
+++ b/tests/Australia/Queensland/Brisbane/BrisbaneBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/BrisbaneTest.php
+++ b/tests/Australia/Queensland/Brisbane/BrisbaneTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/ChristmasDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/EasterMondayTest.php
+++ b/tests/Australia/Queensland/Brisbane/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/GoodFridayTest.php
+++ b/tests/Australia/Queensland/Brisbane/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/LabourDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/NationalDayOfMourningTest.php
+++ b/tests/Australia/Queensland/Brisbane/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/NewYearsDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/PeoplesDayTest.php
+++ b/tests/Australia/Queensland/Brisbane/PeoplesDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/Brisbane/QueensBirthdayTest.php
+++ b/tests/Australia/Queensland/Brisbane/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/ChristmasDayTest.php
+++ b/tests/Australia/Queensland/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/EasterMondayTest.php
+++ b/tests/Australia/Queensland/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/GoodFridayTest.php
+++ b/tests/Australia/Queensland/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/LabourDayTest.php
+++ b/tests/Australia/Queensland/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/NationalDayOfMourningTest.php
+++ b/tests/Australia/Queensland/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/NewYearsDayTest.php
+++ b/tests/Australia/Queensland/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/QueensBirthdayTest.php
+++ b/tests/Australia/Queensland/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/QueenslandBaseTestCase.php
+++ b/tests/Australia/Queensland/QueenslandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Queensland/QueenslandTest.php
+++ b/tests/Australia/Queensland/QueenslandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/AdelaideCupDayTest.php
+++ b/tests/Australia/SouthAustralia/AdelaideCupDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/AnzacDayTest.php
+++ b/tests/Australia/SouthAustralia/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/AustraliaDayTest.php
+++ b/tests/Australia/SouthAustralia/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/ChristmasDayTest.php
+++ b/tests/Australia/SouthAustralia/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/EasterMondayTest.php
+++ b/tests/Australia/SouthAustralia/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/EasterSaturdayTest.php
+++ b/tests/Australia/SouthAustralia/EasterSaturdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/GoodFridayTest.php
+++ b/tests/Australia/SouthAustralia/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/LabourDayTest.php
+++ b/tests/Australia/SouthAustralia/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/NationalDayOfMourningTest.php
+++ b/tests/Australia/SouthAustralia/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/NewYearsDayTest.php
+++ b/tests/Australia/SouthAustralia/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/ProclamationDayTest.php
+++ b/tests/Australia/SouthAustralia/ProclamationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/QueensBirthdayTest.php
+++ b/tests/Australia/SouthAustralia/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/SouthAustraliaBaseTestCase.php
+++ b/tests/Australia/SouthAustralia/SouthAustraliaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/SouthAustralia/SouthAustraliaTest.php
+++ b/tests/Australia/SouthAustralia/SouthAustraliaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/CentralNorthBaseTestCase.php
+++ b/tests/Australia/Tasmania/CentralNorth/CentralNorthBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/CentralNorthTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/CentralNorthTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/DevonportShowTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/DevonportShowTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/EightHourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/CentralNorth/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/RecreationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/EightHourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/EightHourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/FlindersIslandBaseTestCase.php
+++ b/tests/Australia/Tasmania/FlindersIsland/FlindersIslandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/FlindersIslandShowTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/FlindersIslandShowTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/FlindersIslandTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/FlindersIslandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/FlindersIsland/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/RecreationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/EightHourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/KingIslandBaseTestCase.php
+++ b/tests/Australia/Tasmania/KingIsland/KingIslandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/KingIslandShowTest.php
+++ b/tests/Australia/Tasmania/KingIsland/KingIslandShowTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/KingIslandTest.php
+++ b/tests/Australia/Tasmania/KingIsland/KingIslandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/KingIsland/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/KingIsland/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/RecreationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/Northeast/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/EightHourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/Northeast/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/LauncestonShowTest.php
+++ b/tests/Australia/Tasmania/Northeast/LauncestonShowTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/Northeast/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/NortheastBaseTestCase.php
+++ b/tests/Australia/Tasmania/Northeast/NortheastBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/NortheastTest.php
+++ b/tests/Australia/Tasmania/Northeast/NortheastTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/Northeast/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northeast/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/Northeast/RecreationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/BurnieShowTest.php
+++ b/tests/Australia/Tasmania/Northwest/BurnieShowTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/AGFESTTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/AGFESTTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/BurnieShowTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/BurnieShowTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadBaseTestCase.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/EightHourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/CircularHead/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/RecreationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/Northwest/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/EightHourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/Northwest/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/Northwest/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/NorthwestBaseTestCase.php
+++ b/tests/Australia/Tasmania/Northwest/NorthwestBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/NorthwestTest.php
+++ b/tests/Australia/Tasmania/Northwest/NorthwestTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/Northwest/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/Northwest/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/Northwest/RecreationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/RecreationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/South/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/South/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/South/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/South/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/South/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/South/EightHourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/South/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/HobartShowTest.php
+++ b/tests/Australia/Tasmania/South/HobartShowTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/South/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/South/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/South/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/RecreationDayTest.php
+++ b/tests/Australia/Tasmania/South/RecreationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/SouthBaseTestCase.php
+++ b/tests/Australia/Tasmania/South/SouthBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/SouthTest.php
+++ b/tests/Australia/Tasmania/South/SouthTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/AnzacDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/AustraliaDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/BoxingDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/ChristmasDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/EasterMondayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/EightHourDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/EightHourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/GoodFridayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/HobartRegattaTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/HobartRegattaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/HobartShowTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/HobartShowTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/NationalDayOfMourningTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/NewYearsDayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/SoutheastBaseTestCase.php
+++ b/tests/Australia/Tasmania/South/Southeast/SoutheastBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/South/Southeast/SoutheastTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/SoutheastTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/TasmaniaBaseTestCase.php
+++ b/tests/Australia/Tasmania/TasmaniaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Tasmania/TasmaniaTest.php
+++ b/tests/Australia/Tasmania/TasmaniaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/AFLGrandFinalFridayTest.php
+++ b/tests/Australia/Victoria/AFLGrandFinalFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/AnzacDayTest.php
+++ b/tests/Australia/Victoria/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/AustraliaDayTest.php
+++ b/tests/Australia/Victoria/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/BoxingDayTest.php
+++ b/tests/Australia/Victoria/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/ChristmasDayTest.php
+++ b/tests/Australia/Victoria/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/EasterMondayTest.php
+++ b/tests/Australia/Victoria/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/EasterSaturdayTest.php
+++ b/tests/Australia/Victoria/EasterSaturdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/EasterSundayTest.php
+++ b/tests/Australia/Victoria/EasterSundayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/GoodFridayTest.php
+++ b/tests/Australia/Victoria/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/LabourDayTest.php
+++ b/tests/Australia/Victoria/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/MelbourneCupDayTest.php
+++ b/tests/Australia/Victoria/MelbourneCupDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/NationalDayOfMourningTest.php
+++ b/tests/Australia/Victoria/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/NewYearsDayTest.php
+++ b/tests/Australia/Victoria/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/QueensBirthdayTest.php
+++ b/tests/Australia/Victoria/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/VictoriaBaseTestCase.php
+++ b/tests/Australia/Victoria/VictoriaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/Victoria/VictoriaTest.php
+++ b/tests/Australia/Victoria/VictoriaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/AnzacDayTest.php
+++ b/tests/Australia/WesternAustralia/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/AustraliaDayTest.php
+++ b/tests/Australia/WesternAustralia/AustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/BoxingDayTest.php
+++ b/tests/Australia/WesternAustralia/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/ChristmasDayTest.php
+++ b/tests/Australia/WesternAustralia/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/EasterMondayTest.php
+++ b/tests/Australia/WesternAustralia/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/GoodFridayTest.php
+++ b/tests/Australia/WesternAustralia/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/LabourDayTest.php
+++ b/tests/Australia/WesternAustralia/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/NationalDayOfMourningTest.php
+++ b/tests/Australia/WesternAustralia/NationalDayOfMourningTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/NewYearsDayTest.php
+++ b/tests/Australia/WesternAustralia/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/QueensBirthdayTest.php
+++ b/tests/Australia/WesternAustralia/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/WesternAustraliaBaseTestCase.php
+++ b/tests/Australia/WesternAustralia/WesternAustraliaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/WesternAustraliaDayTest.php
+++ b/tests/Australia/WesternAustralia/WesternAustraliaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Australia/WesternAustralia/WesternAustraliaTest.php
+++ b/tests/Australia/WesternAustralia/WesternAustraliaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/AllSaintsDayTest.php
+++ b/tests/Austria/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/AscensionDayTest.php
+++ b/tests/Austria/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/AssumptionOfMaryTest.php
+++ b/tests/Austria/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/AustriaBaseTestCase.php
+++ b/tests/Austria/AustriaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/AustriaTest.php
+++ b/tests/Austria/AustriaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Burgenland/BurgenlandBaseTestCase.php
+++ b/tests/Austria/Burgenland/BurgenlandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Burgenland/BurgenlandTest.php
+++ b/tests/Austria/Burgenland/BurgenlandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Burgenland/stMartinsDayTest.php
+++ b/tests/Austria/Burgenland/stMartinsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Carinthia/CarinthiaBaseTestCase.php
+++ b/tests/Austria/Carinthia/CarinthiaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Carinthia/CarinthiaTest.php
+++ b/tests/Austria/Carinthia/CarinthiaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Carinthia/PlebisciteDayTest.php
+++ b/tests/Austria/Carinthia/PlebisciteDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Carinthia/StJosephsDayTest.php
+++ b/tests/Austria/Carinthia/StJosephsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/ChristmasTest.php
+++ b/tests/Austria/ChristmasTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/CorpusChristiTest.php
+++ b/tests/Austria/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/EasterMondayTest.php
+++ b/tests/Austria/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/EasterTest.php
+++ b/tests/Austria/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/EpiphanyTest.php
+++ b/tests/Austria/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/ImmaculateConceptionTest.php
+++ b/tests/Austria/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/InternationalWorkersDayTest.php
+++ b/tests/Austria/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/LowerAustria/LowerAustriaBaseTestCase.php
+++ b/tests/Austria/LowerAustria/LowerAustriaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/LowerAustria/LowerAustriaTest.php
+++ b/tests/Austria/LowerAustria/LowerAustriaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/LowerAustria/StLeopoldsDayTest.php
+++ b/tests/Austria/LowerAustria/StLeopoldsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/NationalDayTest.php
+++ b/tests/Austria/NationalDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/NewYearsDayTest.php
+++ b/tests/Austria/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/PentecostMondayTest.php
+++ b/tests/Austria/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/PentecostTest.php
+++ b/tests/Austria/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Salzburg/SalzburgBaseTestCase.php
+++ b/tests/Austria/Salzburg/SalzburgBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Salzburg/SalzburgTest.php
+++ b/tests/Austria/Salzburg/SalzburgTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Salzburg/StRupertsDayTest.php
+++ b/tests/Austria/Salzburg/StRupertsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/SecondChristmasDayTest.php
+++ b/tests/Austria/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Styria/StJosephsDayTest.php
+++ b/tests/Austria/Styria/StJosephsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Styria/StyriaBaseTestCase.php
+++ b/tests/Austria/Styria/StyriaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Styria/StyriaTest.php
+++ b/tests/Austria/Styria/StyriaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Tyrol/StJosephsDayTest.php
+++ b/tests/Austria/Tyrol/StJosephsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Tyrol/TyrolBaseTestCase.php
+++ b/tests/Austria/Tyrol/TyrolBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Tyrol/TyrolTest.php
+++ b/tests/Austria/Tyrol/TyrolTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/UpperAustria/StFloriansDayTest.php
+++ b/tests/Austria/UpperAustria/StFloriansDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/UpperAustria/UpperAustriaBaseTestCase.php
+++ b/tests/Austria/UpperAustria/UpperAustriaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/UpperAustria/UpperAustriaTest.php
+++ b/tests/Austria/UpperAustria/UpperAustriaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Vienna/StLeopoldsDayTest.php
+++ b/tests/Austria/Vienna/StLeopoldsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Vienna/ViennaBaseTestCase.php
+++ b/tests/Austria/Vienna/ViennaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Vienna/ViennaTest.php
+++ b/tests/Austria/Vienna/ViennaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Vorarlberg/StJosephsDayTest.php
+++ b/tests/Austria/Vorarlberg/StJosephsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Vorarlberg/VorarlbergBaseTestCase.php
+++ b/tests/Austria/Vorarlberg/VorarlbergBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Austria/Vorarlberg/VorarlbergTest.php
+++ b/tests/Austria/Vorarlberg/VorarlbergTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Base/HolidayBetweenFilterTest.php
+++ b/tests/Base/HolidayBetweenFilterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -198,7 +201,7 @@ class HolidayBetweenFilterTest extends TestCase
 
         $between = $holidays->between(
             new \DateTime('03/25/2011', new \DateTimeZone($timezone)),
-            new \DateTime('05/17/'.$year, new \DateTimeZone($timezone))
+            new \DateTime('05/17/' . $year, new \DateTimeZone($timezone))
         );
 
         $betweenHolidays = iterator_to_array($between);
@@ -232,7 +235,7 @@ class HolidayBetweenFilterTest extends TestCase
         $holidays = Yasumi::create('Italy', $year);
 
         $between = $holidays->between(
-            new \DateTime('03/25/'.$year, new \DateTimeZone($timezone)),
+            new \DateTime('03/25/' . $year, new \DateTimeZone($timezone)),
             new \DateTime('09/21/2021', new \DateTimeZone($timezone))
         );
 
@@ -269,8 +272,8 @@ class HolidayBetweenFilterTest extends TestCase
         $holidays = Yasumi::create('USA', $year);
 
         $holidays->between(
-            new \DateTime('12/31/'.$year, new \DateTimeZone($timezone)),
-            new \DateTime('01/01/'.$year, new \DateTimeZone($timezone))
+            new \DateTime('12/31/' . $year, new \DateTimeZone($timezone)),
+            new \DateTime('01/01/' . $year, new \DateTimeZone($timezone))
         );
     }
 
@@ -289,8 +292,8 @@ class HolidayBetweenFilterTest extends TestCase
         $holidays = Yasumi::create('Ireland', $year);
 
         $between = $holidays->between(
-            new \DateTime('01/01/'.$year, new \DateTimeZone($timezone)),
-            new \DateTime('12/31/'.$year, new \DateTimeZone($timezone))
+            new \DateTime('01/01/' . $year, new \DateTimeZone($timezone)),
+            new \DateTime('12/31/' . $year, new \DateTimeZone($timezone))
         );
 
         $betweenHolidays = iterator_to_array($between);
@@ -329,8 +332,8 @@ class HolidayBetweenFilterTest extends TestCase
         $holidays = Yasumi::create('Ireland', $year);
 
         $between = $holidays->between(
-            new \DateTime('01/01/'.$year, new \DateTimeZone($timezone)),
-            new \DateTime('03/20/'.$year, new \DateTimeZone($timezone))
+            new \DateTime('01/01/' . $year, new \DateTimeZone($timezone)),
+            new \DateTime('03/20/' . $year, new \DateTimeZone($timezone))
         );
 
         $betweenHolidays = iterator_to_array($between);
@@ -373,8 +376,8 @@ class HolidayBetweenFilterTest extends TestCase
         $holidays = Yasumi::create('Ireland', $year);
 
         $between = $holidays->between(
-            new \DateTime('01/01/'.$year, new \DateTimeZone($timezone)),
-            new \DateTime('03/18/'.$year, new \DateTimeZone($timezone))
+            new \DateTime('01/01/' . $year, new \DateTimeZone($timezone)),
+            new \DateTime('03/18/' . $year, new \DateTimeZone($timezone))
         );
 
         $betweenHolidays = iterator_to_array($between);
@@ -418,8 +421,8 @@ class HolidayBetweenFilterTest extends TestCase
         $holidays = Yasumi::create('Ireland', $year);
 
         $between = $holidays->between(
-            new \DateTime('01/01/'.$year, new \DateTimeZone($timezone)),
-            new \DateTime('03/16/'.$year, new \DateTimeZone($timezone))
+            new \DateTime('01/01/' . $year, new \DateTimeZone($timezone)),
+            new \DateTime('03/16/' . $year, new \DateTimeZone($timezone))
         );
 
         $betweenHolidays = iterator_to_array($between);

--- a/tests/Base/HolidayFiltersTest.php
+++ b/tests/Base/HolidayFiltersTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Base/HolidayOnFilterTest.php
+++ b/tests/Base/HolidayOnFilterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Base/HolidayTest.php
+++ b/tests/Base/HolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Base/SubstituteHolidayTest.php
+++ b/tests/Base/SubstituteHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -98,7 +101,7 @@ class SubstituteHolidayTest extends TestCase
         $substitute = new SubstituteHoliday($holiday, [], new \DateTime('2019-01-02'), 'en_US');
 
         self::assertIsString($substitute->getName());
-        self::assertEquals('substituteHoliday:'.$name, $substitute->getName());
+        self::assertEquals('substituteHoliday:' . $name, $substitute->getName());
     }
 
     /** @throws \Exception */

--- a/tests/Base/TranslationsTest.php
+++ b/tests/Base/TranslationsTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -155,7 +158,7 @@ return [
 ];
 FILE;
 
-        vfsStream::setup('root', null, ['lang' => [$key.'.php' => $fileContents]]);
+        vfsStream::setup('root', null, ['lang' => [$key . '.php' => $fileContents]]);
 
         $translations = new Translations(self::LOCALES);
         $translations->loadTranslations(vfsStream::url('root/lang'));
@@ -181,7 +184,7 @@ return [
 ];
 FILE;
 
-        vfsStream::setup('root', null, ['lang' => [$key.'.translation' => $fileContents]]);
+        vfsStream::setup('root', null, ['lang' => [$key . '.translation' => $fileContents]]);
 
         $translations = new Translations(self::LOCALES);
         $translations->loadTranslations(vfsStream::url('root/lang'));
@@ -203,7 +206,7 @@ return [
 ];
 FILE;
 
-        vfsStream::setup('root', null, ['lang' => [$key.'.php' => $fileContents]]);
+        vfsStream::setup('root', null, ['lang' => [$key . '.php' => $fileContents]]);
 
         $translations = new Translations(self::LOCALES);
         $translations->loadTranslations(vfsStream::url('root/lang'));
@@ -242,8 +245,8 @@ FILE;
 
         vfsStream::setup('root', null, [
             'lang' => [
-                $firstIdentifier.'.php' => $firstFileContents,
-                $secondIdentifier.'.php' => $secondFileContents,
+                $firstIdentifier . '.php' => $firstFileContents,
+                $secondIdentifier . '.php' => $secondFileContents,
             ],
         ]);
 

--- a/tests/Base/TypographyTest.php
+++ b/tests/Base/TypographyTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Base/WeekendTest.php
+++ b/tests/Base/WeekendTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Base/YasumiExternalProvider.php
+++ b/tests/Base/YasumiExternalProvider.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Base/YasumiTest.php
+++ b/tests/Base/YasumiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -269,7 +272,7 @@ class YasumiTest extends TestCase
     {
         $year = 2110;
         $provider = 'Spain';
-        $date = $year.'-08-15';
+        $date = $year . '-08-15';
 
         // Assertion using a DateTime instance
         $isHoliday = Yasumi::create($provider, $year)->isHoliday(new \DateTime($date));
@@ -296,7 +299,7 @@ class YasumiTest extends TestCase
     {
         $year = 5220;
         $provider = 'Japan';
-        $date = $year.'-06-10';
+        $date = $year . '-06-10';
 
         // Assertion using a DateTime instance
         $isHoliday = Yasumi::create($provider, $year)->isHoliday(new \DateTime($date));
@@ -323,7 +326,7 @@ class YasumiTest extends TestCase
     {
         $year = 2020;
         $provider = 'Netherlands';
-        $date = $year.'-06-02';
+        $date = $year . '-06-02';
 
         // Assertion using a DateTime instance
         $isWorkingDay = Yasumi::create($provider, $year)->isWorkingDay(new \DateTime($date));
@@ -350,7 +353,7 @@ class YasumiTest extends TestCase
     {
         $year = 2016;
         $provider = 'Japan';
-        $date = $year.'-01-11';
+        $date = $year . '-01-11';
 
         // Assertion using a DateTime instance
         $isNotWorkingDay = Yasumi::create($provider, $year)->isWorkingDay(new \DateTime($date));

--- a/tests/Base/YasumiWorkdayTest.php
+++ b/tests/Base/YasumiWorkdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/AllSaintsDayTest.php
+++ b/tests/Belgium/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/ArmisticeDayTest.php
+++ b/tests/Belgium/ArmisticeDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/AscensionDayTest.php
+++ b/tests/Belgium/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/AssumptionOfMaryTest.php
+++ b/tests/Belgium/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/BelgiumBaseTestCase.php
+++ b/tests/Belgium/BelgiumBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/BelgiumTest.php
+++ b/tests/Belgium/BelgiumTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/ChristmasTest.php
+++ b/tests/Belgium/ChristmasTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/EasterMondayTest.php
+++ b/tests/Belgium/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/EasterTest.php
+++ b/tests/Belgium/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/InternationalWorkersDayTest.php
+++ b/tests/Belgium/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/NationalDayTest.php
+++ b/tests/Belgium/NationalDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/NewYearsDayTest.php
+++ b/tests/Belgium/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/PentecostTest.php
+++ b/tests/Belgium/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Belgium/pentecostMondayTest.php
+++ b/tests/Belgium/pentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/BosniaBaseTestCase.php
+++ b/tests/Bosnia/BosniaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/BosniaTest.php
+++ b/tests/Bosnia/BosniaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/ChristmasDayTest.php
+++ b/tests/Bosnia/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/DayAfterNewYearsDay.php
+++ b/tests/Bosnia/DayAfterNewYearsDay.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/EasterTest.php
+++ b/tests/Bosnia/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/IndependenceDayTest.php
+++ b/tests/Bosnia/IndependenceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/InternationalWorkersDayTest.php
+++ b/tests/Bosnia/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/NewYearsDayTest.php
+++ b/tests/Bosnia/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/OrthodoxChristmasDay.php
+++ b/tests/Bosnia/OrthodoxChristmasDay.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/SecondLabourDay.php
+++ b/tests/Bosnia/SecondLabourDay.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Bosnia/StatehoodDayTest.php
+++ b/tests/Bosnia/StatehoodDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/AllSoulsDayTest.php
+++ b/tests/Brazil/AllSoulsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/AshWednesdayTest.php
+++ b/tests/Brazil/AshWednesdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/BrazilBaseTestCase.php
+++ b/tests/Brazil/BrazilBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/BrazilTest.php
+++ b/tests/Brazil/BrazilTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/CarnavalMondayTest.php
+++ b/tests/Brazil/CarnavalMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/CarnavalTuesdayTest.php
+++ b/tests/Brazil/CarnavalTuesdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/ChristmasDayTest.php
+++ b/tests/Brazil/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/CorpusChristiTest.php
+++ b/tests/Brazil/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/EasterTest.php
+++ b/tests/Brazil/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/GoodFridayTest.php
+++ b/tests/Brazil/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/IndependenceDayTest.php
+++ b/tests/Brazil/IndependenceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/InternationalWorkersDayTest.php
+++ b/tests/Brazil/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/NewYearsDayTest.php
+++ b/tests/Brazil/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/OurLadyOfAparecidaDayTest.php
+++ b/tests/Brazil/OurLadyOfAparecidaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/ProclamationOfRepublicDayTest.php
+++ b/tests/Brazil/ProclamationOfRepublicDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Brazil/TiradentesDayTest.php
+++ b/tests/Brazil/TiradentesDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Alberta/AlbertaBaseTestCase.php
+++ b/tests/Canada/Alberta/AlbertaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Alberta/AlbertaTest.php
+++ b/tests/Canada/Alberta/AlbertaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/BritishColumbia/BritishColumbiaBaseTestCase.php
+++ b/tests/Canada/BritishColumbia/BritishColumbiaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/BritishColumbia/BritishColumbiaTest.php
+++ b/tests/Canada/BritishColumbia/BritishColumbiaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/CanadaBaseTestCase.php
+++ b/tests/Canada/CanadaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/CanadaDayTest.php
+++ b/tests/Canada/CanadaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/CanadaTest.php
+++ b/tests/Canada/CanadaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/ChristmasDayTest.php
+++ b/tests/Canada/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/LabourDayTest.php
+++ b/tests/Canada/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Manitoba/ManitobaBaseTestCase.php
+++ b/tests/Canada/Manitoba/ManitobaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Manitoba/ManitobaTest.php
+++ b/tests/Canada/Manitoba/ManitobaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/NewBrunswick/NewBrunswickBaseTestCase.php
+++ b/tests/Canada/NewBrunswick/NewBrunswickBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/NewBrunswick/NewBrunswickTest.php
+++ b/tests/Canada/NewBrunswick/NewBrunswickTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/NewYearsDayTest.php
+++ b/tests/Canada/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/NewfoundlandAndLabrador/NewfoundlandAndLabradorBaseTestCase.php
+++ b/tests/Canada/NewfoundlandAndLabrador/NewfoundlandAndLabradorBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/NewfoundlandAndLabrador/NewfoundlandAndLabradorTest.php
+++ b/tests/Canada/NewfoundlandAndLabrador/NewfoundlandAndLabradorTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/NorthwestTerritories/NorthwestTerritoriesBaseTestCase.php
+++ b/tests/Canada/NorthwestTerritories/NorthwestTerritoriesBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/NorthwestTerritories/NorthwestTerritoriesTest.php
+++ b/tests/Canada/NorthwestTerritories/NorthwestTerritoriesTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/NovaScotia/NovaScotiaBaseTestCase.php
+++ b/tests/Canada/NovaScotia/NovaScotiaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/NovaScotia/NovaScotiaTest.php
+++ b/tests/Canada/NovaScotia/NovaScotiaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Nunavut/NunavutBaseTestCase.php
+++ b/tests/Canada/Nunavut/NunavutBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Nunavut/NunavutTest.php
+++ b/tests/Canada/Nunavut/NunavutTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Ontario/OntarioBaseTestCase.php
+++ b/tests/Canada/Ontario/OntarioBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Ontario/OntarioTest.php
+++ b/tests/Canada/Ontario/OntarioTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/PrinceEdwardIsland/PrinceEdwardIslandBaseTestCase.php
+++ b/tests/Canada/PrinceEdwardIsland/PrinceEdwardIslandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/PrinceEdwardIsland/PrinceEdwardIslandTest.php
+++ b/tests/Canada/PrinceEdwardIsland/PrinceEdwardIslandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Quebec/QuebecBaseTestCase.php
+++ b/tests/Canada/Quebec/QuebecBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Quebec/QuebecTest.php
+++ b/tests/Canada/Quebec/QuebecTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/RemembranceDayTest.php
+++ b/tests/Canada/RemembranceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Saskatchewan/SaskatchewanBaseTestCase.php
+++ b/tests/Canada/Saskatchewan/SaskatchewanBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Saskatchewan/SaskatchewanTest.php
+++ b/tests/Canada/Saskatchewan/SaskatchewanTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/ThanksgivingDayTest.php
+++ b/tests/Canada/ThanksgivingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/TruthAndReconciliationDayTest.php
+++ b/tests/Canada/TruthAndReconciliationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Yukon/YukonBaseTestCase.php
+++ b/tests/Canada/Yukon/YukonBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Canada/Yukon/YukonTest.php
+++ b/tests/Canada/Yukon/YukonTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/AllSaintsDayTest.php
+++ b/tests/Croatia/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/AntifascistStruggleDayTest.php
+++ b/tests/Croatia/AntifascistStruggleDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/AssumptionOfMaryTest.php
+++ b/tests/Croatia/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/ChristmasDayTest.php
+++ b/tests/Croatia/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/CorpusChristiTest.php
+++ b/tests/Croatia/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/CroatiaBaseTestCase.php
+++ b/tests/Croatia/CroatiaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/CroatiaTest.php
+++ b/tests/Croatia/CroatiaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/EasterMondayTest.php
+++ b/tests/Croatia/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/EasterTest.php
+++ b/tests/Croatia/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/EpiphanyTest.php
+++ b/tests/Croatia/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/HomelandThanksgivingDayTest.php
+++ b/tests/Croatia/HomelandThanksgivingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/IndependenceDayTest.php
+++ b/tests/Croatia/IndependenceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/InternationalWorkersDayTest.php
+++ b/tests/Croatia/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/NewYearsDayTest.php
+++ b/tests/Croatia/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/RemembranceDayTest.php
+++ b/tests/Croatia/RemembranceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/StStephensDayTest.php
+++ b/tests/Croatia/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Croatia/StatehoodDayTest.php
+++ b/tests/Croatia/StatehoodDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/ChristmasDayTest.php
+++ b/tests/CzechRepublic/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/ChristmasEveTest.php
+++ b/tests/CzechRepublic/ChristmasEveTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/CzechRepublicBaseTestCase.php
+++ b/tests/CzechRepublic/CzechRepublicBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/CzechRepublicTest.php
+++ b/tests/CzechRepublic/CzechRepublicTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/CzechStateHoodDayTest.php
+++ b/tests/CzechRepublic/CzechStateHoodDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/EasterMondayTest.php
+++ b/tests/CzechRepublic/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/GoodFridayTest.php
+++ b/tests/CzechRepublic/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/IndependentCzechoslovakStateDayTest.php
+++ b/tests/CzechRepublic/IndependentCzechoslovakStateDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/InternationalWorkersDayTest.php
+++ b/tests/CzechRepublic/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/JanHusDayTest.php
+++ b/tests/CzechRepublic/JanHusDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/NewYearsDayTest.php
+++ b/tests/CzechRepublic/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/RenewalOfIndependentCzechStateDayTest.php
+++ b/tests/CzechRepublic/RenewalOfIndependentCzechStateDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/SaintsCyrilAndMethodiusDayTest.php
+++ b/tests/CzechRepublic/SaintsCyrilAndMethodiusDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/SecondChristmasDayTest.php
+++ b/tests/CzechRepublic/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/StruggleForFreedomAndDemocracyDayTest.php
+++ b/tests/CzechRepublic/StruggleForFreedomAndDemocracyDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/CzechRepublic/VictoryInEuropeDayTest.php
+++ b/tests/CzechRepublic/VictoryInEuropeDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/AscensionDayTest.php
+++ b/tests/Denmark/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/ChristmasDayTest.php
+++ b/tests/Denmark/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/ChristmasEveTest.php
+++ b/tests/Denmark/ChristmasEveTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/ConstitutionDayTest.php
+++ b/tests/Denmark/ConstitutionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/DaylightSavingTime.php
+++ b/tests/Denmark/DaylightSavingTime.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/DenmarkBaseTestCase.php
+++ b/tests/Denmark/DenmarkBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/DenmarkTest.php
+++ b/tests/Denmark/DenmarkTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/EasterMondayTest.php
+++ b/tests/Denmark/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/EasterTest.php
+++ b/tests/Denmark/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/GoodFridayTest.php
+++ b/tests/Denmark/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/GreatPrayerDayTest.php
+++ b/tests/Denmark/GreatPrayerDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/InternationalWorkersDayTest.php
+++ b/tests/Denmark/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/MaundyThursdayTest.php
+++ b/tests/Denmark/MaundyThursdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/NewYearsDayTest.php
+++ b/tests/Denmark/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/NewYearsEveTest.php
+++ b/tests/Denmark/NewYearsEveTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/PentecostMondayTest.php
+++ b/tests/Denmark/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/PentecostTest.php
+++ b/tests/Denmark/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Denmark/SecondChristmasDayTest.php
+++ b/tests/Denmark/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/ChristmasDayTest.php
+++ b/tests/Estonia/ChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/ChristmasEveDayTest.php
+++ b/tests/Estonia/ChristmasEveDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/EasterDayTest.php
+++ b/tests/Estonia/EasterDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/EstoniaBaseTestCase.php
+++ b/tests/Estonia/EstoniaBaseTestCase.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/EstoniaTest.php
+++ b/tests/Estonia/EstoniaTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/GoodFridayDayTest.php
+++ b/tests/Estonia/GoodFridayDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/IndependenceDayTest.php
+++ b/tests/Estonia/IndependenceDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/InternationalWorkersDayTest.php
+++ b/tests/Estonia/InternationalWorkersDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/NewYearsDayTest.php
+++ b/tests/Estonia/NewYearsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/PentecostTest.php
+++ b/tests/Estonia/PentecostTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/RestorationOfIndependenceDayTest.php
+++ b/tests/Estonia/RestorationOfIndependenceDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/SecondChristmasDayTest.php
+++ b/tests/Estonia/SecondChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/StJohnsDayTest.php
+++ b/tests/Estonia/StJohnsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Estonia/VictoryDayTest.php
+++ b/tests/Estonia/VictoryDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/AllSaintsDayTest.php
+++ b/tests/Finland/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/AscensionDayTest.php
+++ b/tests/Finland/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/ChristmasDayTest.php
+++ b/tests/Finland/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/EasterMondayTest.php
+++ b/tests/Finland/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/EasterTest.php
+++ b/tests/Finland/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/EpiphanyTest.php
+++ b/tests/Finland/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/FinlandBaseTestCase.php
+++ b/tests/Finland/FinlandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/FinlandTest.php
+++ b/tests/Finland/FinlandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/GoodFridayTest.php
+++ b/tests/Finland/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/IndependenceDayTest.php
+++ b/tests/Finland/IndependenceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/InternationalWorkersDayTest.php
+++ b/tests/Finland/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/NewYearsDayTest.php
+++ b/tests/Finland/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/PentecostTest.php
+++ b/tests/Finland/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/SecondChristmasDayTest.php
+++ b/tests/Finland/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Finland/stJohnsDayTest.php
+++ b/tests/Finland/stJohnsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/AllSaintsDayTest.php
+++ b/tests/France/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/ArmisticeDayTest.php
+++ b/tests/France/ArmisticeDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/AscensionDayTest.php
+++ b/tests/France/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/AssumptionOfMaryTest.php
+++ b/tests/France/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/BasRhin/BasRhinBaseTestCase.php
+++ b/tests/France/BasRhin/BasRhinBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/BasRhin/BasRhinTest.php
+++ b/tests/France/BasRhin/BasRhinTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/BasRhin/GoodFridayTest.php
+++ b/tests/France/BasRhin/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/BasRhin/stStephensDayTest.php
+++ b/tests/France/BasRhin/stStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/BastilleDayTest.php
+++ b/tests/France/BastilleDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/ChristmasDayTest.php
+++ b/tests/France/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/EasterMondayTest.php
+++ b/tests/France/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/FranceBaseTestCase.php
+++ b/tests/France/FranceBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/FranceTest.php
+++ b/tests/France/FranceTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/HautRhin/GoodFridayTest.php
+++ b/tests/France/HautRhin/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/HautRhin/HautRhinBaseTestCase.php
+++ b/tests/France/HautRhin/HautRhinBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/HautRhin/HautRhinTest.php
+++ b/tests/France/HautRhin/HautRhinTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/HautRhin/stStephensDayTest.php
+++ b/tests/France/HautRhin/stStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/InternationalWorkersDayTest.php
+++ b/tests/France/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/Moselle/GoodFridayTest.php
+++ b/tests/France/Moselle/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/Moselle/MoselleBaseTestCase.php
+++ b/tests/France/Moselle/MoselleBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/Moselle/MoselleTest.php
+++ b/tests/France/Moselle/MoselleTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/Moselle/stStephensDayTest.php
+++ b/tests/France/Moselle/stStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/NewYearsDayTest.php
+++ b/tests/France/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/PentecostMondayTest.php
+++ b/tests/France/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/France/VictoryInEuropeDayTest.php
+++ b/tests/France/VictoryInEuropeDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/EasterTest.php
+++ b/tests/Georgia/EasterTest.php
@@ -1,6 +1,19 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 namespace Yasumi\tests\Georgia;
 

--- a/tests/Georgia/GeorgiaBaseTestCase.php
+++ b/tests/Georgia/GeorgiaBaseTestCase.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/GeorgiaTest.php
+++ b/tests/Georgia/GeorgiaTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/IndependenceDayTest.php
+++ b/tests/Georgia/IndependenceDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/InternationalWomensDayTest.php
+++ b/tests/Georgia/InternationalWomensDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/MtskhetobaDayTest.php
+++ b/tests/Georgia/MtskhetobaDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/NewYearsDayTest.php
+++ b/tests/Georgia/NewYearsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/OrthodoxChristmasDayTest.php
+++ b/tests/Georgia/OrthodoxChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/OrthodoxEpiphanyDayTest.php
+++ b/tests/Georgia/OrthodoxEpiphanyDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/SecondNewYearDayTest.php
+++ b/tests/Georgia/SecondNewYearDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/StAndrewsDayTest.php
+++ b/tests/Georgia/StAndrewsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/StGeorgesDayTest.php
+++ b/tests/Georgia/StGeorgesDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/StMarysDayTest.php
+++ b/tests/Georgia/StMarysDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/UnityDayTest.php
+++ b/tests/Georgia/UnityDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Georgia/VictoryDayTest.php
+++ b/tests/Georgia/VictoryDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/AscensionDayTest.php
+++ b/tests/Germany/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/BadenWurttemberg/AllSaintsDayTest.php
+++ b/tests/Germany/BadenWurttemberg/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/BadenWurttemberg/BadenWurttembergBaseTestCase.php
+++ b/tests/Germany/BadenWurttemberg/BadenWurttembergBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/BadenWurttemberg/BadenWurttembergTest.php
+++ b/tests/Germany/BadenWurttemberg/BadenWurttembergTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/BadenWurttemberg/CorpusChristiTest.php
+++ b/tests/Germany/BadenWurttemberg/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/BadenWurttemberg/EpiphanyTest.php
+++ b/tests/Germany/BadenWurttemberg/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/BadenWurttemberg/GermanUnityDayTest.php
+++ b/tests/Germany/BadenWurttemberg/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/BadenWurttemberg/ReformationDay2017Test.php
+++ b/tests/Germany/BadenWurttemberg/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bavaria/AllSaintsDayTest.php
+++ b/tests/Germany/Bavaria/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bavaria/AssumptionOfMaryTest.php
+++ b/tests/Germany/Bavaria/AssumptionOfMaryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Germany\Bavaria;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing the day of the Assumption of Mary in Bavaria (Germany).
+ */
+class AssumptionOfMaryTest extends BavariaBaseTestCase implements HolidayTestCase
+{
+    /**
+     * The name of the holiday.
+     */
+    public const HOLIDAY = 'assumptionOfMary';
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int       $year     the year for which the holiday defined in this test needs to be tested
+     * @param \DateTime $expected the expected date
+     */
+    public function testHoliday(int $year, \DateTimeInterface $expected): void
+    {
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /**
+     * Returns a list of random test dates used for assertion of the holiday defined in this test.
+     *
+     * @return array<array> list of test dates for the holiday defined in this test
+     *
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        return $this->generateRandomDates(8, 15, self::TIMEZONE);
+    }
+
+    /**
+     * Tests translated name of the Assumption of Mary.
+     *
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Mariä Himmelfahrt']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
+    }
+}

--- a/tests/Germany/Bavaria/BavariaBaseTestCase.php
+++ b/tests/Germany/Bavaria/BavariaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bavaria/BavariaTest.php
+++ b/tests/Germany/Bavaria/BavariaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bavaria/CorpusChristiTest.php
+++ b/tests/Germany/Bavaria/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bavaria/EpiphanyTest.php
+++ b/tests/Germany/Bavaria/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bavaria/GermanUnityDayTest.php
+++ b/tests/Germany/Bavaria/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bavaria/ReformationDay2017Test.php
+++ b/tests/Germany/Bavaria/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Berlin/BerlinBaseTestCase.php
+++ b/tests/Germany/Berlin/BerlinBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Berlin/BerlinTest.php
+++ b/tests/Germany/Berlin/BerlinTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Berlin/DayOfLiberation2020Test.php
+++ b/tests/Germany/Berlin/DayOfLiberation2020Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -43,7 +46,7 @@ class DayOfLiberation2020Test extends BerlinBaseTestCase implements HolidayTestC
             self::REGION,
             self::HOLIDAY,
             self::YEAR,
-            new \DateTime(self::YEAR.'-05-08', new \DateTimeZone(self::TIMEZONE))
+            new \DateTime(self::YEAR . '-05-08', new \DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/Germany/Berlin/GermanUnityDayTest.php
+++ b/tests/Germany/Berlin/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Berlin/InternationalWomensDay2019Test.php
+++ b/tests/Germany/Berlin/InternationalWomensDay2019Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -43,7 +46,7 @@ class InternationalWomensDay2019Test extends BerlinBaseTestCase implements Holid
             self::REGION,
             self::HOLIDAY,
             self::ESTABLISHMENT_YEAR,
-            new \DateTime(self::ESTABLISHMENT_YEAR.'-03-08', new \DateTimeZone(self::TIMEZONE))
+            new \DateTime(self::ESTABLISHMENT_YEAR . '-03-08', new \DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/Germany/Berlin/ReformationDay2017Test.php
+++ b/tests/Germany/Berlin/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Brandenburg/BrandenburgBaseTestCase.php
+++ b/tests/Germany/Brandenburg/BrandenburgBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Brandenburg/BrandenburgTest.php
+++ b/tests/Germany/Brandenburg/BrandenburgTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Brandenburg/GermanUnityDayTest.php
+++ b/tests/Germany/Brandenburg/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Brandenburg/ReformationDayTest.php
+++ b/tests/Germany/Brandenburg/ReformationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bremen/BremenBaseTestCase.php
+++ b/tests/Germany/Bremen/BremenBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bremen/BremenTest.php
+++ b/tests/Germany/Bremen/BremenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bremen/GermanUnityDayTest.php
+++ b/tests/Germany/Bremen/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bremen/ReformationDay2017Test.php
+++ b/tests/Germany/Bremen/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Bremen/ReformationDayTest.php
+++ b/tests/Germany/Bremen/ReformationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/ChristmasTest.php
+++ b/tests/Germany/ChristmasTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/EasterMondayTest.php
+++ b/tests/Germany/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/GermanUnityDayTest.php
+++ b/tests/Germany/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/GermanyBaseTestCase.php
+++ b/tests/Germany/GermanyBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/GermanyTest.php
+++ b/tests/Germany/GermanyTest.php
@@ -87,7 +87,10 @@ class GermanyTest extends GermanyBaseTestCase implements ProviderTestCase
      */
     public function testOtherHolidays(): void
     {
-        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+        $this->assertDefinedHolidays([
+            'newYearsEve',
+            'pentecost',
+        ], self::REGION, $this->year, Holiday::TYPE_OTHER);
     }
 
     /**

--- a/tests/Germany/GermanyTest.php
+++ b/tests/Germany/GermanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/GoodFridayTest.php
+++ b/tests/Germany/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Hamburg/DayOfReformationTest.php
+++ b/tests/Germany/Hamburg/DayOfReformationTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Hamburg/GermanUnityDay.php
+++ b/tests/Germany/Hamburg/GermanUnityDay.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Hamburg/HamburgBaseTestCase.php
+++ b/tests/Germany/Hamburg/HamburgBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Hamburg/HamburgTest.php
+++ b/tests/Germany/Hamburg/HamburgTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Hamburg/ReformationDay2017Test.php
+++ b/tests/Germany/Hamburg/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Hesse/CorpusChristiTest.php
+++ b/tests/Germany/Hesse/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Hesse/GermanUnityDayTest.php
+++ b/tests/Germany/Hesse/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Hesse/HesseBaseTestCase.php
+++ b/tests/Germany/Hesse/HesseBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Hesse/HesseTest.php
+++ b/tests/Germany/Hesse/HesseTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Hesse/ReformationDay2017Test.php
+++ b/tests/Germany/Hesse/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/InternationalWorkersDayTest.php
+++ b/tests/Germany/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/LowerSaxony/GermanUnityDayTest.php
+++ b/tests/Germany/LowerSaxony/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/LowerSaxony/LowerSaxonyBaseTestCase.php
+++ b/tests/Germany/LowerSaxony/LowerSaxonyBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/LowerSaxony/LowerSaxonyTest.php
+++ b/tests/Germany/LowerSaxony/LowerSaxonyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/LowerSaxony/ReformationDay2017Test.php
+++ b/tests/Germany/LowerSaxony/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/LowerSaxony/ReformationDayTest.php
+++ b/tests/Germany/LowerSaxony/ReformationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/MecklenburgWesternPomerania/GermanUnityDayTest.php
+++ b/tests/Germany/MecklenburgWesternPomerania/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/MecklenburgWesternPomerania/InternationalWomensDayTest.php
+++ b/tests/Germany/MecklenburgWesternPomerania/InternationalWomensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -43,7 +46,7 @@ class InternationalWomensDayTest extends MecklenburgWesternPomeraniaBaseTestCase
             self::REGION,
             self::HOLIDAY,
             self::ESTABLISHMENT_YEAR,
-            new \DateTime(self::ESTABLISHMENT_YEAR.'-03-08', new \DateTimeZone(self::TIMEZONE))
+            new \DateTime(self::ESTABLISHMENT_YEAR . '-03-08', new \DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/Germany/MecklenburgWesternPomerania/MecklenburgWesternPomeraniaBaseTestCase.php
+++ b/tests/Germany/MecklenburgWesternPomerania/MecklenburgWesternPomeraniaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/MecklenburgWesternPomerania/MecklenburgWesternPomeraniaTest.php
+++ b/tests/Germany/MecklenburgWesternPomerania/MecklenburgWesternPomeraniaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/MecklenburgWesternPomerania/ReformationDayTest.php
+++ b/tests/Germany/MecklenburgWesternPomerania/ReformationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/NewYearsDayTest.php
+++ b/tests/Germany/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/NewYearsEveTest.php
+++ b/tests/Germany/NewYearsEveTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/NorthRhineWestphalia/AllSaintsDayTest.php
+++ b/tests/Germany/NorthRhineWestphalia/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/NorthRhineWestphalia/CorpusChristiTest.php
+++ b/tests/Germany/NorthRhineWestphalia/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/NorthRhineWestphalia/GermanUnityDayTest.php
+++ b/tests/Germany/NorthRhineWestphalia/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/NorthRhineWestphalia/NorthRhineWestphaliaBaseTestCase.php
+++ b/tests/Germany/NorthRhineWestphalia/NorthRhineWestphaliaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/NorthRhineWestphalia/NorthRhineWestphaliaTest.php
+++ b/tests/Germany/NorthRhineWestphalia/NorthRhineWestphaliaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/NorthRhineWestphalia/ReformationDay2017Test.php
+++ b/tests/Germany/NorthRhineWestphalia/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/PentecostMondayTest.php
+++ b/tests/Germany/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/PentecostTest.php
+++ b/tests/Germany/PentecostTest.php
@@ -73,6 +73,6 @@ class PentecostTest extends GermanyBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OTHER);
     }
 }

--- a/tests/Germany/PentecostTest.php
+++ b/tests/Germany/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -36,7 +39,7 @@ class PentecostTest extends GermanyBaseTestCase implements HolidayTestCase
     {
         $year = $this->generateRandomYear();
         $time_stamp = strtotime(
-            $year.'-03-21'.easter_days($year).' day + 49 day'
+            $year . '-03-21' . easter_days($year) . ' day + 49 day'
         );
         $date = date('Y-m-d', $time_stamp);
 

--- a/tests/Germany/ReformationDay2017Test.php
+++ b/tests/Germany/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -43,7 +46,7 @@ class ReformationDay2017Test extends GermanyBaseTestCase implements HolidayTestC
             self::REGION,
             self::HOLIDAY,
             self::ESTABLISHMENT_YEAR,
-            new \DateTime(self::ESTABLISHMENT_YEAR.'-10-31', new \DateTimeZone(self::TIMEZONE))
+            new \DateTime(self::ESTABLISHMENT_YEAR . '-10-31', new \DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/Germany/RhinelandPalatinate/AllSaintsDayTest.php
+++ b/tests/Germany/RhinelandPalatinate/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/RhinelandPalatinate/CorpusChristiTest.php
+++ b/tests/Germany/RhinelandPalatinate/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/RhinelandPalatinate/GermanUnityDayTest.php
+++ b/tests/Germany/RhinelandPalatinate/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/RhinelandPalatinate/ReformationDay2017Test.php
+++ b/tests/Germany/RhinelandPalatinate/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/RhinelandPalatinate/RhinelandPalatinateBaseTestCase.php
+++ b/tests/Germany/RhinelandPalatinate/RhinelandPalatinateBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/RhinelandPalatinate/RhinelandPalatinateTest.php
+++ b/tests/Germany/RhinelandPalatinate/RhinelandPalatinateTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saarland/AllSaintsDayTest.php
+++ b/tests/Germany/Saarland/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saarland/AssumptionOfMaryTest.php
+++ b/tests/Germany/Saarland/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saarland/CorpusChristiTest.php
+++ b/tests/Germany/Saarland/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saarland/GermanUnityDayTest.php
+++ b/tests/Germany/Saarland/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saarland/ReformationDay2017Test.php
+++ b/tests/Germany/Saarland/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saarland/SaarlandBaseTestCase.php
+++ b/tests/Germany/Saarland/SaarlandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saarland/SaarlandTest.php
+++ b/tests/Germany/Saarland/SaarlandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saxony/GermanUnityDayTest.php
+++ b/tests/Germany/Saxony/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saxony/ReformationDayTest.php
+++ b/tests/Germany/Saxony/ReformationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saxony/RepentanceAndPrayerDayTest.php
+++ b/tests/Germany/Saxony/RepentanceAndPrayerDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saxony/SaxonyBaseTestCase.php
+++ b/tests/Germany/Saxony/SaxonyBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Saxony/SaxonyTest.php
+++ b/tests/Germany/Saxony/SaxonyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SaxonyAnhalt/EpiphanyTest.php
+++ b/tests/Germany/SaxonyAnhalt/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SaxonyAnhalt/GermanUnityDayTest.php
+++ b/tests/Germany/SaxonyAnhalt/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SaxonyAnhalt/ReformationDayTest.php
+++ b/tests/Germany/SaxonyAnhalt/ReformationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SaxonyAnhalt/SaxonyAnhaltBaseTestCase.php
+++ b/tests/Germany/SaxonyAnhalt/SaxonyAnhaltBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SaxonyAnhalt/SaxonyAnhaltTest.php
+++ b/tests/Germany/SaxonyAnhalt/SaxonyAnhaltTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SchleswigHolstein/GermanUnityDayTest.php
+++ b/tests/Germany/SchleswigHolstein/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SchleswigHolstein/ReformationDay2017Test.php
+++ b/tests/Germany/SchleswigHolstein/ReformationDay2017Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SchleswigHolstein/ReformationDayTest.php
+++ b/tests/Germany/SchleswigHolstein/ReformationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SchleswigHolstein/SchleswigHolsteinBaseTestCase.php
+++ b/tests/Germany/SchleswigHolstein/SchleswigHolsteinBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SchleswigHolstein/SchleswigHolsteinTest.php
+++ b/tests/Germany/SchleswigHolstein/SchleswigHolsteinTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/SecondChristmasDayTest.php
+++ b/tests/Germany/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Thuringia/GermanUnityDayTest.php
+++ b/tests/Germany/Thuringia/GermanUnityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Thuringia/ReformationDayTest.php
+++ b/tests/Germany/Thuringia/ReformationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Thuringia/ThuringiaBaseTestCase.php
+++ b/tests/Germany/Thuringia/ThuringiaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Thuringia/ThuringiaTest.php
+++ b/tests/Germany/Thuringia/ThuringiaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Germany/Thuringia/WorldChildrensDayTest.php
+++ b/tests/Germany/Thuringia/WorldChildrensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/AnnunciationTest.php
+++ b/tests/Greece/AnnunciationTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/AscensionDayTest.php
+++ b/tests/Greece/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/AssumptionOfMaryTest.php
+++ b/tests/Greece/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/ChristmasDayTest.php
+++ b/tests/Greece/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/CleanMondayTest.php
+++ b/tests/Greece/CleanMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/EasterMondayTest.php
+++ b/tests/Greece/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/EasterTest.php
+++ b/tests/Greece/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/EpiphanyTest.php
+++ b/tests/Greece/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/GreeceBaseTestCase.php
+++ b/tests/Greece/GreeceBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/GreeceTest.php
+++ b/tests/Greece/GreeceTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/IndependenceDayTest.php
+++ b/tests/Greece/IndependenceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/InternationalWorkersDayTest.php
+++ b/tests/Greece/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/NewYearsDayTest.php
+++ b/tests/Greece/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/OhiDayTest.php
+++ b/tests/Greece/OhiDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/PentecostMondayTest.php
+++ b/tests/Greece/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/PentecostTest.php
+++ b/tests/Greece/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/PolytechnioTest.php
+++ b/tests/Greece/PolytechnioTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/ThreeHolyHierarchsTest.php
+++ b/tests/Greece/ThreeHolyHierarchsTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Greece/goodFridayTest.php
+++ b/tests/Greece/goodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/HolidayTestCase.php
+++ b/tests/HolidayTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/AllSaintsDayTest.php
+++ b/tests/Hungary/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/ChristmasTest.php
+++ b/tests/Hungary/ChristmasTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/EasterMondayTest.php
+++ b/tests/Hungary/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/EasterTest.php
+++ b/tests/Hungary/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/HungaryBaseTestCase.php
+++ b/tests/Hungary/HungaryBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/HungaryTest.php
+++ b/tests/Hungary/HungaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/InternationalWorkersDayTest.php
+++ b/tests/Hungary/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/MemorialDay1848Test.php
+++ b/tests/Hungary/MemorialDay1848Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/MemorialDay1956Test.php
+++ b/tests/Hungary/MemorialDay1956Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/NewYearsDayTest.php
+++ b/tests/Hungary/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/PentecostMondayTest.php
+++ b/tests/Hungary/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/PentecostTest.php
+++ b/tests/Hungary/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/SecondChristmasDayTest.php
+++ b/tests/Hungary/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Hungary/StateFoundationDayTest.php
+++ b/tests/Hungary/StateFoundationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Iran/AnniversaryOfIslamicRevolutionTest.php
+++ b/tests/Iran/AnniversaryOfIslamicRevolutionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\Yasumi;
+
+class AnniversaryOfIslamicRevolutionTest extends IranBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'anniversaryOfIslamicRevolution';
+
+    public const ESTABLISHMENT_YEAR = 1979;
+
+    public function testAnniversaryOfIslamicRevolutionBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(Yasumi::YEAR_LOWER_BOUND, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testAnniversaryOfIslamicRevolutionAfterEstablishment(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-02-11", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [
+                self::LOCALE => 'انقلاب اسلامی پنجاه و هفت',
+                'en' => 'Enqelab e Eslami',
+            ]
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(self::ESTABLISHMENT_YEAR), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Iran/DeathOfKhomeiniTest.php
+++ b/tests/Iran/DeathOfKhomeiniTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\Yasumi;
+
+class DeathOfKhomeiniTest extends IranBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'deathOfKhomeini';
+
+    public const ESTABLISHMENT_YEAR = 1989;
+
+    public function testDeathOfKhomeiniBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(Yasumi::YEAR_LOWER_BOUND, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testDeathOfKhomeiniAfterEstablishment(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-06-04", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [
+                self::LOCALE => 'مرگ خمینی',
+                'en' => 'Marg e Khomeini',
+            ]
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(self::ESTABLISHMENT_YEAR), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Iran/IranBaseTestCase.php
+++ b/tests/Iran/IranBaseTestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use PHPUnit\Framework\TestCase;
+use Yasumi\tests\YasumiBase;
+
+class IranBaseTestCase extends TestCase
+{
+    use YasumiBase;
+
+    public const REGION = 'Iran';
+
+    public const TIMEZONE = 'Asia/Tehran';
+
+    public const LOCALE = 'fa';
+}

--- a/tests/Iran/IranTest.php
+++ b/tests/Iran/IranTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\ProviderTestCase;
+
+class IranTest extends IranBaseTestCase implements ProviderTestCase
+{
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected int $year;
+
+    /**
+     * @throws \Exception
+     */
+    protected function setUp(): void
+    {
+        $this->year = $this->generateRandomYear();
+    }
+
+    public function testOfficialHolidays(): void
+    {
+        $holidays = [
+            'nowruz1',
+            'nowruz2',
+            'nowruz3',
+            'nowruz4',
+            'sizdahBedar',
+        ];
+
+        if (1979 <= $this->year) {
+            $holidays[] = 'islamicRepublicDay';
+            $holidays[] = 'revoltOfKhordad15';
+            $holidays[] = 'anniversaryOfIslamicRevolution';
+        }
+
+        if (1989 <= $this->year) {
+            $holidays[] = 'deathOfKhomeini';
+        }
+
+        if (1951 <= $this->year) {
+            $holidays[] = 'nationalizationOfTheIranianOilIndustry';
+        }
+
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    public function testObservedHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+    }
+
+    public function testSeasonalHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_SEASON);
+    }
+
+    public function testBankHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_BANK);
+    }
+
+    public function testOtherHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+    }
+
+    /**
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testSources(): void
+    {
+        $this->assertSources(self::REGION, 2);
+    }
+}

--- a/tests/Iran/IslamicRepublicDayTest.php
+++ b/tests/Iran/IslamicRepublicDayTest.php
@@ -47,7 +47,6 @@ class IslamicRepublicDayTest extends IranBaseTestCase implements HolidayTestCase
     public function testIslamicRepublicDayBeforeEquinoxYear(): void
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::EQUINOX_YEAR - 1);
-        var_dump($year);
         $this->assertHoliday(
             self::REGION,
             self::HOLIDAY,

--- a/tests/Iran/IslamicRepublicDayTest.php
+++ b/tests/Iran/IslamicRepublicDayTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\Yasumi;
+
+class IslamicRepublicDayTest extends IranBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'islamicRepublicDay';
+
+    public const ESTABLISHMENT_YEAR = 1979;
+
+    public const EQUINOX_YEAR = 2016;
+
+    /**
+     * @throws \Exception
+     */
+    public function testIslamicRepublicDayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(Yasumi::YEAR_LOWER_BOUND, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testIslamicRepublicDayBeforeEquinoxYear(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::EQUINOX_YEAR - 1);
+        var_dump($year);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-04-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testIslamicRepublicDayOnEquinoxYear(): void
+    {
+        $year = $this->generateRandomYear(self::EQUINOX_YEAR, self::EQUINOX_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-03-31", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testIslamicRepublicDayAfterEquinoxYear(): void
+    {
+        $year = $this->generateRandomYear(self::EQUINOX_YEAR + 1);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-04-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::EQUINOX_YEAR),
+            [
+                self::LOCALE => 'روز جمهوری اسلامی',
+                'en' => 'Ruz e Jomhuri ye Eslami',
+            ]
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::EQUINOX_YEAR), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Iran/NationalizationOfTheIranianOilIndustryTest.php
+++ b/tests/Iran/NationalizationOfTheIranianOilIndustryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\Yasumi;
+
+class NationalizationOfTheIranianOilIndustryTest extends IranBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'nationalizationOfTheIranianOilIndustry';
+
+    public const ESTABLISHMENT_YEAR = 1951;
+
+    public function testNationalizationOfTheIranianOilIndustryBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(Yasumi::YEAR_LOWER_BOUND, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testNationalizationOfTheIranianOilIndustryAfterEstablishment(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-03-20", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [
+                self::LOCALE => 'ملی شدن صنعت نفت',
+                'en' => 'Melli Shodan e Saneat e Naft',
+            ]
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(self::ESTABLISHMENT_YEAR), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Iran/Nowruz1Test.php
+++ b/tests/Iran/Nowruz1Test.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+class Nowruz1Test extends IranBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'nowruz1';
+
+    /**
+     * @throws \Exception
+     */
+    public function testNowruz1(): void
+    {
+        $year = $this->generateRandomYear();
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-03-21", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [
+                self::LOCALE => 'نوروز',
+                'en' => 'Nowruz',
+            ]
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Iran/Nowruz2Test.php
+++ b/tests/Iran/Nowruz2Test.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+class Nowruz2Test extends IranBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'nowruz2';
+
+    /**
+     * @throws \Exception
+     */
+    public function testNowruz2(): void
+    {
+        $year = $this->generateRandomYear();
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-03-22", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [
+                self::LOCALE => 'نوروز',
+                'en' => 'Nowruz',
+            ]
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Iran/Nowruz3Test.php
+++ b/tests/Iran/Nowruz3Test.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+class Nowruz3Test extends IranBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'nowruz3';
+
+    /**
+     * @throws \Exception
+     */
+    public function testNowruz3(): void
+    {
+        $year = $this->generateRandomYear();
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-03-23", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [
+                self::LOCALE => 'نوروز',
+                'en' => 'Nowruz',
+            ]
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Iran/Nowruz4Test.php
+++ b/tests/Iran/Nowruz4Test.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+class Nowruz4Test extends IranBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'nowruz4';
+
+    /**
+     * @throws \Exception
+     */
+    public function testNowruz4(): void
+    {
+        $year = $this->generateRandomYear();
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-03-24", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [
+                self::LOCALE => 'نوروز',
+                'en' => 'Nowruz',
+            ]
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Iran/RevoltOfKhordad15Test.php
+++ b/tests/Iran/RevoltOfKhordad15Test.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\Yasumi;
+
+class RevoltOfKhordad15Test extends IranBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'revoltOfKhordad15';
+
+    public const ESTABLISHMENT_YEAR = 1979;
+
+    public function testRevoltOfKhordad15BeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(Yasumi::YEAR_LOWER_BOUND, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testRevoltOfKhordad15AfterEstablishment(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-06-05", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [
+                self::LOCALE => 'قیام ۱۵ خرداد',
+                'en' => 'Qiam e Panzdah e Khordad',
+            ]
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(self::ESTABLISHMENT_YEAR), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Iran/SizdahBedarTest.php
+++ b/tests/Iran/SizdahBedarTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Iran;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+class SizdahBedarTest extends IranBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'sizdahBedar';
+
+    /**
+     * @throws \Exception
+     */
+    public function testSizdahBedar(): void
+    {
+        $year = $this->generateRandomYear();
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-04-02", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [
+                self::LOCALE => 'سیزده بدر',
+                'en' => 'Sizdah be dar',
+            ]
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ireland/AugustHolidayTest.php
+++ b/tests/Ireland/AugustHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ireland/ChristmasDayTest.php
+++ b/tests/Ireland/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,7 +47,7 @@ class ChristmasDayTest extends IrelandBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->modify('next tuesday');
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/Ireland/EasterMondayTest.php
+++ b/tests/Ireland/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ireland/EasterTest.php
+++ b/tests/Ireland/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ireland/GoodFridayTest.php
+++ b/tests/Ireland/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ireland/IrelandBaseTestCase.php
+++ b/tests/Ireland/IrelandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ireland/IrelandTest.php
+++ b/tests/Ireland/IrelandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ireland/JuneHolidayTest.php
+++ b/tests/Ireland/JuneHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ireland/MayDayTest.php
+++ b/tests/Ireland/MayDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ireland/NewYearsDayTest.php
+++ b/tests/Ireland/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -49,7 +52,7 @@ class NewYearsDayTest extends IrelandBaseTestCase implements HolidayTestCase
 
         if (0 === (int) $date->format('w')) {
             $date->modify('next monday');
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/Ireland/OctoberHolidayTest.php
+++ b/tests/Ireland/OctoberHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ireland/PentecostTest.php
+++ b/tests/Ireland/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ireland/StPatricksDayTest.php
+++ b/tests/Ireland/StPatricksDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -49,7 +52,7 @@ class StPatricksDayTest extends IrelandBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->modify('next monday');
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/Ireland/StStephensDayTest.php
+++ b/tests/Ireland/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,7 +47,7 @@ class StStephensDayTest extends IrelandBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->modify('next monday');
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/Ireland/pentecostMondayTest.php
+++ b/tests/Ireland/pentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/AllSaintsDayTest.php
+++ b/tests/Italy/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/AssumptionOfMaryTest.php
+++ b/tests/Italy/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/ChristmasTest.php
+++ b/tests/Italy/ChristmasTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/EasterMondayTest.php
+++ b/tests/Italy/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/EasterTest.php
+++ b/tests/Italy/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/EpiphanyTest.php
+++ b/tests/Italy/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/ImmaculateConceptionTest.php
+++ b/tests/Italy/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/InternationalWorkersDayTest.php
+++ b/tests/Italy/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/ItalyBaseTestCase.php
+++ b/tests/Italy/ItalyBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/ItalyTest.php
+++ b/tests/Italy/ItalyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/LiberationDayTest.php
+++ b/tests/Italy/LiberationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/NewYearsDayTest.php
+++ b/tests/Italy/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/RepublicDayTest.php
+++ b/tests/Italy/RepublicDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Italy/stStephensDayTest.php
+++ b/tests/Italy/stStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Japan/AutumnalEquinoxDayTest.php
+++ b/tests/Japan/AutumnalEquinoxDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Japan/ChildrensDayTest.php
+++ b/tests/Japan/ChildrensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -58,7 +61,7 @@ class ChildrensDayTest extends JapanBaseTestCase implements HolidayTestCase
         $year = 2120;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-5-6", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/ComingOfAgeDayTest.php
+++ b/tests/Japan/ComingOfAgeDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Japan/ConstitutionMemorialDayTest.php
+++ b/tests/Japan/ConstitutionMemorialDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -59,7 +62,7 @@ class ConstitutionMemorialDayTest extends JapanBaseTestCase implements HolidayTe
         $year = 2009;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-5-6", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/CoronationDayTest.php
+++ b/tests/Japan/CoronationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Japan/CultureDayTest.php
+++ b/tests/Japan/CultureDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -58,7 +61,7 @@ class CultureDayTest extends JapanBaseTestCase implements HolidayTestCase
         $year = 2661;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-11-4", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/EmperorsBirthdayTest.php
+++ b/tests/Japan/EmperorsBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -97,7 +100,7 @@ class EmperorsBirthdayTest extends JapanBaseTestCase implements HolidayTestCase
         $year = 2001;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-12-24", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/EnthronementProclamationCeremonyTest.php
+++ b/tests/Japan/EnthronementProclamationCeremonyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Japan/GreeneryDayTest.php
+++ b/tests/Japan/GreeneryDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -59,7 +62,7 @@ class GreeneryDayTest extends JapanBaseTestCase implements HolidayTestCase
         $year = 2014;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-5-6", new \DateTimeZone(self::TIMEZONE))
         );
@@ -92,7 +95,7 @@ class GreeneryDayTest extends JapanBaseTestCase implements HolidayTestCase
         $year = 2001;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-4-30", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/JapanBaseTestCase.php
+++ b/tests/Japan/JapanBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Japan/JapanTest.php
+++ b/tests/Japan/JapanTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Japan/LabourThanksgivingDayTest.php
+++ b/tests/Japan/LabourThanksgivingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -60,7 +63,7 @@ class LabourThanksgivingDayTest extends JapanBaseTestCase implements HolidayTest
         $year = 1986;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-11-24", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/MarineDayTest.php
+++ b/tests/Japan/MarineDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -109,7 +112,7 @@ final class MarineDayTest extends JapanBaseTestCase implements HolidayTestCase
         $year = 1997;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-7-21", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/MountainDayTest.php
+++ b/tests/Japan/MountainDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -90,7 +93,7 @@ class MountainDayTest extends JapanBaseTestCase implements HolidayTestCase
         $year = 2019;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-8-12", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/NationalFoundationDayTest.php
+++ b/tests/Japan/NationalFoundationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -59,7 +62,7 @@ class NationalFoundationDayTest extends JapanBaseTestCase implements HolidayTest
         $year = 2046;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-2-12", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/NewYearsDayTest.php
+++ b/tests/Japan/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -58,7 +61,7 @@ class NewYearsDayTest extends JapanBaseTestCase implements HolidayTestCase
         $year = 4473;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-1-2", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/PublicBridgeDayTest.php
+++ b/tests/Japan/PublicBridgeDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -49,13 +52,13 @@ class PublicBridgeDayTest extends JapanBaseTestCase implements HolidayTestCase
     {
         $this->assertHoliday(
             self::REGION,
-            self::HOLIDAY.'1',
+            self::HOLIDAY . '1',
             $this->year,
             new \DateTime("{$this->year}-4-30", new \DateTimeZone(self::TIMEZONE))
         );
         $this->assertHoliday(
             self::REGION,
-            self::HOLIDAY.'2',
+            self::HOLIDAY . '2',
             $this->year,
             new \DateTime("{$this->year}-5-2", new \DateTimeZone(self::TIMEZONE))
         );
@@ -66,7 +69,7 @@ class PublicBridgeDayTest extends JapanBaseTestCase implements HolidayTestCase
      */
     public function testTranslation(): void
     {
-        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY.'1', $this->year, [self::LOCALE => '国民の休日']);
+        $this->assertTranslatedHolidayName(self::REGION, self::HOLIDAY . '1', $this->year, [self::LOCALE => '国民の休日']);
     }
 
     /**
@@ -74,6 +77,6 @@ class PublicBridgeDayTest extends JapanBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY.'1', $this->year, Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY . '1', $this->year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Japan/RespectForTheAgedDayTest.php
+++ b/tests/Japan/RespectForTheAgedDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -77,7 +80,7 @@ class RespectForTheAgedDayTest extends JapanBaseTestCase implements HolidayTestC
         $year = 2002;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-9-16", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/ShowaDayTest.php
+++ b/tests/Japan/ShowaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -58,7 +61,7 @@ class ShowaDayTest extends JapanBaseTestCase implements HolidayTestCase
         $year = 2210;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-4-30", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/SportsDayTest.php
+++ b/tests/Japan/SportsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -114,7 +117,7 @@ class SportsDayTest extends JapanBaseTestCase implements HolidayTestCase
         $year = 1999;
         $this->assertHoliday(
             self::REGION,
-            self::SUBSTITUTE_PREFIX.self::HOLIDAY,
+            self::SUBSTITUTE_PREFIX . self::HOLIDAY,
             $year,
             new \DateTime("{$year}-10-11", new \DateTimeZone(self::TIMEZONE))
         );

--- a/tests/Japan/VernalEquinoxDayTest.php
+++ b/tests/Japan/VernalEquinoxDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/ChristmasDayTest.php
+++ b/tests/Latvia/ChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/ChristmasEveDayTest.php
+++ b/tests/Latvia/ChristmasEveDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/EasterDayTest.php
+++ b/tests/Latvia/EasterDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/EasterMondayDayTest.php
+++ b/tests/Latvia/EasterMondayDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/GoodFridayDayTest.php
+++ b/tests/Latvia/GoodFridayDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/InternationalWorkersDayTest.php
+++ b/tests/Latvia/InternationalWorkersDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/LatviaBaseTestCase.php
+++ b/tests/Latvia/LatviaBaseTestCase.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/LatviaTest.php
+++ b/tests/Latvia/LatviaTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/MidsummerEveDayTest.php
+++ b/tests/Latvia/MidsummerEveDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/NewYearsDayTest.php
+++ b/tests/Latvia/NewYearsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/NewYearsEveDayTest.php
+++ b/tests/Latvia/NewYearsEveDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/ProclamationOfTheRepublicOfLatviaDayTest.php
+++ b/tests/Latvia/ProclamationOfTheRepublicOfLatviaDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/RestorationOfIndependenceDayTest.php
+++ b/tests/Latvia/RestorationOfIndependenceDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/SecondChristmasDayTest.php
+++ b/tests/Latvia/SecondChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Latvia/StJohnsDayTest.php
+++ b/tests/Latvia/StJohnsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/AllSaintsDayTest.php
+++ b/tests/Lithuania/AllSaintsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/AllSoulsDayTest.php
+++ b/tests/Lithuania/AllSoulsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/AssumptionOfMaryDayTest.php
+++ b/tests/Lithuania/AssumptionOfMaryDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/ChristmasDayTest.php
+++ b/tests/Lithuania/ChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/ChristmasEveDayTest.php
+++ b/tests/Lithuania/ChristmasEveDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/EasterDayTest.php
+++ b/tests/Lithuania/EasterDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/EasterMondayDayTest.php
+++ b/tests/Lithuania/EasterMondayDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/InternationalWorkersDayTest.php
+++ b/tests/Lithuania/InternationalWorkersDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/LithuaniaBaseTestCase.php
+++ b/tests/Lithuania/LithuaniaBaseTestCase.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/LithuaniaTest.php
+++ b/tests/Lithuania/LithuaniaTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/NewYearsDayTest.php
+++ b/tests/Lithuania/NewYearsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/RestorationOfIndependenceOfLithuaniaDayTest.php
+++ b/tests/Lithuania/RestorationOfIndependenceOfLithuaniaDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/RestorationOfTheStateOfLithuaniaDayTest.php
+++ b/tests/Lithuania/RestorationOfTheStateOfLithuaniaDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/SecondChristmasDayTest.php
+++ b/tests/Lithuania/SecondChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/StJohnsDayTest.php
+++ b/tests/Lithuania/StJohnsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Lithuania/StatehoodDayTest.php
+++ b/tests/Lithuania/StatehoodDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/AllSaintsDayTest.php
+++ b/tests/Luxembourg/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/AscensionDayTest.php
+++ b/tests/Luxembourg/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/AssumptionOfMaryTest.php
+++ b/tests/Luxembourg/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/ChristmasDayTest.php
+++ b/tests/Luxembourg/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/EasterMondayTest.php
+++ b/tests/Luxembourg/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/EuropeDayTest.php
+++ b/tests/Luxembourg/EuropeDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/InternationalWorkersDayTest.php
+++ b/tests/Luxembourg/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/LuxembourgBaseTestCase.php
+++ b/tests/Luxembourg/LuxembourgBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/LuxembourgTest.php
+++ b/tests/Luxembourg/LuxembourgTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/NationalDayTest.php
+++ b/tests/Luxembourg/NationalDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/NewYearsDayTest.php
+++ b/tests/Luxembourg/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/PentecostMondayTest.php
+++ b/tests/Luxembourg/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Luxembourg/SecondChristmasDayTest.php
+++ b/tests/Luxembourg/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/AllSaintsDayTest.php
+++ b/tests/Mexico/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/AssumptionOfMaryTest.php
+++ b/tests/Mexico/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/BenitoJuarezBirthdayTest.php
+++ b/tests/Mexico/BenitoJuarezBirthdayTest.php
@@ -1,6 +1,19 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 namespace Yasumi\tests\Mexico;
 

--- a/tests/Mexico/ChristmasTest.php
+++ b/tests/Mexico/ChristmasTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/EasterMondayTest.php
+++ b/tests/Mexico/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/EpiphanyTest.php
+++ b/tests/Mexico/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/GoodFridayTest.php
+++ b/tests/Mexico/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/ImmaculateConceptionTest.php
+++ b/tests/Mexico/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/IndependenceDayTest.php
+++ b/tests/Mexico/IndependenceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/InternationalWorkersDayTest.php
+++ b/tests/Mexico/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/MexicoBaseTestCase.php
+++ b/tests/Mexico/MexicoBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Mexico/NewYearsDayTest.php
+++ b/tests/Mexico/NewYearsDayTest.php
@@ -1,6 +1,19 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 namespace Yasumi\tests\Mexico;
 

--- a/tests/Mexico/VirginOfGuadalupeTest.php
+++ b/tests/Mexico/VirginOfGuadalupeTest.php
@@ -1,6 +1,19 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2024 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
 
 namespace Yasumi\tests\Mexico;
 

--- a/tests/Netherlands/AscensionDayTest.php
+++ b/tests/Netherlands/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/AshWednesdayTest.php
+++ b/tests/Netherlands/AshWednesdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/ChristmasDayTest.php
+++ b/tests/Netherlands/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/CommemorationDayTest.php
+++ b/tests/Netherlands/CommemorationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/DaylightSavingTime.php
+++ b/tests/Netherlands/DaylightSavingTime.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/EasterMondayTest.php
+++ b/tests/Netherlands/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/EasterTest.php
+++ b/tests/Netherlands/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/EpiphanyTest.php
+++ b/tests/Netherlands/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/FathersDayTest.php
+++ b/tests/Netherlands/FathersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/GoodFridayTest.php
+++ b/tests/Netherlands/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/HalloweenTest.php
+++ b/tests/Netherlands/HalloweenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/InternationalWorkersDayTest.php
+++ b/tests/Netherlands/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/KingsDayTest.php
+++ b/tests/Netherlands/KingsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/LiberationDayTest.php
+++ b/tests/Netherlands/LiberationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/MothersDayTest.php
+++ b/tests/Netherlands/MothersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/NetherlandsBaseTestCase.php
+++ b/tests/Netherlands/NetherlandsBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/NetherlandsTest.php
+++ b/tests/Netherlands/NetherlandsTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/NewYearsDayTest.php
+++ b/tests/Netherlands/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/PentecostTest.php
+++ b/tests/Netherlands/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/QueensDayTest.php
+++ b/tests/Netherlands/QueensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/ValentinesDayTest.php
+++ b/tests/Netherlands/ValentinesDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/WorldAnimalDayTest.php
+++ b/tests/Netherlands/WorldAnimalDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/carnivalDayTest.php
+++ b/tests/Netherlands/carnivalDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/pentecostMondayTest.php
+++ b/tests/Netherlands/pentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/princesDayTest.php
+++ b/tests/Netherlands/princesDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/secondCarnivalDay.php
+++ b/tests/Netherlands/secondCarnivalDay.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/secondChristmasdayTest.php
+++ b/tests/Netherlands/secondChristmasdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/stMartinsDayTest.php
+++ b/tests/Netherlands/stMartinsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/stNicholasDayTest.php
+++ b/tests/Netherlands/stNicholasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Netherlands/thirdCarnivalDay.php
+++ b/tests/Netherlands/thirdCarnivalDay.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/AnzacDayTest.php
+++ b/tests/NewZealand/AnzacDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/BoxingDayTest.php
+++ b/tests/NewZealand/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/ChristmasDayTest.php
+++ b/tests/NewZealand/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/DayAfterNewYearsDayTest.php
+++ b/tests/NewZealand/DayAfterNewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/EasterMondayTest.php
+++ b/tests/NewZealand/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/GoodFridayTest.php
+++ b/tests/NewZealand/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/LabourDayTest.php
+++ b/tests/NewZealand/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -74,7 +77,7 @@ class LabourDayTest extends NewZealandBaseTestCase implements HolidayTestCase
         for ($y = 0; $y < 100; ++$y) {
             $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
             $expected = new \DateTime(
-                (($year < 1910) ? 'second wednesday of october' : 'fourth monday of october')." {$year}",
+                (($year < 1910) ? 'second wednesday of october' : 'fourth monday of october') . " {$year}",
                 new \DateTimeZone(self::TIMEZONE)
             );
 

--- a/tests/NewZealand/NewYearsDayTest.php
+++ b/tests/NewZealand/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/NewZealandBaseTestCase.php
+++ b/tests/NewZealand/NewZealandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/NewZealandTest.php
+++ b/tests/NewZealand/NewZealandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/QueensBirthdayTest.php
+++ b/tests/NewZealand/QueensBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/NewZealand/WaitangiDayTest.php
+++ b/tests/NewZealand/WaitangiDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/AscensionDayTest.php
+++ b/tests/Norway/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/ChristmasDayTest.php
+++ b/tests/Norway/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/ConstitutionDayTest.php
+++ b/tests/Norway/ConstitutionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/EasterMondayTest.php
+++ b/tests/Norway/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/EasterTest.php
+++ b/tests/Norway/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/GoodFridayTest.php
+++ b/tests/Norway/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/InternationalWorkersDayTest.php
+++ b/tests/Norway/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/MaundyThursdayTest.php
+++ b/tests/Norway/MaundyThursdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/NewYearsDayTest.php
+++ b/tests/Norway/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/NorwayBaseTestCase.php
+++ b/tests/Norway/NorwayBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/NorwayTest.php
+++ b/tests/Norway/NorwayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/PentecostMondayTest.php
+++ b/tests/Norway/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/PentecostTest.php
+++ b/tests/Norway/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Norway/SecondChristmasDayTest.php
+++ b/tests/Norway/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/AllSaintsDayTest.php
+++ b/tests/Poland/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/AssumptionOfMaryTest.php
+++ b/tests/Poland/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/ChristmasTest.php
+++ b/tests/Poland/ChristmasTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/ConstitutionDayTest.php
+++ b/tests/Poland/ConstitutionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/CorpusChristiTest.php
+++ b/tests/Poland/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/EasterMondayTest.php
+++ b/tests/Poland/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/EasterTest.php
+++ b/tests/Poland/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/EpiphanyTest.php
+++ b/tests/Poland/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/IndependenceDayTest.php
+++ b/tests/Poland/IndependenceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/InternationalWorkersDayTest.php
+++ b/tests/Poland/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/NewYearsDayTest.php
+++ b/tests/Poland/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/PentecostTest.php
+++ b/tests/Poland/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/PolandBaseTestCase.php
+++ b/tests/Poland/PolandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/PolandTest.php
+++ b/tests/Poland/PolandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Poland/SecondChristmasDayTest.php
+++ b/tests/Poland/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/AllSaintsDayTest.php
+++ b/tests/Portugal/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/AssumptionOfMaryTest.php
+++ b/tests/Portugal/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/CarnationRevolutionDayTest.php
+++ b/tests/Portugal/CarnationRevolutionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/ChristmasTest.php
+++ b/tests/Portugal/ChristmasTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/CorpusChristiTest.php
+++ b/tests/Portugal/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/EasterTest.php
+++ b/tests/Portugal/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/GoodFridayTest.php
+++ b/tests/Portugal/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/ImmaculateConceptionTest.php
+++ b/tests/Portugal/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/InternationalWorkersDayTest.php
+++ b/tests/Portugal/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/NewYearsDayTest.php
+++ b/tests/Portugal/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/PortugalBaseTestCase.php
+++ b/tests/Portugal/PortugalBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/PortugalDayTest.php
+++ b/tests/Portugal/PortugalDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/PortugalTest.php
+++ b/tests/Portugal/PortugalTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/PortugueseRepublicDayTest.php
+++ b/tests/Portugal/PortugueseRepublicDayTest.php
@@ -138,7 +138,7 @@ class PortugueseRepublicDayTest extends PortugalBaseTestCase implements HolidayT
      */
     private function randomYearsOnAfterEstablishment(): \Generator
     {
-        yield $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+        yield $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::HOLIDAY_YEAR_SUSPENDED - 1);
         yield self::ESTABLISHMENT_YEAR;
     }
 

--- a/tests/Portugal/PortugueseRepublicDayTest.php
+++ b/tests/Portugal/PortugueseRepublicDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Portugal/RestorationOfIndependenceTest.php
+++ b/tests/Portugal/RestorationOfIndependenceTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/ProviderTestCase.php
+++ b/tests/ProviderTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Randomizer.php
+++ b/tests/Randomizer.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -329,7 +331,7 @@ trait Randomizer
         $timestamp = random_int($startTimestamp, $endTimestamp);
 
         return static::setTimezone(
-            new \DateTime('@'.$timestamp),
+            new \DateTime('@' . $timestamp),
             $timezone
         );
     }
@@ -417,7 +419,7 @@ trait Randomizer
         }
 
         $easter = new \DateTime("{$year}-3-21", new \DateTimeZone($timezone));
-        $easter->add(new \DateInterval('P'.$easter_days.'D'));
+        $easter->add(new \DateInterval('P' . $easter_days . 'D'));
 
         return $easter;
     }

--- a/tests/Romania/AssumptionOfMaryTest.php
+++ b/tests/Romania/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/ChildrensDayTest.php
+++ b/tests/Romania/ChildrensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/ChristmasDayTest.php
+++ b/tests/Romania/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/ConstantinBrancusiDayTest.php
+++ b/tests/Romania/ConstantinBrancusiDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/DayAfterNewYearsDayTest.php
+++ b/tests/Romania/DayAfterNewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/EasterMondayTest.php
+++ b/tests/Romania/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/EasterTest.php
+++ b/tests/Romania/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/EpiphanyTest.php
+++ b/tests/Romania/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/InternationalWorkersDayTest.php
+++ b/tests/Romania/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/NationalDayTest.php
+++ b/tests/Romania/NationalDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/NewYearsDayTest.php
+++ b/tests/Romania/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/PentecostMondayTest.php
+++ b/tests/Romania/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/PentecostTest.php
+++ b/tests/Romania/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/RomaniaBaseTestCase.php
+++ b/tests/Romania/RomaniaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/RomaniaTest.php
+++ b/tests/Romania/RomaniaTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/SecondChristmasDayTest.php
+++ b/tests/Romania/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/StAndrewsDayTest.php
+++ b/tests/Romania/StAndrewsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/StJohnsDayTest.php
+++ b/tests/Romania/StJohnsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Romania/UnitedPrincipalitiesDayTest.php
+++ b/tests/Romania/UnitedPrincipalitiesDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/DefenceOfTheFatherlandDayTest.php
+++ b/tests/Russia/DefenceOfTheFatherlandDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/InternationalWomensDayTest.php
+++ b/tests/Russia/InternationalWomensDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/NewYearHolidaysDay2Test.php
+++ b/tests/Russia/NewYearHolidaysDay2Test.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/NewYearHolidaysDay3Test.php
+++ b/tests/Russia/NewYearHolidaysDay3Test.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/NewYearHolidaysDay4Test.php
+++ b/tests/Russia/NewYearHolidaysDay4Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/NewYearHolidaysDay5Test.php
+++ b/tests/Russia/NewYearHolidaysDay5Test.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/NewYearHolidaysDay6Test.php
+++ b/tests/Russia/NewYearHolidaysDay6Test.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/NewYearHolidaysDay8Test.php
+++ b/tests/Russia/NewYearHolidaysDay8Test.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/NewYearsDayTest.php
+++ b/tests/Russia/NewYearsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/OrthodoxChristmasDayTest.php
+++ b/tests/Russia/OrthodoxChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/RussiaBaseTestCase.php
+++ b/tests/Russia/RussiaBaseTestCase.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/RussiaDayTest.php
+++ b/tests/Russia/RussiaDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/RussiaTest.php
+++ b/tests/Russia/RussiaTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/SpringAndLabourDayTest.php
+++ b/tests/Russia/SpringAndLabourDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/UnityDayTest.php
+++ b/tests/Russia/UnityDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Russia/VictoryDayTest.php
+++ b/tests/Russia/VictoryDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/AllSaintsDayTest.php
+++ b/tests/Slovakia/AllSaintsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/ChristmasDayTest.php
+++ b/tests/Slovakia/ChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/ChristmasEveTest.php
+++ b/tests/Slovakia/ChristmasEveTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/DeclarationOfTheSlovakNationTest.php
+++ b/tests/Slovakia/DeclarationOfTheSlovakNationTest.php
@@ -23,14 +23,14 @@ use Yasumi\tests\HolidayTestCase;
 /**
  * Class for testing an official holiday in Slovakia.
  *
- * @author  Andrej Rypak (dakujem) <xrypak@gmail.com>
+ * @author  Jan Hamrak <snickom@gmail.com>
  */
-class SlovakConstitutionDayTest extends SlovakiaBaseTestCase implements HolidayTestCase
+class DeclarationOfTheSlovakNationTest extends SlovakiaBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday to be tested.
      */
-    public const HOLIDAY = 'slovakConstitutionDay';
+    public const HOLIDAY = 'declarationOfTheSlovakNation';
 
     /**
      * Tests the holiday defined in this test.
@@ -42,7 +42,7 @@ class SlovakConstitutionDayTest extends SlovakiaBaseTestCase implements HolidayT
      */
     public function testHoliday(int $year, \DateTimeInterface $expected): void
     {
-        if ($year < 2024) {
+        if (2018 === $year) {
             $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
         } else {
             $this->assertNotHoliday(self::REGION, self::HOLIDAY, $year);
@@ -58,7 +58,7 @@ class SlovakConstitutionDayTest extends SlovakiaBaseTestCase implements HolidayT
      */
     public function HolidayDataProvider(): array
     {
-        return $this->generateRandomDates(9, 1, self::TIMEZONE);
+        return $this->generateRandomDates(10, 30, self::TIMEZONE);
     }
 
     /**
@@ -71,8 +71,8 @@ class SlovakConstitutionDayTest extends SlovakiaBaseTestCase implements HolidayT
         $this->assertTranslatedHolidayName(
             self::REGION,
             self::HOLIDAY,
-            $this->generateRandomYear(null, 2013),
-            [self::LOCALE => 'Deň Ústavy Slovenskej republiky']
+            2018,
+            [self::LOCALE => 'Výročie Deklarácie slovenského národa']
         );
     }
 
@@ -83,6 +83,6 @@ class SlovakConstitutionDayTest extends SlovakiaBaseTestCase implements HolidayT
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(null, 2013), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, 2018, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Slovakia/EasterMondayTest.php
+++ b/tests/Slovakia/EasterMondayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/EpiphanyTest.php
+++ b/tests/Slovakia/EpiphanyTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/GoodFridayTest.php
+++ b/tests/Slovakia/GoodFridayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/InternationalWorkersDayTest.php
+++ b/tests/Slovakia/InternationalWorkersDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/OurLadyOfSorrowsDayTest.php
+++ b/tests/Slovakia/OurLadyOfSorrowsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/SaintsCyrilAndMethodiusDayTest.php
+++ b/tests/Slovakia/SaintsCyrilAndMethodiusDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/SecondChristmasDayTest.php
+++ b/tests/Slovakia/SecondChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/SlovakConstitutionDayTest.php
+++ b/tests/Slovakia/SlovakConstitutionDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/SlovakIndependenceDayTest.php
+++ b/tests/Slovakia/SlovakIndependenceDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/SlovakNationalUprisingDayTest.php
+++ b/tests/Slovakia/SlovakNationalUprisingDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/SlovakiaBaseTestCase.php
+++ b/tests/Slovakia/SlovakiaBaseTestCase.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/SlovakiaTest.php
+++ b/tests/Slovakia/SlovakiaTest.php
@@ -50,11 +50,18 @@ class SlovakiaTest extends SlovakiaBaseTestCase implements ProviderTestCase
     {
         $this->assertDefinedHolidays([
             'slovakIndependenceDay',
-            'slovakConstitutionDay',
             'slovakNationalUprisingDay',
             'saintsCyrilAndMethodiusDay',
             'struggleForFreedomAndDemocracyDay',
         ], self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+
+        $this->assertDefinedHolidays([
+            'slovakConstitutionDay',
+        ], self::REGION, 2013, Holiday::TYPE_OFFICIAL);
+
+        $this->assertDefinedHolidays([
+            'declarationOfTheSlovakNation',
+        ], self::REGION, 2018, Holiday::TYPE_OFFICIAL);
     }
 
     /**

--- a/tests/Slovakia/SlovakiaTest.php
+++ b/tests/Slovakia/SlovakiaTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/StruggleForFreedomAndDemocracyDayTest.php
+++ b/tests/Slovakia/StruggleForFreedomAndDemocracyDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Slovakia/VictoryInEuropeDayTest.php
+++ b/tests/Slovakia/VictoryInEuropeDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthAfrica/ChristmasDayTest.php
+++ b/tests/SouthAfrica/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class ChristmasDayTest extends SouthAfricaBaseTestCase implements HolidayTestCas
         // Whenever any public holiday falls on a Sunday, the Monday following on it shall be a public holiday.
         if (0 === (int) $date->format('w')) {
             $date->add(new \DateInterval('P1D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/SouthAfrica/FamilyDayTest.php
+++ b/tests/SouthAfrica/FamilyDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthAfrica/FreedomDayTest.php
+++ b/tests/SouthAfrica/FreedomDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class FreedomDayTest extends SouthAfricaBaseTestCase implements HolidayTestCase
         // Whenever any public holiday falls on a Sunday, the Monday following on it shall be a public holiday.
         if (0 === (int) $date->format('w')) {
             $date->add(new \DateInterval('P1D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/SouthAfrica/GoodFridayTest.php
+++ b/tests/SouthAfrica/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthAfrica/HeritageDayTest.php
+++ b/tests/SouthAfrica/HeritageDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class HeritageDayTest extends SouthAfricaBaseTestCase implements HolidayTestCase
         // Whenever any public holiday falls on a Sunday, the Monday following on it shall be a public holiday.
         if (0 === (int) $date->format('w')) {
             $date->add(new \DateInterval('P1D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/SouthAfrica/HumanRightsDayTest.php
+++ b/tests/SouthAfrica/HumanRightsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class HumanRightsDayTest extends SouthAfricaBaseTestCase implements HolidayTestC
         // Whenever any public holiday falls on a Sunday, the Monday following on it shall be a public holiday.
         if (0 === (int) $date->format('w')) {
             $date->add(new \DateInterval('P1D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/SouthAfrica/MunicipalElections2016DayTest.php
+++ b/tests/SouthAfrica/MunicipalElections2016DayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -47,7 +50,7 @@ class MunicipalElections2016DayTest extends SouthAfricaBaseTestCase implements H
             self::REGION,
             self::HOLIDAY,
             self::ESTABLISHMENT_YEAR,
-            new \DateTime(self::ESTABLISHMENT_YEAR.'-8-3', new \DateTimeZone(self::TIMEZONE))
+            new \DateTime(self::ESTABLISHMENT_YEAR . '-8-3', new \DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/SouthAfrica/NationalWomensDayTest.php
+++ b/tests/SouthAfrica/NationalWomensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class NationalWomensDayTest extends SouthAfricaBaseTestCase implements HolidayTe
         // Whenever any public holiday falls on a Sunday, the Monday following on it shall be a public holiday.
         if (0 === (int) $date->format('w')) {
             $date->add(new \DateInterval('P1D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/SouthAfrica/NewYearsDayTest.php
+++ b/tests/SouthAfrica/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class NewYearsDayTest extends SouthAfricaBaseTestCase implements HolidayTestCase
         // Whenever any public holiday falls on a Sunday, the Monday following on it shall be a public holiday.
         if (0 === (int) $date->format('w')) {
             $date->add(new \DateInterval('P1D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/SouthAfrica/ReconciliationDayTest.php
+++ b/tests/SouthAfrica/ReconciliationDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class ReconciliationDayTest extends SouthAfricaBaseTestCase implements HolidayTe
         // Whenever any public holiday falls on a Sunday, the Monday following on it shall be a public holiday.
         if (0 === (int) $date->format('w')) {
             $date->add(new \DateInterval('P1D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/SouthAfrica/SecondChristmasDayTest.php
+++ b/tests/SouthAfrica/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class SecondChristmasDayTest extends SouthAfricaBaseTestCase implements HolidayT
         // Whenever any public holiday falls on a Sunday, the Monday following on it shall be a public holiday.
         if (0 === (int) $date->format('w')) {
             $date->add(new \DateInterval('P1D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/SouthAfrica/SouthAfricaBaseTestCase.php
+++ b/tests/SouthAfrica/SouthAfricaBaseTestCase.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthAfrica/SouthAfricaTest.php
+++ b/tests/SouthAfrica/SouthAfricaTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthAfrica/SubstituteDayOfGoodwillTest.php
+++ b/tests/SouthAfrica/SubstituteDayOfGoodwillTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -47,7 +50,7 @@ class SubstituteDayOfGoodwillTest extends SouthAfricaBaseTestCase implements Hol
             self::REGION,
             self::HOLIDAY,
             self::ESTABLISHMENT_YEAR,
-            new \DateTime(self::ESTABLISHMENT_YEAR.'-12-27', new \DateTimeZone(self::TIMEZONE))
+            new \DateTime(self::ESTABLISHMENT_YEAR . '-12-27', new \DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/SouthAfrica/WorkersDayTest.php
+++ b/tests/SouthAfrica/WorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class WorkersDayTest extends SouthAfricaBaseTestCase implements HolidayTestCase
         // Whenever any public holiday falls on a Sunday, the Monday following on it shall be a public holiday.
         if (0 === (int) $date->format('w')) {
             $date->add(new \DateInterval('P1D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/SouthAfrica/YouthDayTest.php
+++ b/tests/SouthAfrica/YouthDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class YouthDayTest extends SouthAfricaBaseTestCase implements HolidayTestCase
         // Whenever any public holiday falls on a Sunday, the Monday following on it shall be a public holiday.
         if (0 === (int) $date->format('w')) {
             $date->add(new \DateInterval('P1D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/SouthKorea/ArborDayTest.php
+++ b/tests/SouthKorea/ArborDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/ArmedForcesDayTest.php
+++ b/tests/SouthKorea/ArmedForcesDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/BuddhasBirthdayTest.php
+++ b/tests/SouthKorea/BuddhasBirthdayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/ChildrensDayTest.php
+++ b/tests/SouthKorea/ChildrensDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/ChristmasDayTest.php
+++ b/tests/SouthKorea/ChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/ChuseokTest.php
+++ b/tests/SouthKorea/ChuseokTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/ConstitutionDayTest.php
+++ b/tests/SouthKorea/ConstitutionDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/GaecheonjeolTest.php
+++ b/tests/SouthKorea/GaecheonjeolTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/HangulDayTest.php
+++ b/tests/SouthKorea/HangulDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/IndependenceMovementDayTest.php
+++ b/tests/SouthKorea/IndependenceMovementDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/LiberationDayTest.php
+++ b/tests/SouthKorea/LiberationDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/MemorialDayTest.php
+++ b/tests/SouthKorea/MemorialDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/NewYearsDayTest.php
+++ b/tests/SouthKorea/NewYearsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/SeollalTest.php
+++ b/tests/SouthKorea/SeollalTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/SouthKoreaBaseTestCase.php
+++ b/tests/SouthKorea/SouthKoreaBaseTestCase.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/SouthKoreaTest.php
+++ b/tests/SouthKorea/SouthKoreaTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/SouthKorea/UnitedNationsDayTest.php
+++ b/tests/SouthKorea/UnitedNationsDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/AllSaintsDayTest.php
+++ b/tests/Spain/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Andalusia/AndalusiaBaseTestCase.php
+++ b/tests/Spain/Andalusia/AndalusiaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Andalusia/AndalusiaDayTest.php
+++ b/tests/Spain/Andalusia/AndalusiaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Andalusia/AndalusiaTest.php
+++ b/tests/Spain/Andalusia/AndalusiaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Aragon/AragonBaseTestCase.php
+++ b/tests/Spain/Aragon/AragonBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Aragon/AragonTest.php
+++ b/tests/Spain/Aragon/AragonTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Aragon/StGeorgesDayTest.php
+++ b/tests/Spain/Aragon/StGeorgesDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/AssumptionOfMaryTest.php
+++ b/tests/Spain/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Asturias/AsturiasBaseTestCase.php
+++ b/tests/Spain/Asturias/AsturiasBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Asturias/AsturiasDayTest.php
+++ b/tests/Spain/Asturias/AsturiasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Asturias/AsturiasTest.php
+++ b/tests/Spain/Asturias/AsturiasTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/BalearicIslands/BalearicIslandsBaseTestCase.php
+++ b/tests/Spain/BalearicIslands/BalearicIslandsBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/BalearicIslands/BalearicIslandsDayTest.php
+++ b/tests/Spain/BalearicIslands/BalearicIslandsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/BalearicIslands/BalearicIslandsTest.php
+++ b/tests/Spain/BalearicIslands/BalearicIslandsTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/BasqueCountry/BasqueCountryBaseTestCase.php
+++ b/tests/Spain/BasqueCountry/BasqueCountryBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/BasqueCountry/BasqueCountryDayTest.php
+++ b/tests/Spain/BasqueCountry/BasqueCountryDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/BasqueCountry/BasqueCountryTest.php
+++ b/tests/Spain/BasqueCountry/BasqueCountryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CanaryIslands/CanaryIslandsBaseTestCase.php
+++ b/tests/Spain/CanaryIslands/CanaryIslandsBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CanaryIslands/CanaryIslandsDayTest.php
+++ b/tests/Spain/CanaryIslands/CanaryIslandsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CanaryIslands/CanaryIslandsTest.php
+++ b/tests/Spain/CanaryIslands/CanaryIslandsTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Cantabria/CantabriaBaseTestCase.php
+++ b/tests/Spain/Cantabria/CantabriaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Cantabria/CantabriaDayTest.php
+++ b/tests/Spain/Cantabria/CantabriaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Cantabria/CantabriaTest.php
+++ b/tests/Spain/Cantabria/CantabriaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CastileAndLeon/CastileAndLeonBaseTestCase.php
+++ b/tests/Spain/CastileAndLeon/CastileAndLeonBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CastileAndLeon/CastileAndLeonDayTest.php
+++ b/tests/Spain/CastileAndLeon/CastileAndLeonDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CastileAndLeon/CastileAndLeonTest.php
+++ b/tests/Spain/CastileAndLeon/CastileAndLeonTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CastillaLaMancha/CastillaLaManchaBaseTestCase.php
+++ b/tests/Spain/CastillaLaMancha/CastillaLaManchaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CastillaLaMancha/CastillaLaManchaDayTest.php
+++ b/tests/Spain/CastillaLaMancha/CastillaLaManchaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CastillaLaMancha/CastillaLaManchaTest.php
+++ b/tests/Spain/CastillaLaMancha/CastillaLaManchaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Catalonia/CataloniaBaseTestCase.php
+++ b/tests/Spain/Catalonia/CataloniaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Catalonia/CataloniaTest.php
+++ b/tests/Spain/Catalonia/CataloniaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Catalonia/nationalCataloniaDayTest.php
+++ b/tests/Spain/Catalonia/nationalCataloniaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Catalonia/stJohnsDayTest.php
+++ b/tests/Spain/Catalonia/stJohnsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Ceuta/CeutaBaseTestCase.php
+++ b/tests/Spain/Ceuta/CeutaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Ceuta/CeutaTest.php
+++ b/tests/Spain/Ceuta/CeutaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Ceuta/ceutaDayTest.php
+++ b/tests/Spain/Ceuta/ceutaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/ChristmasTest.php
+++ b/tests/Spain/ChristmasTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CommunityOfMadrid/CommunityOfMadridBaseTestCase.php
+++ b/tests/Spain/CommunityOfMadrid/CommunityOfMadridBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CommunityOfMadrid/CommunityOfMadridTest.php
+++ b/tests/Spain/CommunityOfMadrid/CommunityOfMadridTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/CommunityOfMadrid/DosdeMayoUprisingDayTest.php
+++ b/tests/Spain/CommunityOfMadrid/DosdeMayoUprisingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/ConstitutionDayTest.php
+++ b/tests/Spain/ConstitutionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/EasterMondayTest.php
+++ b/tests/Spain/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/EpiphanyTest.php
+++ b/tests/Spain/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Extremadura/ExtremaduraBaseTestCase.php
+++ b/tests/Spain/Extremadura/ExtremaduraBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Extremadura/ExtremaduraDayTest.php
+++ b/tests/Spain/Extremadura/ExtremaduraDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Extremadura/ExtremaduraTest.php
+++ b/tests/Spain/Extremadura/ExtremaduraTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Galicia/GaliciaBaseTestCase.php
+++ b/tests/Spain/Galicia/GaliciaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Galicia/GaliciaTest.php
+++ b/tests/Spain/Galicia/GaliciaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Galicia/GalicianLiteratureDayTest.php
+++ b/tests/Spain/Galicia/GalicianLiteratureDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Galicia/stJamesDayTest.php
+++ b/tests/Spain/Galicia/stJamesDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/GoodFridayTest.php
+++ b/tests/Spain/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/ImmaculateConceptionTest.php
+++ b/tests/Spain/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/InternationalWorkersDayTest.php
+++ b/tests/Spain/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/LaRioja/LaRiojaBaseTestCase.php
+++ b/tests/Spain/LaRioja/LaRiojaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/LaRioja/LaRiojaDayTest.php
+++ b/tests/Spain/LaRioja/LaRiojaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/LaRioja/LaRiojaTest.php
+++ b/tests/Spain/LaRioja/LaRiojaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/MaundyThursdayTest.php
+++ b/tests/Spain/MaundyThursdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Melilla/MelillaBaseTestCase.php
+++ b/tests/Spain/Melilla/MelillaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Melilla/MelillaTest.php
+++ b/tests/Spain/Melilla/MelillaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/NationalDayTest.php
+++ b/tests/Spain/NationalDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Navarre/NavarreBaseTestCase.php
+++ b/tests/Spain/Navarre/NavarreBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/Navarre/NavarreTest.php
+++ b/tests/Spain/Navarre/NavarreTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/NewYearsDayTest.php
+++ b/tests/Spain/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/RegionOfMurcia/RegionOfMurciaBaseTestCase.php
+++ b/tests/Spain/RegionOfMurcia/RegionOfMurciaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/RegionOfMurcia/RegionOfMurciaDayTest.php
+++ b/tests/Spain/RegionOfMurcia/RegionOfMurciaDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/RegionOfMurcia/RegionOfMurciaTest.php
+++ b/tests/Spain/RegionOfMurcia/RegionOfMurciaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/SpainBaseTestCase.php
+++ b/tests/Spain/SpainBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/SpainTest.php
+++ b/tests/Spain/SpainTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/ValencianCommunity/ValencianCommunityBaseTestCase.php
+++ b/tests/Spain/ValencianCommunity/ValencianCommunityBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/ValencianCommunity/ValencianCommunityDayTest.php
+++ b/tests/Spain/ValencianCommunity/ValencianCommunityDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/ValencianCommunity/ValencianCommunityTest.php
+++ b/tests/Spain/ValencianCommunity/ValencianCommunityTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/ValentinesDayTest.php
+++ b/tests/Spain/ValentinesDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Spain/stJosephsDayTest.php
+++ b/tests/Spain/stJosephsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/AllSaintsDayTest.php
+++ b/tests/Sweden/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/AllSaintsEveTest.php
+++ b/tests/Sweden/AllSaintsEveTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/AscensionDayTest.php
+++ b/tests/Sweden/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/ChristmasDayTest.php
+++ b/tests/Sweden/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/ChristmasEveTest.php
+++ b/tests/Sweden/ChristmasEveTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/EasterMondayTest.php
+++ b/tests/Sweden/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/EasterTest.php
+++ b/tests/Sweden/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/EpiphanyEveTest.php
+++ b/tests/Sweden/EpiphanyEveTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/EpiphanyTest.php
+++ b/tests/Sweden/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/GoodFridayTest.php
+++ b/tests/Sweden/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/InternationalWorkersDayTest.php
+++ b/tests/Sweden/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/NationalDayTest.php
+++ b/tests/Sweden/NationalDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/NewYearsDayTest.php
+++ b/tests/Sweden/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/NewYearsEveTest.php
+++ b/tests/Sweden/NewYearsEveTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/PentecostTest.php
+++ b/tests/Sweden/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/SecondChristmasDayTest.php
+++ b/tests/Sweden/SecondChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/StJohnsDayTest.php
+++ b/tests/Sweden/StJohnsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/StJohnsEveTest.php
+++ b/tests/Sweden/StJohnsEveTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/SwedenBaseTestCase.php
+++ b/tests/Sweden/SwedenBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/SwedenTest.php
+++ b/tests/Sweden/SwedenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Sweden/WalpurgisEveTest.php
+++ b/tests/Sweden/WalpurgisEveTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Aargau/AargauBaseTestCase.php
+++ b/tests/Switzerland/Aargau/AargauBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Aargau/AargauTest.php
+++ b/tests/Switzerland/Aargau/AargauTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Aargau/AscensionDayTest.php
+++ b/tests/Switzerland/Aargau/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Aargau/ChristmasDayTest.php
+++ b/tests/Switzerland/Aargau/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Aargau/GoodFridayTest.php
+++ b/tests/Switzerland/Aargau/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Aargau/NewYearsDayTest.php
+++ b/tests/Switzerland/Aargau/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellAusserrhoden/AppenzellAusserrhodenBaseTestCase.php
+++ b/tests/Switzerland/AppenzellAusserrhoden/AppenzellAusserrhodenBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellAusserrhoden/AppenzellAusserrhodenTest.php
+++ b/tests/Switzerland/AppenzellAusserrhoden/AppenzellAusserrhodenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellAusserrhoden/AscensionDayTest.php
+++ b/tests/Switzerland/AppenzellAusserrhoden/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellAusserrhoden/ChristmasDayTest.php
+++ b/tests/Switzerland/AppenzellAusserrhoden/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellAusserrhoden/EasterMondayTest.php
+++ b/tests/Switzerland/AppenzellAusserrhoden/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellAusserrhoden/GoodFridayTest.php
+++ b/tests/Switzerland/AppenzellAusserrhoden/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellAusserrhoden/NewYearsDayTest.php
+++ b/tests/Switzerland/AppenzellAusserrhoden/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellAusserrhoden/PentecostMondayTest.php
+++ b/tests/Switzerland/AppenzellAusserrhoden/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellAusserrhoden/StStephensDayTest.php
+++ b/tests/Switzerland/AppenzellAusserrhoden/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/AllSaintsDayTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/AppenzellInnerrhodenBaseTestCase.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/AppenzellInnerrhodenBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/AppenzellInnerrhodenTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/AppenzellInnerrhodenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/AscensionDayTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/ChristmasDayTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/CorpusChristiTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/EasterMondayTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/GoodFridayTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/ImmaculateConceptionTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/NewYearsDayTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/PentecostMondayTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/AppenzellInnerrhoden/StStephensDayTest.php
+++ b/tests/Switzerland/AppenzellInnerrhoden/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselLandschaft/AscensionDayTest.php
+++ b/tests/Switzerland/BaselLandschaft/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselLandschaft/BaselLandschaftBaseTestCase.php
+++ b/tests/Switzerland/BaselLandschaft/BaselLandschaftBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselLandschaft/BaselLandschaftTest.php
+++ b/tests/Switzerland/BaselLandschaft/BaselLandschaftTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselLandschaft/ChristmasDayTest.php
+++ b/tests/Switzerland/BaselLandschaft/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselLandschaft/EasterMondayTest.php
+++ b/tests/Switzerland/BaselLandschaft/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselLandschaft/GoodFridayTest.php
+++ b/tests/Switzerland/BaselLandschaft/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselLandschaft/NewYearsDayTest.php
+++ b/tests/Switzerland/BaselLandschaft/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselLandschaft/PentecostMondayTest.php
+++ b/tests/Switzerland/BaselLandschaft/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselLandschaft/StStephensDayTest.php
+++ b/tests/Switzerland/BaselLandschaft/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselLandschaft/WorkersDayTest.php
+++ b/tests/Switzerland/BaselLandschaft/WorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselStadt/AscensionDayTest.php
+++ b/tests/Switzerland/BaselStadt/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselStadt/BaselStadtBaseTestCase.php
+++ b/tests/Switzerland/BaselStadt/BaselStadtBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselStadt/BaselStadtTest.php
+++ b/tests/Switzerland/BaselStadt/BaselStadtTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselStadt/ChristmasDayTest.php
+++ b/tests/Switzerland/BaselStadt/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselStadt/EasterMondayTest.php
+++ b/tests/Switzerland/BaselStadt/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselStadt/GoodFridayTest.php
+++ b/tests/Switzerland/BaselStadt/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselStadt/NewYearsDayTest.php
+++ b/tests/Switzerland/BaselStadt/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselStadt/PentecostMondayTest.php
+++ b/tests/Switzerland/BaselStadt/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselStadt/StStephensDayTest.php
+++ b/tests/Switzerland/BaselStadt/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/BaselStadt/WorkersDayTest.php
+++ b/tests/Switzerland/BaselStadt/WorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Bern/AscensionDayTest.php
+++ b/tests/Switzerland/Bern/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Bern/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Bern/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends BernBaseTestCase implements HolidayTestCase
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Bern/BernBaseTestCase.php
+++ b/tests/Switzerland/Bern/BernBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Bern/BernTest.php
+++ b/tests/Switzerland/Bern/BernTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Bern/ChristmasDayTest.php
+++ b/tests/Switzerland/Bern/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Bern/EasterMondayTest.php
+++ b/tests/Switzerland/Bern/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Bern/GoodFridayTest.php
+++ b/tests/Switzerland/Bern/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Bern/NewYearsDayTest.php
+++ b/tests/Switzerland/Bern/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Bern/PentecostMondayTest.php
+++ b/tests/Switzerland/Bern/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Bern/StStephensDayTest.php
+++ b/tests/Switzerland/Bern/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/AllSaintsDayTest.php
+++ b/tests/Switzerland/Fribourg/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/AscensionDayTest.php
+++ b/tests/Switzerland/Fribourg/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/Fribourg/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Fribourg/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends FribourgBaseTestCase implements HolidayTestCase
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Fribourg/ChristmasDayTest.php
+++ b/tests/Switzerland/Fribourg/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/CorpusChristiTest.php
+++ b/tests/Switzerland/Fribourg/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/December26thTest.php
+++ b/tests/Switzerland/Fribourg/December26thTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/EasterMondayTest.php
+++ b/tests/Switzerland/Fribourg/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/FribourgBaseTestCase.php
+++ b/tests/Switzerland/Fribourg/FribourgBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/FribourgTest.php
+++ b/tests/Switzerland/Fribourg/FribourgTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/GoodFridayTest.php
+++ b/tests/Switzerland/Fribourg/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/ImmaculateConceptionTest.php
+++ b/tests/Switzerland/Fribourg/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/NewYearsDayTest.php
+++ b/tests/Switzerland/Fribourg/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Fribourg/PentecostMondayTest.php
+++ b/tests/Switzerland/Fribourg/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Geneva/AscensionDayTest.php
+++ b/tests/Switzerland/Geneva/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Geneva/ChristmasDayTest.php
+++ b/tests/Switzerland/Geneva/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Geneva/EasterMondayTest.php
+++ b/tests/Switzerland/Geneva/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Geneva/GenevaBaseTestCase.php
+++ b/tests/Switzerland/Geneva/GenevaBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Geneva/GenevaTest.php
+++ b/tests/Switzerland/Geneva/GenevaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Geneva/GoodFridayTest.php
+++ b/tests/Switzerland/Geneva/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Geneva/JeuneGenevoisTest.php
+++ b/tests/Switzerland/Geneva/JeuneGenevoisTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -37,7 +40,7 @@ class JeuneGenevoisTest extends GenevaBaseTestCase implements HolidayTestCase
     {
         $year = $this->generateRandomYear(1870, 1965);
         // Find first Sunday of September
-        $date = new \DateTime('First Sunday of '.$year.'-09', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime('First Sunday of ' . $year . '-09', new \DateTimeZone(self::TIMEZONE));
         // Go to next Thursday
         $date->add(new \DateInterval('P4D'));
 
@@ -54,7 +57,7 @@ class JeuneGenevoisTest extends GenevaBaseTestCase implements HolidayTestCase
     {
         $year = $this->generateRandomYear(Geneva::JEUNE_GENEVOIS_ESTABLISHMENT_YEAR, 1869);
         // Find first Sunday of September
-        $date = new \DateTime('First Sunday of '.$year.'-09', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime('First Sunday of ' . $year . '-09', new \DateTimeZone(self::TIMEZONE));
         // Go to next Thursday
         $date->add(new \DateInterval('P4D'));
 

--- a/tests/Switzerland/Geneva/NewYearsDayTest.php
+++ b/tests/Switzerland/Geneva/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Geneva/PentecostMondayTest.php
+++ b/tests/Switzerland/Geneva/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Geneva/RestaurationGenevoiseTest.php
+++ b/tests/Switzerland/Geneva/RestaurationGenevoiseTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -40,7 +43,7 @@ class RestaurationGenevoiseTest extends GenevaBaseTestCase implements HolidayTes
             self::REGION,
             self::HOLIDAY,
             $year,
-            new \DateTime($year.'-12-31', new \DateTimeZone(self::TIMEZONE))
+            new \DateTime($year . '-12-31', new \DateTimeZone(self::TIMEZONE))
         );
     }
 

--- a/tests/Switzerland/Glarus/AllSaintsDayTest.php
+++ b/tests/Switzerland/Glarus/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Glarus/AscensionDayTest.php
+++ b/tests/Switzerland/Glarus/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Glarus/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Glarus/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends GlarusBaseTestCase implements HolidayTestCase
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Glarus/ChristmasDayTest.php
+++ b/tests/Switzerland/Glarus/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Glarus/EasterMondayTest.php
+++ b/tests/Switzerland/Glarus/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Glarus/GlarusBaseTestCase.php
+++ b/tests/Switzerland/Glarus/GlarusBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Glarus/GlarusTest.php
+++ b/tests/Switzerland/Glarus/GlarusTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Glarus/GoodFridayTest.php
+++ b/tests/Switzerland/Glarus/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Glarus/NafelserFahrtTest.php
+++ b/tests/Switzerland/Glarus/NafelserFahrtTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -40,7 +43,7 @@ class NafelserFahrtTest extends GlarusBaseTestCase implements HolidayTestCase
     public function testNafelserFahrtOnAfter1389(): void
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        $date = new \DateTime('First Thursday of '.$year.'-04', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime('First Thursday of ' . $year . '-04', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
     }

--- a/tests/Switzerland/Glarus/NewYearsDayTest.php
+++ b/tests/Switzerland/Glarus/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Glarus/PentecostMondayTest.php
+++ b/tests/Switzerland/Glarus/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Glarus/StStephensDayTest.php
+++ b/tests/Switzerland/Glarus/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Grisons/AscensionDayTest.php
+++ b/tests/Switzerland/Grisons/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Grisons/ChristmasDayTest.php
+++ b/tests/Switzerland/Grisons/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Grisons/EasterMondayTest.php
+++ b/tests/Switzerland/Grisons/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Grisons/GoodFridayTest.php
+++ b/tests/Switzerland/Grisons/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Grisons/GrisonsBaseTestCase.php
+++ b/tests/Switzerland/Grisons/GrisonsBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Grisons/GrisonsTest.php
+++ b/tests/Switzerland/Grisons/GrisonsTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Grisons/NewYearsDayTest.php
+++ b/tests/Switzerland/Grisons/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Grisons/PentecostMondayTest.php
+++ b/tests/Switzerland/Grisons/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Grisons/StStephensDayTest.php
+++ b/tests/Switzerland/Grisons/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/AllSaintsDayTest.php
+++ b/tests/Switzerland/Jura/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/AscensionDayTest.php
+++ b/tests/Switzerland/Jura/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/Jura/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Jura/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends JuraBaseTestCase implements HolidayTestCase
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Jura/BettagsMontagTest.php
+++ b/tests/Switzerland/Jura/BettagsMontagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -37,7 +40,7 @@ class BettagsMontagTest extends JuraBaseTestCase implements HolidayTestCase
         $year = $this->generateRandomYear(1832);
 
         // Find third Sunday of September
-        $date = new \DateTime('Third Sunday of '.$year.'-09', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime('Third Sunday of ' . $year . '-09', new \DateTimeZone(self::TIMEZONE));
         // Go to next Thursday
         $date->add(new \DateInterval('P1D'));
 

--- a/tests/Switzerland/Jura/ChristmasDayTest.php
+++ b/tests/Switzerland/Jura/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/CorpusChristiTest.php
+++ b/tests/Switzerland/Jura/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/EasterMondayTest.php
+++ b/tests/Switzerland/Jura/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/EasterTest.php
+++ b/tests/Switzerland/Jura/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/GoodFridayTest.php
+++ b/tests/Switzerland/Jura/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/JuraBaseTestCase.php
+++ b/tests/Switzerland/Jura/JuraBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/JuraTest.php
+++ b/tests/Switzerland/Jura/JuraTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/NewYearsDayTest.php
+++ b/tests/Switzerland/Jura/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/PentecostMondayTest.php
+++ b/tests/Switzerland/Jura/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/PentecostTest.php
+++ b/tests/Switzerland/Jura/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/PlebisciteJurassienTest.php
+++ b/tests/Switzerland/Jura/PlebisciteJurassienTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Jura/WorkersDayTest.php
+++ b/tests/Switzerland/Jura/WorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/AllSaintsDayTest.php
+++ b/tests/Switzerland/Lucerne/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/AscensionDayTest.php
+++ b/tests/Switzerland/Lucerne/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/Lucerne/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Lucerne/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends LucerneBaseTestCase implements HolidayTestCase
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Lucerne/ChristmasDayTest.php
+++ b/tests/Switzerland/Lucerne/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/CorpusChristiTest.php
+++ b/tests/Switzerland/Lucerne/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/EasterMondayTest.php
+++ b/tests/Switzerland/Lucerne/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/GoodFridayTest.php
+++ b/tests/Switzerland/Lucerne/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/ImmaculateConceptionTest.php
+++ b/tests/Switzerland/Lucerne/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/LucerneBaseTestCase.php
+++ b/tests/Switzerland/Lucerne/LucerneBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/LucerneTest.php
+++ b/tests/Switzerland/Lucerne/LucerneTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/NewYearsDayTest.php
+++ b/tests/Switzerland/Lucerne/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/PentecostMondayTest.php
+++ b/tests/Switzerland/Lucerne/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Lucerne/StStephensDayTest.php
+++ b/tests/Switzerland/Lucerne/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Neuchatel/AscensionDayTest.php
+++ b/tests/Switzerland/Neuchatel/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Neuchatel/BettagsMontagTest.php
+++ b/tests/Switzerland/Neuchatel/BettagsMontagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -37,7 +40,7 @@ class BettagsMontagTest extends NeuchatelBaseTestCase implements HolidayTestCase
         $year = $this->generateRandomYear(1832);
 
         // Find third Sunday of September
-        $date = new \DateTime('Third Sunday of '.$year.'-09', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime('Third Sunday of ' . $year . '-09', new \DateTimeZone(self::TIMEZONE));
         // Go to next Thursday
         $date->add(new \DateInterval('P1D'));
 

--- a/tests/Switzerland/Neuchatel/ChristmasDayTest.php
+++ b/tests/Switzerland/Neuchatel/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Neuchatel/December26thTest.php
+++ b/tests/Switzerland/Neuchatel/December26thTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -43,7 +46,7 @@ class December26thTest extends NeuchatelBaseTestCase implements HolidayTestCase
             self::REGION,
             self::HOLIDAY,
             self::OBSERVANCE_YEAR,
-            new \DateTime(self::OBSERVANCE_YEAR.'-12-26', new \DateTimeZone(self::TIMEZONE))
+            new \DateTime(self::OBSERVANCE_YEAR . '-12-26', new \DateTimeZone(self::TIMEZONE))
         );
         $this->assertNotHoliday(
             self::REGION,

--- a/tests/Switzerland/Neuchatel/EasterMondayTest.php
+++ b/tests/Switzerland/Neuchatel/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Neuchatel/GoodFridayTest.php
+++ b/tests/Switzerland/Neuchatel/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Neuchatel/InstaurationRepubliqueTest.php
+++ b/tests/Switzerland/Neuchatel/InstaurationRepubliqueTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Neuchatel/January2ndTest.php
+++ b/tests/Switzerland/Neuchatel/January2ndTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -43,7 +46,7 @@ class January2ndTest extends NeuchatelBaseTestCase implements HolidayTestCase
             self::REGION,
             self::HOLIDAY,
             self::OBSERVANCE_YEAR,
-            new \DateTime(self::OBSERVANCE_YEAR.'-1-02', new \DateTimeZone(self::TIMEZONE))
+            new \DateTime(self::OBSERVANCE_YEAR . '-1-02', new \DateTimeZone(self::TIMEZONE))
         );
         $this->assertNotHoliday(
             self::REGION,

--- a/tests/Switzerland/Neuchatel/NeuchatelBaseTestCase.php
+++ b/tests/Switzerland/Neuchatel/NeuchatelBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Neuchatel/NeuchatelTest.php
+++ b/tests/Switzerland/Neuchatel/NeuchatelTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Neuchatel/NewYearsDayTest.php
+++ b/tests/Switzerland/Neuchatel/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Neuchatel/PentecostMondayTest.php
+++ b/tests/Switzerland/Neuchatel/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Neuchatel/WorkersDayTest.php
+++ b/tests/Switzerland/Neuchatel/WorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/AllSaintsDayTest.php
+++ b/tests/Switzerland/Nidwalden/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/AscensionDayTest.php
+++ b/tests/Switzerland/Nidwalden/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/Nidwalden/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/ChristmasDayTest.php
+++ b/tests/Switzerland/Nidwalden/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/CorpusChristiTest.php
+++ b/tests/Switzerland/Nidwalden/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/EasterMondayTest.php
+++ b/tests/Switzerland/Nidwalden/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/GoodFridayTest.php
+++ b/tests/Switzerland/Nidwalden/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/ImmaculateConceptionTest.php
+++ b/tests/Switzerland/Nidwalden/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/NewYearsDayTest.php
+++ b/tests/Switzerland/Nidwalden/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/NidwaldenBaseTestCase.php
+++ b/tests/Switzerland/Nidwalden/NidwaldenBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/NidwaldenTest.php
+++ b/tests/Switzerland/Nidwalden/NidwaldenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/PentecostMondayTest.php
+++ b/tests/Switzerland/Nidwalden/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/StJosephDayTest.php
+++ b/tests/Switzerland/Nidwalden/StJosephDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Nidwalden/StStephensDayTest.php
+++ b/tests/Switzerland/Nidwalden/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/AllSaintsDayTest.php
+++ b/tests/Switzerland/Obwalden/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/AscensionDayTest.php
+++ b/tests/Switzerland/Obwalden/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/Obwalden/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Obwalden/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends ObwaldenBaseTestCase implements HolidayTestCase
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Obwalden/BruderKlausenFestTest.php
+++ b/tests/Switzerland/Obwalden/BruderKlausenFestTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BruderKlausenFestTest extends ObwaldenBaseTestCase implements HolidayTestC
     public function testBruderKlausenFestOnAfter1947(): void
     {
         $year = $this->generateRandomYear(1947);
-        $date = new \DateTime($year.'-09-25', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-09-25', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);
@@ -49,7 +52,7 @@ class BruderKlausenFestTest extends ObwaldenBaseTestCase implements HolidayTestC
     public function testBruderKlausenFestBetween1649And1946(): void
     {
         $year = $this->generateRandomYear(1649, 1946);
-        $date = new \DateTime($year.'-09-21', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-09-21', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Obwalden/ChristmasDayTest.php
+++ b/tests/Switzerland/Obwalden/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/CorpusChristiTest.php
+++ b/tests/Switzerland/Obwalden/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/EasterMondayTest.php
+++ b/tests/Switzerland/Obwalden/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/GoodFridayTest.php
+++ b/tests/Switzerland/Obwalden/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/ImmaculateConceptionTest.php
+++ b/tests/Switzerland/Obwalden/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/NewYearsDayTest.php
+++ b/tests/Switzerland/Obwalden/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/ObwaldenBaseTestCase.php
+++ b/tests/Switzerland/Obwalden/ObwaldenBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/ObwaldenTest.php
+++ b/tests/Switzerland/Obwalden/ObwaldenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/PentecostMondayTest.php
+++ b/tests/Switzerland/Obwalden/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Obwalden/StStephensDayTest.php
+++ b/tests/Switzerland/Obwalden/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schaffhausen/AscensionDayTest.php
+++ b/tests/Switzerland/Schaffhausen/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schaffhausen/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Schaffhausen/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends SchaffhausenBaseTestCase implements HolidayTestC
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Schaffhausen/ChristmasDayTest.php
+++ b/tests/Switzerland/Schaffhausen/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schaffhausen/EasterMondayTest.php
+++ b/tests/Switzerland/Schaffhausen/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schaffhausen/GoodFridayTest.php
+++ b/tests/Switzerland/Schaffhausen/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schaffhausen/NewYearsDayTest.php
+++ b/tests/Switzerland/Schaffhausen/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schaffhausen/PentecostMondayTest.php
+++ b/tests/Switzerland/Schaffhausen/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schaffhausen/SchaffhausenBaseTestCase.php
+++ b/tests/Switzerland/Schaffhausen/SchaffhausenBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schaffhausen/SchaffhausenTest.php
+++ b/tests/Switzerland/Schaffhausen/SchaffhausenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schaffhausen/StStephensDayTest.php
+++ b/tests/Switzerland/Schaffhausen/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schaffhausen/WorkersDayTest.php
+++ b/tests/Switzerland/Schaffhausen/WorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/AllSaintsDayTest.php
+++ b/tests/Switzerland/Schwyz/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/AscensionDayTest.php
+++ b/tests/Switzerland/Schwyz/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/Schwyz/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/ChristmasDayTest.php
+++ b/tests/Switzerland/Schwyz/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/CorpusChristiTest.php
+++ b/tests/Switzerland/Schwyz/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/EasterMondayTest.php
+++ b/tests/Switzerland/Schwyz/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/EpiphanyTest.php
+++ b/tests/Switzerland/Schwyz/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/GoodFridayTest.php
+++ b/tests/Switzerland/Schwyz/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/ImmaculateConceptionTest.php
+++ b/tests/Switzerland/Schwyz/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/NewYearsDayTest.php
+++ b/tests/Switzerland/Schwyz/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/PentecostMondayTest.php
+++ b/tests/Switzerland/Schwyz/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/SchwyzBaseTestCase.php
+++ b/tests/Switzerland/Schwyz/SchwyzBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/SchwyzTest.php
+++ b/tests/Switzerland/Schwyz/SchwyzTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/StJosephDayTest.php
+++ b/tests/Switzerland/Schwyz/StJosephDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Schwyz/StStephensDayTest.php
+++ b/tests/Switzerland/Schwyz/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Solothurn/AscensionDayTest.php
+++ b/tests/Switzerland/Solothurn/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Solothurn/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Solothurn/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends SolothurnBaseTestCase implements HolidayTestCase
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Solothurn/ChristmasDayTest.php
+++ b/tests/Switzerland/Solothurn/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Solothurn/GoodFridayTest.php
+++ b/tests/Switzerland/Solothurn/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Solothurn/NewYearsDayTest.php
+++ b/tests/Switzerland/Solothurn/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Solothurn/SolothurnBaseTestCase.php
+++ b/tests/Switzerland/Solothurn/SolothurnBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Solothurn/SolothurnTest.php
+++ b/tests/Switzerland/Solothurn/SolothurnTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/StGallen/AllSaintsDayTest.php
+++ b/tests/Switzerland/StGallen/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/StGallen/AscensionDayTest.php
+++ b/tests/Switzerland/StGallen/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/StGallen/ChristmasDayTest.php
+++ b/tests/Switzerland/StGallen/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/StGallen/EasterMondayTest.php
+++ b/tests/Switzerland/StGallen/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/StGallen/GoodFridayTest.php
+++ b/tests/Switzerland/StGallen/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/StGallen/NewYearsDayTest.php
+++ b/tests/Switzerland/StGallen/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/StGallen/PentecostMondayTest.php
+++ b/tests/Switzerland/StGallen/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/StGallen/StGallenBaseTestCase.php
+++ b/tests/Switzerland/StGallen/StGallenBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/StGallen/StGallenTest.php
+++ b/tests/Switzerland/StGallen/StGallenTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/StGallen/StStephensDayTest.php
+++ b/tests/Switzerland/StGallen/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/SwissNationalDayTest.php
+++ b/tests/Switzerland/SwissNationalDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/SwitzerlandBaseTestCase.php
+++ b/tests/Switzerland/SwitzerlandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/SwitzerlandTest.php
+++ b/tests/Switzerland/SwitzerlandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Thurgau/AscensionDayTest.php
+++ b/tests/Switzerland/Thurgau/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Thurgau/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Thurgau/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends ThurgauBaseTestCase implements HolidayTestCase
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Thurgau/ChristmasDayTest.php
+++ b/tests/Switzerland/Thurgau/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Thurgau/EasterMondayTest.php
+++ b/tests/Switzerland/Thurgau/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Thurgau/GoodFridayTest.php
+++ b/tests/Switzerland/Thurgau/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Thurgau/NewYearsDayTest.php
+++ b/tests/Switzerland/Thurgau/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Thurgau/PentecostMondayTest.php
+++ b/tests/Switzerland/Thurgau/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Thurgau/StStephensDayTest.php
+++ b/tests/Switzerland/Thurgau/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Thurgau/ThurgauBaseTestCase.php
+++ b/tests/Switzerland/Thurgau/ThurgauBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Thurgau/ThurgauTest.php
+++ b/tests/Switzerland/Thurgau/ThurgauTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Thurgau/WorkersDayTest.php
+++ b/tests/Switzerland/Thurgau/WorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/AllSaintsDayTest.php
+++ b/tests/Switzerland/Ticino/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/AscensionDayTest.php
+++ b/tests/Switzerland/Ticino/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/Ticino/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/ChristmasDayTest.php
+++ b/tests/Switzerland/Ticino/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/CorpusChristiTest.php
+++ b/tests/Switzerland/Ticino/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/EasterMondayTest.php
+++ b/tests/Switzerland/Ticino/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/EpiphanyTest.php
+++ b/tests/Switzerland/Ticino/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/ImmaculateConceptionTest.php
+++ b/tests/Switzerland/Ticino/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/NewYearsDayTest.php
+++ b/tests/Switzerland/Ticino/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/PentecostMondayTest.php
+++ b/tests/Switzerland/Ticino/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/StJosephDayTest.php
+++ b/tests/Switzerland/Ticino/StJosephDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/StPeterPaulTest.php
+++ b/tests/Switzerland/Ticino/StPeterPaulTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/StStephensDayTest.php
+++ b/tests/Switzerland/Ticino/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/TicinoBaseTestCase.php
+++ b/tests/Switzerland/Ticino/TicinoBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/TicinoTest.php
+++ b/tests/Switzerland/Ticino/TicinoTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Ticino/WorkersDayTest.php
+++ b/tests/Switzerland/Ticino/WorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/AllSaintsDayTest.php
+++ b/tests/Switzerland/Uri/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/AscensionDayTest.php
+++ b/tests/Switzerland/Uri/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/Uri/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/ChristmasDayTest.php
+++ b/tests/Switzerland/Uri/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/CorpusChristiTest.php
+++ b/tests/Switzerland/Uri/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/EasterMondayTest.php
+++ b/tests/Switzerland/Uri/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/EpiphanyTest.php
+++ b/tests/Switzerland/Uri/EpiphanyTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/GoodFridayTest.php
+++ b/tests/Switzerland/Uri/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/ImmaculateConceptionTest.php
+++ b/tests/Switzerland/Uri/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/NewYearsDayTest.php
+++ b/tests/Switzerland/Uri/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/PentecostMondayTest.php
+++ b/tests/Switzerland/Uri/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/StJosephDayTest.php
+++ b/tests/Switzerland/Uri/StJosephDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/StStephensDayTest.php
+++ b/tests/Switzerland/Uri/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/UriBaseTestCase.php
+++ b/tests/Switzerland/Uri/UriBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Uri/UriTest.php
+++ b/tests/Switzerland/Uri/UriTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Valais/AllSaintsDayTest.php
+++ b/tests/Switzerland/Valais/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Valais/AscensionDayTest.php
+++ b/tests/Switzerland/Valais/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Valais/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/Valais/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Valais/ChristmasDayTest.php
+++ b/tests/Switzerland/Valais/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Valais/CorpusChristiTest.php
+++ b/tests/Switzerland/Valais/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Valais/ImmaculateConceptionTest.php
+++ b/tests/Switzerland/Valais/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Valais/NewYearsDayTest.php
+++ b/tests/Switzerland/Valais/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Valais/StJosephDayTest.php
+++ b/tests/Switzerland/Valais/StJosephDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Valais/ValaisBaseTestCase.php
+++ b/tests/Switzerland/Valais/ValaisBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Valais/ValaisTest.php
+++ b/tests/Switzerland/Valais/ValaisTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Vaud/AscensionDayTest.php
+++ b/tests/Switzerland/Vaud/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Vaud/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Vaud/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends VaudBaseTestCase implements HolidayTestCase
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Vaud/BettagsMontagTest.php
+++ b/tests/Switzerland/Vaud/BettagsMontagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -37,7 +40,7 @@ class BettagsMontagTest extends VaudBaseTestCase implements HolidayTestCase
         $year = $this->generateRandomYear(1832);
 
         // Find third Sunday of September
-        $date = new \DateTime('Third Sunday of '.$year.'-09', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime('Third Sunday of ' . $year . '-09', new \DateTimeZone(self::TIMEZONE));
         // Go to next Thursday
         $date->add(new \DateInterval('P1D'));
 

--- a/tests/Switzerland/Vaud/ChristmasDayTest.php
+++ b/tests/Switzerland/Vaud/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Vaud/EasterMondayTest.php
+++ b/tests/Switzerland/Vaud/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Vaud/GoodFridayTest.php
+++ b/tests/Switzerland/Vaud/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Vaud/NewYearsDayTest.php
+++ b/tests/Switzerland/Vaud/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Vaud/PentecostMondayTest.php
+++ b/tests/Switzerland/Vaud/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Vaud/VaudBaseTestCase.php
+++ b/tests/Switzerland/Vaud/VaudBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Vaud/VaudTest.php
+++ b/tests/Switzerland/Vaud/VaudTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/AllSaintsDayTest.php
+++ b/tests/Switzerland/Zug/AllSaintsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/AscensionDayTest.php
+++ b/tests/Switzerland/Zug/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/AssumptionOfMaryTest.php
+++ b/tests/Switzerland/Zug/AssumptionOfMaryTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/BerchtoldsTagTest.php
+++ b/tests/Switzerland/Zug/BerchtoldsTagTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -35,7 +38,7 @@ class BerchtoldsTagTest extends ZugBaseTestCase implements HolidayTestCase
     public function testBerchtoldsTag(): void
     {
         $year = $this->generateRandomYear();
-        $date = new \DateTime($year.'-01-02', new \DateTimeZone(self::TIMEZONE));
+        $date = new \DateTime($year . '-01-02', new \DateTimeZone(self::TIMEZONE));
 
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
         $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);

--- a/tests/Switzerland/Zug/ChristmasDayTest.php
+++ b/tests/Switzerland/Zug/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/CorpusChristiTest.php
+++ b/tests/Switzerland/Zug/CorpusChristiTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/EasterMondayTest.php
+++ b/tests/Switzerland/Zug/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/GoodFridayTest.php
+++ b/tests/Switzerland/Zug/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/ImmaculateConceptionTest.php
+++ b/tests/Switzerland/Zug/ImmaculateConceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/NewYearsDayTest.php
+++ b/tests/Switzerland/Zug/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/PentecostMondayTest.php
+++ b/tests/Switzerland/Zug/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/StStephensDayTest.php
+++ b/tests/Switzerland/Zug/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/ZugBaseTestCase.php
+++ b/tests/Switzerland/Zug/ZugBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zug/ZugTest.php
+++ b/tests/Switzerland/Zug/ZugTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zurich/AscensionDayTest.php
+++ b/tests/Switzerland/Zurich/AscensionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zurich/ChristmasDayTest.php
+++ b/tests/Switzerland/Zurich/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zurich/EasterMondayTest.php
+++ b/tests/Switzerland/Zurich/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zurich/GoodFridayTest.php
+++ b/tests/Switzerland/Zurich/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zurich/NewYearsDayTest.php
+++ b/tests/Switzerland/Zurich/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zurich/PentecostMondayTest.php
+++ b/tests/Switzerland/Zurich/PentecostMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zurich/StStephensDayTest.php
+++ b/tests/Switzerland/Zurich/StStephensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zurich/WorkersDayTest.php
+++ b/tests/Switzerland/Zurich/WorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zurich/ZurichBaseTestCase.php
+++ b/tests/Switzerland/Zurich/ZurichBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Switzerland/Zurich/ZurichTest.php
+++ b/tests/Switzerland/Zurich/ZurichTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Turkey/CommemorationOfAtaturkTest.php
+++ b/tests/Turkey/CommemorationOfAtaturkTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Turkey/DemocracyDayTest.php
+++ b/tests/Turkey/DemocracyDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Turkey/LabourDayTest.php
+++ b/tests/Turkey/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Turkey/NationalSovereigntyDayTest.php
+++ b/tests/Turkey/NationalSovereigntyDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Turkey/NewYearsDayTest.php
+++ b/tests/Turkey/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Turkey/RepublicDayTest.php
+++ b/tests/Turkey/RepublicDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Turkey/TurkeyBaseTestCase.php
+++ b/tests/Turkey/TurkeyBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Turkey/TurkeyTest.php
+++ b/tests/Turkey/TurkeyTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Turkey/VictoryDayTest.php
+++ b/tests/Turkey/VictoryDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/ChristmasDayTest.php
+++ b/tests/USA/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/ColumbusDayTest.php
+++ b/tests/USA/ColumbusDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/IndependenceDayTest.php
+++ b/tests/USA/IndependenceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/JuneteenthTest.php
+++ b/tests/USA/JuneteenthTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/LabourDayTest.php
+++ b/tests/USA/LabourDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/MartinLutherKingDayTest.php
+++ b/tests/USA/MartinLutherKingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/MemorialDayTest.php
+++ b/tests/USA/MemorialDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/NewYearsDayTest.php
+++ b/tests/USA/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/ThanksgivingDayTest.php
+++ b/tests/USA/ThanksgivingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/USABaseTestCase.php
+++ b/tests/USA/USABaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/USATest.php
+++ b/tests/USA/USATest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/VeteransDayTest.php
+++ b/tests/USA/VeteransDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/USA/WashingtonsBirthdayTest.php
+++ b/tests/USA/WashingtonsBirthdayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/CatholicChristmasDayTest.php
+++ b/tests/Ukraine/CatholicChristmasDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/ChristmasDayTest.php
+++ b/tests/Ukraine/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/ConstitutionDayTest.php
+++ b/tests/Ukraine/ConstitutionDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/DefenderOfUkraineDayTest.php
+++ b/tests/Ukraine/DefenderOfUkraineDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/EasterTest.php
+++ b/tests/Ukraine/EasterTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/IndependenceDayTest.php
+++ b/tests/Ukraine/IndependenceDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/InternationalWomensDayTest.php
+++ b/tests/Ukraine/InternationalWomensDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/InternationalWorkersDayTest.php
+++ b/tests/Ukraine/InternationalWorkersDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/NewYearsDayTest.php
+++ b/tests/Ukraine/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/PentecostTest.php
+++ b/tests/Ukraine/PentecostTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/SecondInternationalWorkersDayTest.php
+++ b/tests/Ukraine/SecondInternationalWorkersDayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/SubstitutedHolidayTest.php
+++ b/tests/Ukraine/SubstitutedHolidayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -73,7 +75,7 @@ class SubstitutedHolidayTest extends UkraineBaseTestCase implements HolidayTestC
         self::assertTrue($holidays->isHoliday($holidayOfficial));
         self::assertEquals(Holiday::TYPE_OFFICIAL, $holidayOfficial->getType());
 
-        $holidaySubstitution = $holidays->getHoliday('substituteHoliday:'.$holidayOfficial->getKey());
+        $holidaySubstitution = $holidays->getHoliday('substituteHoliday:' . $holidayOfficial->getKey());
 
         if (! $expectedSubstitution instanceof \DateTimeInterface) {
             // without substitution

--- a/tests/Ukraine/UkraineBaseTestCase.php
+++ b/tests/Ukraine/UkraineBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/UkraineTest.php
+++ b/tests/Ukraine/UkraineTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/Ukraine/VictoryDayTest.php
+++ b/tests/Ukraine/VictoryDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/BoxingDayTest.php
+++ b/tests/UnitedKingdom/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,8 +47,8 @@ class BoxingDayTest extends UnitedKingdomBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
-            $this->assertHolidayType(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, Holiday::TYPE_BANK);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
         }
     }
 

--- a/tests/UnitedKingdom/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,8 +47,8 @@ class ChristmasDayTest extends UnitedKingdomBaseTestCase implements HolidayTestC
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
-            $this->assertHolidayType(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, Holiday::TYPE_BANK);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
         }
     }
 

--- a/tests/UnitedKingdom/EasterMondayTest.php
+++ b/tests/UnitedKingdom/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/England/BoxingDayTest.php
+++ b/tests/UnitedKingdom/England/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,8 +47,8 @@ class BoxingDayTest extends EnglandBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
-            $this->assertHolidayType(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, Holiday::TYPE_BANK);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
         }
     }
 

--- a/tests/UnitedKingdom/England/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/England/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,8 +47,8 @@ class ChristmasDayTest extends EnglandBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
-            $this->assertHolidayType(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, Holiday::TYPE_BANK);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
         }
     }
 

--- a/tests/UnitedKingdom/England/EasterMondayTest.php
+++ b/tests/UnitedKingdom/England/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/England/EnglandBaseTestCase.php
+++ b/tests/UnitedKingdom/England/EnglandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/England/EnglandTest.php
+++ b/tests/UnitedKingdom/England/EnglandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/England/GoodFridayTest.php
+++ b/tests/UnitedKingdom/England/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/England/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/MayDayBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/England/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/England/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/England/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/SpringBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/England/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/England/SummerBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/GoodFridayTest.php
+++ b/tests/UnitedKingdom/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/KingCharlesCoronationBankHolidayTest.php
+++ b/tests/UnitedKingdom/KingCharlesCoronationBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/MayDayBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/MotheringSundayTest.php
+++ b/tests/UnitedKingdom/MotheringSundayTest.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/NorthernIreland/BattleOfTheBoyneTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/BattleOfTheBoyneTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -49,7 +52,7 @@ class BattleOfTheBoyneTest extends NorthernIrelandBaseTestCase implements Holida
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->modify('next monday');
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/UnitedKingdom/NorthernIreland/BoxingDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,8 +47,8 @@ class BoxingDayTest extends NorthernIrelandBaseTestCase implements HolidayTestCa
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
-            $this->assertHolidayType(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, Holiday::TYPE_BANK);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
         }
     }
 

--- a/tests/UnitedKingdom/NorthernIreland/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,8 +47,8 @@ class ChristmasDayTest extends NorthernIrelandBaseTestCase implements HolidayTes
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
-            $this->assertHolidayType(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, Holiday::TYPE_BANK);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
         }
     }
 

--- a/tests/UnitedKingdom/NorthernIreland/EasterMondayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/NorthernIreland/GoodFridayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/NorthernIreland/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/MayDayBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/NorthernIreland/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/NorthernIreland/NorthernIrelandBaseTestCase.php
+++ b/tests/UnitedKingdom/NorthernIreland/NorthernIrelandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/NorthernIreland/NorthernIrelandTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/NorthernIrelandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/NorthernIreland/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/SpringBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/NorthernIreland/StPatricksDayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/StPatricksDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -49,7 +52,7 @@ class StPatricksDayTest extends NorthernIrelandBaseTestCase implements HolidayTe
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->modify('next monday');
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/NorthernIreland/SummerBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/PlatinumJubileeBankHolidayTest.php
+++ b/tests/UnitedKingdom/PlatinumJubileeBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/QueenElizabethFuneralBankHolidayTest.php
+++ b/tests/UnitedKingdom/QueenElizabethFuneralBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Scotland/BoxingDayTest.php
+++ b/tests/UnitedKingdom/Scotland/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,8 +47,8 @@ class BoxingDayTest extends ScotlandBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
-            $this->assertHolidayType(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, Holiday::TYPE_BANK);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
         }
     }
 

--- a/tests/UnitedKingdom/Scotland/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/Scotland/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,8 +47,8 @@ class ChristmasDayTest extends ScotlandBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
-            $this->assertHolidayType(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, Holiday::TYPE_BANK);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
         }
     }
 

--- a/tests/UnitedKingdom/Scotland/GoodFridayTest.php
+++ b/tests/UnitedKingdom/Scotland/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Scotland/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/Scotland/MayDayBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Scotland/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/Scotland/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class NewYearsDayTest extends ScotlandBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/UnitedKingdom/Scotland/ScotlandBaseTestCase.php
+++ b/tests/UnitedKingdom/Scotland/ScotlandBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Scotland/ScotlandTest.php
+++ b/tests/UnitedKingdom/Scotland/ScotlandTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Scotland/SecondNewYearsDayTest.php
+++ b/tests/UnitedKingdom/Scotland/SecondNewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -54,7 +57,7 @@ class SecondNewYearsDayTest extends ScotlandBaseTestCase implements HolidayTestC
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/UnitedKingdom/Scotland/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/Scotland/SpringBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Scotland/StAndrewsDayTest.php
+++ b/tests/UnitedKingdom/Scotland/StAndrewsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -49,7 +52,7 @@ class StAndrewsDayTest extends ScotlandBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->modify('next monday');
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }
     }
 

--- a/tests/UnitedKingdom/Scotland/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/Scotland/SummerBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/SpringBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/SummerBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/UnitedKingdomBaseTestCase.php
+++ b/tests/UnitedKingdom/UnitedKingdomBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/UnitedKingdomTest.php
+++ b/tests/UnitedKingdom/UnitedKingdomTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -72,7 +75,7 @@ class UnitedKingdomTest extends UnitedKingdomBaseTestCase implements ProviderTes
         $holidays = [
             'easterMonday',
             'secondChristmasDay',
-       ];
+        ];
 
         $year = $this->generateRandomYear();
 

--- a/tests/UnitedKingdom/Wales/BoxingDayTest.php
+++ b/tests/UnitedKingdom/Wales/BoxingDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,8 +47,8 @@ class BoxingDayTest extends WalesBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
-            $this->assertHolidayType(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, Holiday::TYPE_BANK);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
         }
     }
 

--- a/tests/UnitedKingdom/Wales/ChristmasDayTest.php
+++ b/tests/UnitedKingdom/Wales/ChristmasDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -44,8 +47,8 @@ class ChristmasDayTest extends WalesBaseTestCase implements HolidayTestCase
 
         if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->add(new \DateInterval('P2D'));
-            $this->assertHoliday(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, $date);
-            $this->assertHolidayType(self::REGION, 'substituteHoliday:'.self::HOLIDAY, $year, Holiday::TYPE_BANK);
+            $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
+            $this->assertHolidayType(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, Holiday::TYPE_BANK);
         }
     }
 

--- a/tests/UnitedKingdom/Wales/EasterMondayTest.php
+++ b/tests/UnitedKingdom/Wales/EasterMondayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Wales/GoodFridayTest.php
+++ b/tests/UnitedKingdom/Wales/GoodFridayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Wales/MayDayBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/MayDayBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Wales/NewYearsDayTest.php
+++ b/tests/UnitedKingdom/Wales/NewYearsDayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Wales/SpringBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/SpringBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Wales/SummerBankHolidayTest.php
+++ b/tests/UnitedKingdom/Wales/SummerBankHolidayTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Wales/WalesBaseTestCase.php
+++ b/tests/UnitedKingdom/Wales/WalesBaseTestCase.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/UnitedKingdom/Wales/WalesTest.php
+++ b/tests/UnitedKingdom/Wales/WalesTest.php
@@ -1,8 +1,11 @@
 <?php
 
-declare(strict_types=1);
-/*
- * This file is part of the Yasumi package.
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *

--- a/tests/YasumiBase.php
+++ b/tests/YasumiBase.php
@@ -1,9 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-/*
- * This file is part of the Yasumi package.
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
  *
  * Copyright (c) 2015 - 2024 AzuyaLabs
  *
@@ -126,7 +128,7 @@ trait YasumiBase
         \DateTimeInterface $expected
     ): void {
         $holidays = Yasumi::create($provider, $year);
-        $holiday = $holidays->getHoliday('substituteHoliday:'.$key);
+        $holiday = $holidays->getHoliday('substituteHoliday:' . $key);
 
         self::assertInstanceOf(SubstituteHoliday::class, $holiday);
         $this->assertDateTime($expected, $holiday);
@@ -152,7 +154,7 @@ trait YasumiBase
     ): void {
         $this->assertNotHoliday(
             $provider,
-            'substituteHoliday:'.$key,
+            'substituteHoliday:' . $key,
             $year
         );
     }


### PR DESCRIPTION
Fixes #342

I hope the code comments explain the reasoning behind the changes.

All my systems seem to support both variants, but I had multiple bugs raised about `Australia/ACT` and `Europe/Kiev`.
Can't say when this happens, maybe it depends on the `tzdata` lib on the system where PHP was compiled. Or some PHP builds remove all timezone name which are only so called "links". 

In the official table (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones ) both problematic TZ are only links, so I replaced them with their real TZ identifier.

Edit: I used two approaches, so you can decide which way is the better one. 
Use the correct TZ identifier directly (Sydney) or use the try&catch approach (Kiev). 
Maybe try&catch in both places is the best approach for maximum BC?