### PR TITLE
feat(brazil): Black Consciousness Day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ changes.
 ## [Unreleased]
 
 ### Added
+- Black Consciousness Day ('Dia Nacional de Zumbi e da Consciência Negra') is public holiday in Brazil. [\#365](https://github.com/azuyalabs/yasumi/pull/365) ([c960657](https://github.com/c960657))
 
 ### Changed
 

--- a/src/Yasumi/Provider/Brazil.php
+++ b/src/Yasumi/Provider/Brazil.php
@@ -63,6 +63,7 @@ class Brazil extends AbstractProvider
         $this->calculateOurLadyOfAparecidaDay();
         $this->calculateProclamationOfRepublicDay();
         $this->calculateTiradentesDay();
+        $this->calculateBlackConsciousnessDay();
     }
 
     public function getSources(): array
@@ -157,7 +158,7 @@ class Brazil extends AbstractProvider
     /*
      * Tiradentes Day
      *
-     * Tiradentes Day is a the Brazilian national holidays. Is the a tribute to national Brazilian hero Joaquim José
+     * Tiradentes Day is a Brazilian national holiday. Is is a tribute to national Brazilian hero Joaquim José
      * da Silva Xavier, martyr of Inconfidência Mineira. Is celebrated on 21 Abril, because the execution of
      * Tiradentes got in the day, in 1792.
      *
@@ -214,6 +215,29 @@ class Brazil extends AbstractProvider
                     Holiday::TYPE_OBSERVANCE
                 ));
             }
+        }
+    }
+
+    /*
+     * Black Consciousness Day
+     *
+     * Black Consciousness Day is a Brazilian national holiday commemorating Afro-Brazilians and their struggle
+     * to achieve racial equality. It is celebrated on 20 November, the anniversary of the death of resistance
+     * leader Zumbi dos Palmares, and is also known as Zumbi Day.
+     *
+     * @link https://en.wikipedia.org/wiki/Black_Awareness_Day
+     */
+    protected function calculateBlackConsciousnessDay(): void
+    {
+        if ($this->year >= 2011) {
+            $type = $this->year <= 2023 ? Holiday::TYPE_OBSERVANCE : Holiday::TYPE_OFFICIAL;
+            $this->addHoliday(new Holiday(
+                'blackConsciousnessDay',
+                ['pt' => 'Dia Nacional de Zumbi e da Consciência Negra'],
+                new \DateTime("{$this->year}-11-20", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale,
+                $type
+            ));
         }
     }
 }

--- a/tests/Brazil/BlackConsciousnessDayTest.php
+++ b/tests/Brazil/BlackConsciousnessDayTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2025 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Brazil;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class containing tests for Black Consciousness Day in Brazil.
+ */
+class BlackConsciousnessDayTest extends BrazilBaseTestCase implements HolidayTestCase
+{
+    /**
+     * The name of the holiday.
+     */
+    public const HOLIDAY = 'blackConsciousnessDay';
+
+    /**
+     * The year in which the holiday was first established.
+     */
+    public const ESTABLISHMENT_YEAR = 2011;
+
+    /**
+     * The year in which the holiday celebration date has changed.
+     */
+    public const OFFICIAL_YEAR = 2024;
+
+    /**
+     * Tests Black Consciousness Day.
+     *
+     * @throws \Exception
+     */
+    public function testBlackConsciousnessDay(): void
+    {
+        $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::OFFICIAL_YEAR - 1);
+        $expectedDate = "{$year}-11-20";
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime($expectedDate, new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests Black Consciousness Day before 2011.
+     *
+     * @throws \Exception
+     */
+    public function testBlackConsciousnessDayBefore2011(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests translated name of Black Consciousness Day.
+     *
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Dia Nacional de Zumbi e da Consciência Negra']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR, self::OFFICIAL_YEAR - 1),
+            Holiday::TYPE_OBSERVANCE
+        );
+
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::OFFICIAL_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}


### PR DESCRIPTION
In Brazil, Black Consciousness Day (_Dia Nacional de Zumbi e da Consciência Negra_) has been celebrated on 20 November since 2011. In December 2023 it was made a public holiday. 

Source:
https://www.planalto.gov.br/ccivil_03/_ato2011-2014/2011/lei/l12519.htm
https://www.planalto.gov.br/ccivil_03/_ato2023-2026/2023/lei/l14759.htm
https://en.wikipedia.org/wiki/Black_Awareness_Day
https://pt.wikipedia.org/wiki/Dia_Nacional_de_Zumbi_e_da_Consci%C3%AAncia_Negra