### PR TITLE
feat(lithuania): Mother's Day and Father's Day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ changes.
 
 ### Added
 - Black Consciousness Day ('Dia Nacional de Zumbi e da Consciência Negra') is public holiday in Brazil. [\#365](https://github.com/azuyalabs/yasumi/pull/365) ([c960657](https://github.com/c960657))
+- Mother's Day and Father's Day are public holidays in Lithuania. [\#370](https://github.com/azuyalabs/yasumi/pull/370) ([c960657](https://github.com/c960657))
 
 ### Changed
 

--- a/src/Yasumi/Provider/Lithuania.php
+++ b/src/Yasumi/Provider/Lithuania.php
@@ -72,6 +72,8 @@ class Lithuania extends AbstractProvider
         $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
+        $this->addMothersDay();
+        $this->addFathersDay();
         $this->addHoliday($this->stJohnsDay($this->year, $this->timezone, $this->locale));
         $this->addStatehoodDay();
         $this->addHoliday($this->assumptionOfMary($this->year, $this->timezone, $this->locale));
@@ -87,6 +89,7 @@ class Lithuania extends AbstractProvider
         return [
             'https://en.wikipedia.org/wiki/Public_holidays_in_Lithuania',
             'https://lt.wikipedia.org/wiki/S%C4%85ra%C5%A1as:Lietuvos_%C5%A1vent%C4%97s',
+            'https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/10c6bfd07bd511e6a0f68fd135e6f40c/asr',
         ];
     }
 
@@ -120,6 +123,36 @@ class Lithuania extends AbstractProvider
                 'lt' => 'Lietuvos nepriklausomybės atkūrimo diena',
             ], new \DateTime("{$this->year}-03-11", new \DateTimeZone($this->timezone))));
         }
+    }
+
+    /**
+     * Mother's Day.
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    protected function addMothersDay(): void
+    {
+        $this->addHoliday(new Holiday(
+            'mothersDay',
+            [],
+            new \DateTime("first sunday of may {$this->year}", new \DateTimeZone($this->timezone))
+        ));
+    }
+
+    /**
+     * Father's Day.
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Exception
+     */
+    protected function addFathersDay(): void
+    {
+        $this->addHoliday(new Holiday(
+            'fathersDay',
+            [],
+            new \DateTime("first sunday of june {$this->year}", new \DateTimeZone($this->timezone))
+        ));
     }
 
     /**

--- a/src/Yasumi/data/translations/fathersDay.php
+++ b/src/Yasumi/data/translations/fathersDay.php
@@ -17,11 +17,13 @@ declare(strict_types = 1);
 
 // Translations for Father's Day
 return [
+    'da' => 'fars dag',
     'de' => 'Vatertag',
     'el' => 'Γιορτή του πατέρα',
     'en' => 'Father’s Day',
     'fr' => 'Fête des pères',
     'it' => 'Festa del papà',
+    'lt' => 'Tėvo dieną',
     'nl' => 'Vaderdag',
     'pt' => 'Dia do Pai',
     'ro' => 'Ziua Tatălui',

--- a/src/Yasumi/data/translations/mothersDay.php
+++ b/src/Yasumi/data/translations/mothersDay.php
@@ -22,6 +22,7 @@ return [
     'en' => 'Mother’s Day',
     'fr' => 'Fête des mères',
     'it' => 'Festa della mamma',
+    'lt' => 'Motinos dieną',
     'nl' => 'Moederdag',
     'pt' => 'Dia da Mãe',
     'ro' => 'Ziua Mamei',

--- a/tests/Lithuania/FathersDayTest.php
+++ b/tests/Lithuania/FathersDayTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2025 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Lithuania;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Lithuania;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class containing tests for Father's Day in Lithuania.
+ *
+ * @author Gedas Lukošius <gedas@lukosius.me>
+ */
+class FathersDayTest extends LithuaniaBaseTestCase implements HolidayTestCase
+{
+    /**
+     * The name of the holiday to be tested.
+     */
+    public const HOLIDAY = 'fathersDay';
+
+    /**
+     * Test if holiday is not defined before restoration.
+     *
+     * @throws \Exception
+     */
+    public function testHoliday(): void
+    {
+        $year = $this->generateRandomYear();
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("first sunday of june {$year}", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Tėvo dieną']
+        );
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            ['en' => 'Father’s Day']
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Lithuania/LithuaniaTest.php
+++ b/tests/Lithuania/LithuaniaTest.php
@@ -39,6 +39,8 @@ class LithuaniaTest extends LithuaniaBaseTestCase
             'easter',
             'easterMonday',
             'internationalWorkersDay',
+            'mothersDay',
+            'fathersDay',
             'stJohnsDay',
             'assumptionOfMary',
             'allSaintsDay',
@@ -110,6 +112,6 @@ class LithuaniaTest extends LithuaniaBaseTestCase
      */
     public function testSources(): void
     {
-        $this->assertSources(self::REGION, 2);
+        $this->assertSources(self::REGION, 3);
     }
 }

--- a/tests/Lithuania/MothersDayTest.php
+++ b/tests/Lithuania/MothersDayTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2025 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Lithuania;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Lithuania;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class containing tests for Mother's Day in Lithuania.
+ *
+ * @author Gedas Lukošius <gedas@lukosius.me>
+ */
+class MothersDayTest extends LithuaniaBaseTestCase implements HolidayTestCase
+{
+    /**
+     * The name of the holiday to be tested.
+     */
+    public const HOLIDAY = 'mothersDay';
+
+    /**
+     * Test if holiday is not defined before restoration.
+     *
+     * @throws \Exception
+     */
+    public function testHoliday(): void
+    {
+        $year = $this->generateRandomYear();
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("first sunday of may {$year}", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            [self::LOCALE => 'Motinos dieną']
+        );
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            ['en' => 'Mother’s Day']
+        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}


### PR DESCRIPTION
According to article 123 of the Labour Code of Lithuania (_Darbo kodekso_), Mother's Day (_motinos dieną_) and Father's Day (_tėvo dieną_) are official holidays.

Source:
https://en.wikipedia.org/wiki/Public_holidays_in_Lithuania
https://e-seimas.lrs.lt/portal/legalAct/lt/TAD/10c6bfd07bd511e6a0f68fd135e6f40c/asr
