### PR TITLE
fix(ireland): Easter Sunday is not an official holiday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ changes.
 - For the Czech Republic, Christmas Eve is considered an official holiday. [\#366](https://github.com/azuyalabs/yasumi/pull/366) ([c960657](https://github.com/c960657))
 - For Mexico, several holidays are not considered official holidays. [\#362](https://github.com/azuyalabs/yasumi/pull/362) ([c960657](https://github.com/c960657))
 - For Portual, Corpus Christi is considered an official holiday. [\#363](https://github.com/azuyalabs/yasumi/pull/363) ([c960657](https://github.com/c960657))
+- For Ireland, Easter Sunday is not an official holiday. [\#373](https://github.com/azuyalabs/yasumi/pull/373) ([c960657](https://github.com/c960657))
 
 ### Fixed
 

--- a/src/Yasumi/Provider/Ireland.php
+++ b/src/Yasumi/Provider/Ireland.php
@@ -56,7 +56,7 @@ class Ireland extends AbstractProvider
 
         // Add common Christian holidays (common in Ireland)
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
-        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->easter($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
         $this->calculatePentecostMonday();

--- a/tests/Base/HolidayFiltersTest.php
+++ b/tests/Base/HolidayFiltersTest.php
@@ -41,7 +41,6 @@ class HolidayFiltersTest extends TestCase
         // Assert array definitions
         self::assertArrayHasKey('newYearsDay', $filteredHolidaysArray);
         self::assertArrayHasKey('stPatricksDay', $filteredHolidaysArray);
-        self::assertArrayHasKey('easter', $filteredHolidaysArray);
         self::assertArrayHasKey('easterMonday', $filteredHolidaysArray);
         self::assertArrayHasKey('mayDay', $filteredHolidaysArray);
         self::assertArrayHasKey('juneHoliday', $filteredHolidaysArray);
@@ -49,14 +48,14 @@ class HolidayFiltersTest extends TestCase
         self::assertArrayHasKey('octoberHoliday', $filteredHolidaysArray);
         self::assertArrayHasKey('christmasDay', $filteredHolidaysArray);
         self::assertArrayHasKey('stStephensDay', $filteredHolidaysArray);
-        self::assertArrayNotHasKey('pentecost', $filteredHolidaysArray);
-        self::assertArrayNotHasKey('pentecostMonday', $filteredHolidaysArray);
         self::assertArrayNotHasKey('goodFriday', $filteredHolidaysArray);
+        self::assertArrayNotHasKey('easter', $filteredHolidaysArray);
+        self::assertArrayNotHasKey('pentecost', $filteredHolidaysArray);
 
         // Assert number of results returned
-        self::assertCount(10, $filteredHolidays);
+        self::assertCount(9, $filteredHolidays);
         self::assertNotCount(\count($holidays), $filteredHolidays);
-        self::assertEquals(10, $filteredHolidays->count());
+        self::assertEquals(9, $filteredHolidays->count());
         self::assertNotEquals(\count($holidays), $filteredHolidays->count());
     }
 
@@ -71,22 +70,21 @@ class HolidayFiltersTest extends TestCase
         // Assert array definitions
         self::assertArrayNotHasKey('newYearsDay', $filteredHolidaysArray);
         self::assertArrayNotHasKey('stPatricksDay', $filteredHolidaysArray);
-        self::assertArrayNotHasKey('easter', $filteredHolidaysArray);
         self::assertArrayNotHasKey('easterMonday', $filteredHolidaysArray);
-        self::assertArrayNotHasKey('pentecostMonday', $filteredHolidaysArray);
         self::assertArrayNotHasKey('mayDay', $filteredHolidaysArray);
         self::assertArrayNotHasKey('juneHoliday', $filteredHolidaysArray);
         self::assertArrayNotHasKey('augustHoliday', $filteredHolidaysArray);
         self::assertArrayNotHasKey('octoberHoliday', $filteredHolidaysArray);
         self::assertArrayNotHasKey('christmasDay', $filteredHolidaysArray);
         self::assertArrayNotHasKey('stStephensDay', $filteredHolidaysArray);
+        self::assertArrayHasKey('easter', $filteredHolidaysArray);
         self::assertArrayHasKey('pentecost', $filteredHolidaysArray);
         self::assertArrayHasKey('goodFriday', $filteredHolidaysArray);
 
         // Assert number of results returned
-        self::assertCount(2, $filteredHolidays);
+        self::assertCount(3, $filteredHolidays);
         self::assertNotCount(\count($holidays), $filteredHolidays);
-        self::assertEquals(2, $filteredHolidays->count());
+        self::assertEquals(3, $filteredHolidays->count());
         self::assertNotEquals(\count($holidays), $filteredHolidays->count());
     }
 

--- a/tests/Ireland/EasterTest.php
+++ b/tests/Ireland/EasterTest.php
@@ -99,6 +99,6 @@ class EasterTest extends IrelandBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OFFICIAL);
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, $this->generateRandomYear(), Holiday::TYPE_OBSERVANCE);
     }
 }

--- a/tests/Ireland/IrelandTest.php
+++ b/tests/Ireland/IrelandTest.php
@@ -45,7 +45,7 @@ class IrelandTest extends IrelandBaseTestCase implements ProviderTestCase
      */
     public function testOfficialHolidays(): void
     {
-        $officialHolidays = ['easter', 'easterMonday', 'augustHoliday', 'christmasDay', 'stStephensDay'];
+        $officialHolidays = ['easterMonday', 'augustHoliday', 'christmasDay', 'stStephensDay'];
         if ($this->year >= 1974) {
             $officialHolidays[] = 'newYearsDay';
             $officialHolidays[] = 'juneHoliday';
@@ -75,7 +75,7 @@ class IrelandTest extends IrelandBaseTestCase implements ProviderTestCase
      */
     public function testObservedHolidays(): void
     {
-        $this->assertDefinedHolidays(['goodFriday', 'pentecost'], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+        $this->assertDefinedHolidays(['easter', 'goodFriday', 'pentecost'], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
     }
 
     /**


### PR DESCRIPTION
Easter Sunday is not mentioned as an official holiday in the Irish Organisation of Working Time Act.

Sources:
https://en.wikipedia.org/wiki/Public_holidays_in_the_Republic_of_Ireland
https://www.irishstatutebook.ie/eli/1997/act/20/schedule/2/enacted/en/html