### PR TITLE
fix(portugal): Corpus Christi is official

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
   to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
   [\#331](https://github.com/azuyalabs/yasumi/issues/331)
 - For Argentina, Carneval Monday and Tuesday, and Good Friday are considered official holidays. [\#360](https://github.com/azuyalabs/yasumi/pull/360) ([c960657](https://github.com/c960657))
+- For Portual, Corpus Christi is considered an official holiday. [\#363](https://github.com/azuyalabs/yasumi/pull/363) ([c960657](https://github.com/c960657))
 
 ### Fixed
 

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -65,6 +65,7 @@ class Portugal extends AbstractProvider
         return [
             'https://en.wikipedia.org/wiki/Public_holidays_in_Portugal',
             'https://pt.wikipedia.org/wiki/Feriados_em_Portugal',
+            'https://diariodarepublica.pt/dr/legislacao-consolidada/lei/2009-34546475-73982045'
         ];
     }
 

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -65,7 +65,7 @@ class Portugal extends AbstractProvider
         return [
             'https://en.wikipedia.org/wiki/Public_holidays_in_Portugal',
             'https://pt.wikipedia.org/wiki/Feriados_em_Portugal',
-            'https://diariodarepublica.pt/dr/legislacao-consolidada/lei/2009-34546475-73982045'
+            'https://diariodarepublica.pt/dr/legislacao-consolidada/lei/2009-34546475-73982045',
         ];
     }
 

--- a/src/Yasumi/Provider/Portugal.php
+++ b/src/Yasumi/Provider/Portugal.php
@@ -112,7 +112,7 @@ class Portugal extends AbstractProvider
     protected function calculateCorpusChristi(): void
     {
         if ($this->year <= 2012 || $this->year >= 2016) {
-            $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale));
+            $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         }
     }
 

--- a/tests/Portugal/CorpusChristiTest.php
+++ b/tests/Portugal/CorpusChristiTest.php
@@ -83,10 +83,10 @@ class CorpusChristiTest extends PortugalBaseTestCase implements HolidayTestCase
     {
         // Before abolishment
         $year = $this->generateRandomYear(1000, self::HOLIDAY_YEAR_ABOLISHED - 1);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
 
         // After restoration
         $year = $this->generateRandomYear(self::HOLIDAY_YEAR_RESTORED);
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OTHER);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $year, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Portugal/PortugalTest.php
+++ b/tests/Portugal/PortugalTest.php
@@ -116,6 +116,6 @@ class PortugalTest extends PortugalBaseTestCase implements ProviderTestCase
      */
     public function testSources(): void
     {
-        $this->assertSources(self::REGION, 2);
+        $this->assertSources(self::REGION, 3);
     }
 }

--- a/tests/Portugal/PortugalTest.php
+++ b/tests/Portugal/PortugalTest.php
@@ -107,7 +107,7 @@ class PortugalTest extends PortugalBaseTestCase implements ProviderTestCase
             $holidays[] = 'corpusChristi';
         }
 
-        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OTHER);
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
     /**


### PR DESCRIPTION
According to article 234 of the Labour Code of Portugal (_Código do Trabalho_), Corpus Christi (_Corpo de Deus_) is an official public holiday.

https://diariodarepublica.pt/dr/legislacao-consolidada/lei/2009-34546475

> 1 - São feriados obrigatórios os dias 1 de janeiro, de Sexta-Feira Santa, de Domingo de Páscoa, 25 de abril, 1 de maio, de Corpo de Deus, 10 de junho, 15 de agosto, 5 de outubro, 1 de novembro, 1, 8 e 25 de dezembro.

Automated translation:
> 1 - The following are mandatory holidays: January 1st, Good Friday, Easter Sunday, April 25th, May 1st, Corpus Christi, June 10th, August 15th, October 5th, November 1st, December 1st, 8th and 25th.