### PR TITLE
fix(czech-republic): Christmas Eve is official

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ changes.
   to allow use in [custom providers](https://www.yasumi.dev/docs/cookbook/custom_provider/).
   [\#331](https://github.com/azuyalabs/yasumi/issues/331)
 - For Argentina, Carneval Monday and Tuesday, and Good Friday are considered official holidays. [\#360](https://github.com/azuyalabs/yasumi/pull/360) ([c960657](https://github.com/c960657))
+- For the Czech Republic, Christmas Eve is considered an official holiday. [\#366](https://github.com/azuyalabs/yasumi/pull/366) ([c960657](https://github.com/c960657))
 
 ### Fixed
 

--- a/src/Yasumi/Provider/CzechRepublic.php
+++ b/src/Yasumi/Provider/CzechRepublic.php
@@ -60,7 +60,7 @@ class CzechRepublic extends AbstractProvider
         $this->calculateCzechStatehoodDay();
         $this->calculateIndependentCzechoslovakStateDay();
         $this->calculateStruggleForFreedomAndDemocracyDay();
-        $this->addHoliday($this->christmasEve($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->christmasEve($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale));
     }
@@ -70,6 +70,7 @@ class CzechRepublic extends AbstractProvider
         return [
             'https://en.wikipedia.org/wiki/Public_holidays_in_the_Czech_Republic',
             'https://cs.wikipedia.org/wiki/%C4%8Cesk%C3%BD_st%C3%A1tn%C3%AD_sv%C3%A1tek',
+            'https://www.e-sbirka.cz/sb/2000/245/0000-00-00?zalozka=text#par_2',
         ];
     }
 

--- a/tests/CzechRepublic/ChristmasEveTest.php
+++ b/tests/CzechRepublic/ChristmasEveTest.php
@@ -81,6 +81,6 @@ class ChristmasEveTest extends CzechRepublicBaseTestCase implements HolidayTestC
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/CzechRepublic/CzechRepublicTest.php
+++ b/tests/CzechRepublic/CzechRepublicTest.php
@@ -105,6 +105,6 @@ class CzechRepublicTest extends CzechRepublicBaseTestCase implements ProviderTes
      */
     public function testSources(): void
     {
-        $this->assertSources(self::REGION, 2);
+        $this->assertSources(self::REGION, 3);
     }
 }

--- a/tests/CzechRepublic/CzechRepublicTest.php
+++ b/tests/CzechRepublic/CzechRepublicTest.php
@@ -56,6 +56,7 @@ class CzechRepublicTest extends CzechRepublicBaseTestCase implements ProviderTes
             'goodFriday',
             'easterMonday',
             'internationalWorkersDay',
+            'christmasEve',
             'christmasDay',
             'secondChristmasDay',
             'saintsCyrilAndMethodiusDay',
@@ -71,7 +72,7 @@ class CzechRepublicTest extends CzechRepublicBaseTestCase implements ProviderTes
      */
     public function testObservedHolidays(): void
     {
-        $this->assertDefinedHolidays(['christmasEve'], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
     }
 
     /**


### PR DESCRIPTION
According to the Czech Act on Public Holidays, Other Holidays, Important Days and Rest Days (_Zákon o státních svátcích, o ostatních svátcích, o významných dnech a o dnech pracovního klidu_), Christmas Eve has the same status as Christmas Day.

The law makes a distinction between “public holidays” (_státní svátky_) and “other holidays” (_ostatní svátky_). Both groups are non-working days, so in context of Yasumi, I think both should be mapped to `TYPE_OFFICIAL` (except from Christmas Eve, they already are).

Source:
https://www.e-sbirka.cz/sb/2000/245/0000-00-00?zalozka=text#par_2