### PR TITLE
fix(mexico): mark three holidays as official

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 - Holiday calculation methods in providers are now protected instead of private 
   to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
   [\#331](https://github.com/azuyalabs/yasumi/issues/331)
+- For Mexico, Constitution Day, Benito Juárez’s birthday, and Revolution Day are not considered official holidays. [\#359](https://github.com/azuyalabs/yasumi/pull/359) ([c960657](https://github.com/c960657))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ changes.
 - Holiday calculation methods in providers are now protected instead of private 
   to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
   [\#331](https://github.com/azuyalabs/yasumi/issues/331)
-- For Mexico, Constitution Day, Benito Juárez’s birthday, and Revolution Day are not considered official holidays. [\#359](https://github.com/azuyalabs/yasumi/pull/359) ([c960657](https://github.com/c960657))
+- For Mexico, Constitution Day, Benito Juárez’s birthday, and Revolution Day are considered official holidays. [\#359](https://github.com/azuyalabs/yasumi/pull/359) ([c960657](https://github.com/c960657))
 
 ### Fixed
 

--- a/src/Yasumi/Provider/Mexico.php
+++ b/src/Yasumi/Provider/Mexico.php
@@ -121,7 +121,7 @@ class Mexico extends AbstractProvider
                     'en' => 'Constitution Day',
                     'es' => 'Día de la Constitución',
                 ],
-                new \DateTime("first monday of february {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_OBSERVANCE)
+                new \DateTime("first monday of february {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale)
             );
         }
     }
@@ -151,7 +151,7 @@ class Mexico extends AbstractProvider
                     'en' => 'Benito Juárez’s birthday',
                     'es' => 'Natalicio de Benito Juárez',
                 ],
-                new \DateTime("third monday of march {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_OBSERVANCE)
+                new \DateTime("third monday of march {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale)
             );
         }
     }
@@ -170,7 +170,7 @@ class Mexico extends AbstractProvider
                     'en' => 'Revolution Day',
                     'es' => 'Día de la Revolución',
                 ],
-                new \DateTime("third monday of november {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_OBSERVANCE)
+                new \DateTime("third monday of november {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale)
             );
         }
     }

--- a/src/Yasumi/Provider/Mexico.php
+++ b/src/Yasumi/Provider/Mexico.php
@@ -140,7 +140,7 @@ class Mexico extends AbstractProvider
                     'en' => 'Benito Juárez’s birthday',
                     'es' => 'Natalicio de Benito Juárez',
                 ],
-                new \DateTime("{$this->year}-03-21", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_OBSERVANCE)
+                new \DateTime("{$this->year}-03-21", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale)
             );
         }
 

--- a/tests/Mexico/BenitoJuarezBirthdayTest.php
+++ b/tests/Mexico/BenitoJuarezBirthdayTest.php
@@ -67,6 +67,6 @@ class BenitoJuarezBirthdayTest extends MexicoBaseTestCase implements HolidayTest
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(self::ESTABLISHMENT_YEAR), Holiday::TYPE_OBSERVANCE);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(self::ESTABLISHMENT_YEAR), Holiday::TYPE_OFFICIAL);
     }
 }


### PR DESCRIPTION
According to the Mexican Federal Labor Law (_Ley Federal del Trabajo_), these three holidays are official public holidays:
- First Monday of February (Constitution Day, _el primer lunes de febrero en conmemoración del 5 de febrer_)
- Third Monday of March (Benito Juárez’s birthday, _el tercer lunes de marzo en conmemoración del 21 de marzo_)
- Third Monday in November (Revolution Day, _el tercer lunes de noviembre en conmemoración del 20 de noviembre_)

In Yasumi they are currently marked as `TYPE_OBSERVANCE`.

Source:
https://www.gob.mx/profedet/articulos/sabes-cuales-son-los-dias-de-descanso-obligatorios-163134
https://mexico.justia.com/federales/leyes/ley-federal-del-trabajo/titulo-tercero/capitulo-iii/#articulo-74