### PR TITLE
feat(mexico): add Transmission of Federal Executive Power Holiday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes.
 - Holiday calculation methods in providers are now protected instead of private 
   to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
   [\#331](https://github.com/azuyalabs/yasumi/issues/331)
+- For Mexico, add the Day of Transmission of Federal Executive Power in election years. [\#359](https://github.com/azuyalabs/yasumi/pull/359) ([c960657](https://github.com/c960657))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ changes.
 - Holiday calculation methods in providers are now protected instead of private 
   to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
   [\#331](https://github.com/azuyalabs/yasumi/issues/331)
-- For Mexico, add the Day of Transmission of Federal Executive Power in election years. [\#359](https://github.com/azuyalabs/yasumi/pull/359) ([c960657](https://github.com/c960657))
+- For Mexico, add the Day of Transmission of Federal Executive Power in election years. [\#361](https://github.com/azuyalabs/yasumi/pull/361) ([c960657](https://github.com/c960657))
 
 ### Fixed
 

--- a/src/Yasumi/Provider/Mexico.php
+++ b/src/Yasumi/Provider/Mexico.php
@@ -164,7 +164,7 @@ class Mexico extends AbstractProvider
      */
     protected function calculateTransmissionOfFederalPowerDay(): void
     {
-        if ($this->year >= 1934 && $this->year % 6 === 2) {
+        if ($this->year >= 1934 && 2 === $this->year % 6) {
             $day = $this->year < 2024 ? "{$this->year}-12-01" : "{$this->year}-10-01";
             $this->addHoliday(new Holiday(
                 'transmissionOfFederalPowerDay',
@@ -176,7 +176,6 @@ class Mexico extends AbstractProvider
             );
         }
     }
-
 
     /*
     * Revolution Day.

--- a/src/Yasumi/Provider/Mexico.php
+++ b/src/Yasumi/Provider/Mexico.php
@@ -67,6 +67,7 @@ class Mexico extends AbstractProvider
         $this->calculateRevolutionDay();
         $this->calculateDiscoveryOfAmerica();
         $this->addIndependenceDay();
+        $this->calculateTransmissionOfFederalPowerDay();
         $this->calculateDayOfTheDead();
         $this->calculateChristmasEve();
         $this->calculateNewYearsEve();
@@ -155,6 +156,27 @@ class Mexico extends AbstractProvider
             );
         }
     }
+
+    /**
+     * Transmission of Federal Executive Power.
+     *
+     * In years of presidential elections (every 6 years), the new president is inaugurated on 1 October. Prior to 2024, this happened on 1 December.
+     */
+    protected function calculateTransmissionOfFederalPowerDay(): void
+    {
+        if ($this->year >= 1934 && $this->year % 6 === 2) {
+            $day = $this->year < 2024 ? "{$this->year}-12-01" : "{$this->year}-10-01";
+            $this->addHoliday(new Holiday(
+                'transmissionOfFederalPowerDay',
+                [
+                    'en' => 'Transmission of Federal Executive Power',
+                    'es' => 'Transmisión de Poder Ejecutivo Federal',
+                ],
+                new \DateTime($day, DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale)
+            );
+        }
+    }
+
 
     /*
     * Revolution Day.

--- a/tests/Mexico/TransmissionOfFederalPowerDayTest.php
+++ b/tests/Mexico/TransmissionOfFederalPowerDayTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2025 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Mexico;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+class TransmissionOfFederalPowerDayTest extends MexicoBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'transmissionOfFederalPowerDay';
+
+    public const ESTABLISHMENT_YEAR = 1934;
+
+    /**
+     *  Tests that holiday is in December in 1934-2018.
+     */
+    public function testHolidayBefore2018(): void
+    {
+        $year = self::ESTABLISHMENT_YEAR;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-12-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     *  Tests that holiday is in October since 2024.
+     */
+    public function testHolidayAfter2024(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("2024-10-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     *  Tests that holiday is in October since 2024.
+     */
+    public function testNotHolidayOutsideElectionYear(): void
+    {
+        $year = $this->numberBetween(2019, 2023);
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-10-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     *  Tests that holiday is not present before establishment year.
+     */
+    public function testNotHolidayBefore1934(): void
+    {
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, self::ESTABLISHMENT_YEAR - 6);
+    }
+
+    /**
+     * Tests translated name of the holiday.
+     *
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            self::ESTABLISHMENT_YEAR,
+            [self::LOCALE => 'Transmisión de Poder Ejecutivo Federal']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY,self::ESTABLISHMENT_YEAR, Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Mexico/TransmissionOfFederalPowerDayTest.php
+++ b/tests/Mexico/TransmissionOfFederalPowerDayTest.php
@@ -50,7 +50,7 @@ class TransmissionOfFederalPowerDayTest extends MexicoBaseTestCase implements Ho
             self::REGION,
             self::HOLIDAY,
             $year,
-            new \DateTime("2024-10-01", new \DateTimeZone(self::TIMEZONE))
+            new \DateTime('2024-10-01', new \DateTimeZone(self::TIMEZONE))
         );
     }
 
@@ -98,6 +98,6 @@ class TransmissionOfFederalPowerDayTest extends MexicoBaseTestCase implements Ho
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY,self::ESTABLISHMENT_YEAR, Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, self::ESTABLISHMENT_YEAR, Holiday::TYPE_OFFICIAL);
     }
 }


### PR DESCRIPTION
In Mexico presidential elections are held every six years. The new president is inaugurated on 1 October which is a public holiday.

Prior to 2024, this happened on 1 December.

Source:
https://www.gob.mx/profedet/articulos/sabes-cuales-son-los-dias-de-descanso-obligatorios-163134
https://mexico.justia.com/federales/leyes/ley-federal-del-trabajo/titulo-tercero/capitulo-iii/#articulo-74
https://sil.gobernacion.gob.mx/Archivos/Documentos/2022/03/asun_4332475_20220315_1646845246.pdf

I am not sure when this holiday was officially established, so I arbitrarily chose 1934 where the six-year presidential term was introduced. The holiday is defined by the Federal Labour Act (_Ley Federal del Trabajo_). The current law is from 1970, and its predecessor is from 1931.

Source:
https://en.wikipedia.org/wiki/List_of_heads_of_state_of_Mexico#Modern_Mexico_(1934%E2%80%93present)
https://es.wikipedia.org/wiki/Ley_Federal_del_Trabajo_(M%C3%A9xico)