### PR TITLE
fix(argentina): Mark three holidays as official

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 - Holiday calculation methods in providers are now protected instead of private 
   to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
   [\#331](https://github.com/azuyalabs/yasumi/issues/331)
+- For Argentina, Carneval Monday and Tuesday, and Good Friday are not considered official holidays. [\#360](https://github.com/azuyalabs/yasumi/pull/360) ([c960657](https://github.com/c960657))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ changes.
 - Holiday calculation methods in providers are now protected instead of private 
   to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
   [\#331](https://github.com/azuyalabs/yasumi/issues/331)
-- For Argentina, Carneval Monday and Tuesday, and Good Friday are not considered official holidays. [\#360](https://github.com/azuyalabs/yasumi/pull/360) ([c960657](https://github.com/c960657))
+- For Argentina, Carneval Monday and Tuesday, and Good Friday are considered official holidays. [\#360](https://github.com/azuyalabs/yasumi/pull/360) ([c960657](https://github.com/c960657))
 
 ### Fixed
 

--- a/src/Yasumi/Provider/Argentina.php
+++ b/src/Yasumi/Provider/Argentina.php
@@ -54,7 +54,7 @@ class Argentina extends AbstractProvider
         // Add Christian holidays
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
 
         $this->addCarnvalHolidays();
         $this->addRemembranceDay();
@@ -122,8 +122,7 @@ class Argentina extends AbstractProvider
                         'en' => $day['name_en'],
                     ],
                     $date,
-                    $this->locale,
-                    Holiday::TYPE_OBSERVANCE
+                    $this->locale
                 ));
             }
         }

--- a/tests/Argentina/ArgentinaTest.php
+++ b/tests/Argentina/ArgentinaTest.php
@@ -48,6 +48,9 @@ class ArgentinaTest extends ArgentinaBaseTestCase implements ProviderTestCase
     {
         $holidays = [
             'newYearsDay',
+            'carnavalMonday',
+            'carnavalTuesday',
+            'goodFriday',
             'internationalWorkersDay',
             'mayRevolution',
             'generalMartinMigueldeGuemesDay',
@@ -83,9 +86,6 @@ class ArgentinaTest extends ArgentinaBaseTestCase implements ProviderTestCase
     public function testObservedHolidays(): void
     {
         $this->assertDefinedHolidays([
-            'carnavalMonday',
-            'carnavalTuesday',
-            'goodFriday',
             'easter',
         ], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
     }

--- a/tests/Argentina/CarnavalMondayTest.php
+++ b/tests/Argentina/CarnavalMondayTest.php
@@ -84,6 +84,6 @@ class CarnavalMondayTest extends ArgentinaBaseTestCase implements HolidayTestCas
     public function testHolidayType(): void
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OBSERVANCE);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Argentina/CarnavalTuesdayTest.php
+++ b/tests/Argentina/CarnavalTuesdayTest.php
@@ -84,6 +84,6 @@ class CarnavalTuesdayTest extends ArgentinaBaseTestCase implements HolidayTestCa
     public function testHolidayType(): void
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OBSERVANCE);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Argentina/GoodFridayTest.php
+++ b/tests/Argentina/GoodFridayTest.php
@@ -71,6 +71,6 @@ class GoodFridayTest extends ArgentinaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }


### PR DESCRIPTION
According to the Argentinian Law on the Establishment of Holidays and Long Weekends (_Ley de establecimiento de feriados y fines de semanas largos_), these three holidays are official public holidays:
- Carneval Monday and Tuesday (_Lunes y Martes de Carnaval_)
- Good Friday (_Viernes Santo_)

In Yasumi they are currently marked as `TYPE_OBSERVANCE`.
Source:
https://www.argentina.gob.ar/interior/feriados-nacionales-2025
https://www.argentina.gob.ar/normativa/nacional/ley-27399-281835/texto