### PR TITLE
fix(mexico): mark several holidays as observance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
   to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
   [\#331](https://github.com/azuyalabs/yasumi/issues/331)
 - For Argentina, Carneval Monday and Tuesday, and Good Friday are considered official holidays. [\#360](https://github.com/azuyalabs/yasumi/pull/360) ([c960657](https://github.com/c960657))
+- For Mexico, several holidays are not considered official holidays. [\#362](https://github.com/azuyalabs/yasumi/pull/362) ([c960657](https://github.com/c960657))
 
 ### Fixed
 

--- a/src/Yasumi/Provider/Mexico.php
+++ b/src/Yasumi/Provider/Mexico.php
@@ -54,12 +54,12 @@ class Mexico extends AbstractProvider
 
         // Add Christian holidays
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->epiphany($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
         $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->immaculateConception($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
+        $this->addHoliday($this->immaculateConception($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
 
         // Mexican holidays
         $this->calculateConstitutionDay();
@@ -208,7 +208,7 @@ class Mexico extends AbstractProvider
                 'en' => 'Christmas Eve',
                 'es' => 'Nochebuena',
             ],
-            new \DateTime("{$this->year}-12-24", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale)
+            new \DateTime("{$this->year}-12-24", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_OBSERVANCE)
         );
     }
 
@@ -225,8 +225,10 @@ class Mexico extends AbstractProvider
                 'en' => 'New Year’s Eve',
                 'es' => 'Nochevieja',
             ],
-            new \DateTime("{$this->year}-12-31", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale)
-        );
+            new \DateTime("{$this->year}-12-31", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $this->locale,
+            Holiday::TYPE_OBSERVANCE
+        ));
     }
 
     /**
@@ -244,8 +246,10 @@ class Mexico extends AbstractProvider
                     'en' => 'Day of the Deaths',
                     'es' => 'Día de los Muertos',
                 ],
-                new \DateTime("{$this->year}-11-02", DateTimeZoneFactory::getDateTimeZone($this->timezone)), $this->locale, Holiday::TYPE_OTHER)
-            );
+                new \DateTime("{$this->year}-11-02", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_OBSERVANCE
+            ));
         }
     }
 
@@ -262,7 +266,8 @@ class Mexico extends AbstractProvider
                 'virginOfGuadalupe',
                 ['es' => 'Día de la Virgen de Guadalupe'],
                 new \DateTime("{$this->year}-12-12", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-                $this->locale
+                $this->locale,
+                Holiday::TYPE_OBSERVANCE
             ));
         }
     }

--- a/tests/Mexico/AllSaintsDayTest.php
+++ b/tests/Mexico/AllSaintsDayTest.php
@@ -77,6 +77,6 @@ class AllSaintsDayTest extends MexicoBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
     }
 }

--- a/tests/Mexico/AssumptionOfMaryTest.php
+++ b/tests/Mexico/AssumptionOfMaryTest.php
@@ -77,6 +77,6 @@ class AssumptionOfMaryTest extends MexicoBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
     }
 }

--- a/tests/Mexico/EpiphanyTest.php
+++ b/tests/Mexico/EpiphanyTest.php
@@ -77,6 +77,6 @@ class EpiphanyTest extends MexicoBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
     }
 }

--- a/tests/Mexico/GoodFridayTest.php
+++ b/tests/Mexico/GoodFridayTest.php
@@ -68,6 +68,6 @@ class GoodFridayTest extends MexicoBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
     }
 }

--- a/tests/Mexico/ImmaculateConceptionTest.php
+++ b/tests/Mexico/ImmaculateConceptionTest.php
@@ -77,6 +77,6 @@ class ImmaculateConceptionTest extends MexicoBaseTestCase implements HolidayTest
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
     }
 }

--- a/tests/Mexico/VirginOfGuadalupeTest.php
+++ b/tests/Mexico/VirginOfGuadalupeTest.php
@@ -70,6 +70,6 @@ class VirginOfGuadalupeTest extends MexicoBaseTestCase implements HolidayTestCas
     public function testHolidayType(): void
     {
         $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OBSERVANCE);
     }
 }


### PR DESCRIPTION
AFAICT, these holidays are not official in Mexico, at least not according to the Mexican Federal Labor Law (Ley Federal del Trabajo):
- Epiphany
- Good Friday
- Assumption of Mary
- All Saints Day
- Immaculate Conception
- Virgin of Guadalupe
- Christmas Eve
- New Year's Eve

I don't know which other legislation would make these official.

I have marked them `TYPE_OBSERVANCE` instead. I am not sure how exactly the different types are defined, though.