### PR TITLE
feat(ireland): Saint Brigid's Day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ changes.
 ### Added
 - Black Consciousness Day ('Dia Nacional de Zumbi e da Consciência Negra') is public holiday in Brazil. [\#365](https://github.com/azuyalabs/yasumi/pull/365) ([c960657](https://github.com/c960657))
 - Mother's Day and Father's Day are public holidays in Lithuania. [\#370](https://github.com/azuyalabs/yasumi/pull/370) ([c960657](https://github.com/c960657))
+- Saint Brigid's Day is a public holiday in Ireland since 2023. [\#374](https://github.com/azuyalabs/yasumi/pull/374) ([c960657](https://github.com/c960657))
 
 ### Changed
 

--- a/src/Yasumi/Provider/Ireland.php
+++ b/src/Yasumi/Provider/Ireland.php
@@ -24,10 +24,10 @@ use Yasumi\SubstituteHoliday;
 /**
  * Provider for all holidays in Ireland.
  *
- * Note: All calculations are based on the schedule published in the Holidays (Employees) Act, 1973 and its amendments
- * thereafter.
+ * The public holidays of Ireland are defined in the Organisation of Working Time Act, 1993,
+ * or in statutory instruments issued pursuant on this act.
  *
- * @see: http://www.irishstatutebook.ie/eli/1973/act/25/schedule/1/enacted/en/html#sched1
+ * @see https://www.irishstatutebook.ie/eli/1997/act/20
  */
 class Ireland extends AbstractProvider
 {
@@ -53,6 +53,7 @@ class Ireland extends AbstractProvider
 
         // Add common holidays
         $this->calculateNewYearsDay();
+        $this->calculateStBrigidsDay();
 
         // Add common Christian holidays (common in Ireland)
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
@@ -80,6 +81,8 @@ class Ireland extends AbstractProvider
     {
         return [
             'https://en.wikipedia.org/wiki/Public_holidays_in_Ireland',
+            'https://www.irishstatutebook.ie/eli/1997/act/20/schedule/2/enacted/en/html',
+            'https://www.irishstatutebook.ie/eli/2022/si/50/made/en/html',
         ];
     }
 
@@ -91,7 +94,7 @@ class Ireland extends AbstractProvider
      * observed in 1974.
      *
      * @see https://www.timeanddate.com/holidays/ireland/new-year-day
-     * @see http://www.irishstatutebook.ie/eli/1974/si/341
+     * @see https://www.irishstatutebook.ie/eli/1997/act/20/schedule/2/enacted/en/html
      *
      * @TODO : Check substitution of New Years Day when it falls on a Saturday. The Holidays (Employees) Act 1973
      *       states that New Years Day is substituted the *next* day if it does not fall on a weekday. So what if it
@@ -125,12 +128,40 @@ class Ireland extends AbstractProvider
     }
 
     /**
+     * Saint Brigid's Day.
+     *
+     * Saint Brigid's Day, also known as Imbolc, is a Gaelic traditional festival. It became an official public
+     * holiday in 2023.
+     *
+     * @see https://www.irishstatutebook.ie/eli/2022/si/50/made/en/html
+     * @see https://en.wikipedia.org/wiki/Imbolc
+     */
+    protected function calculateStBrigidsDay(): void
+    {
+        if ($this->year < 2023) {
+            return;
+        }
+
+        $dateTime = new \DateTime("{$this->year}-02-01", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        if (5 !== (int) $dateTime->format('w')) {
+            $dateTime->modify('next monday');
+        }
+
+        $this->addHoliday(new Holiday(
+            'stBrigidsDay',
+            ['en' => 'Saint Brigid’s Day', 'ga' => 'Lá Fhéile Bríde'],
+            $dateTime,
+            $this->locale
+        ));
+    }
+
+    /**
      * Pentecost Monday.
      *
      * Whitmonday (Pentecost Monday) was considered a public holiday in Ireland until 1973.
      *
-     * @see http://www.irishstatutebook.ie/eli/1939/act/1/section/8/enacted/en/html
-     * @see http://www.irishstatutebook.ie/eli/1973/act/25/schedule/1/enacted/en/html#sched1
+     * @see https://www.irishstatutebook.ie/eli/1939/act/1/section/8/enacted/en/html
+     * @see https://www.irishstatutebook.ie/eli/1997/act/20/schedule/2/enacted/en/html
      *
      * @throws \InvalidArgumentException
      * @throws UnknownLocaleException
@@ -151,7 +182,7 @@ class Ireland extends AbstractProvider
      * Most people in Ireland start Christmas celebrations on Christmas Eve (Oíche Nollag), including taking time
      * off work.
      *
-     * @see http://www.irishstatutebook.ie/eli/1973/act/25/schedule/1/enacted/en/html#sched1
+     * @see https://www.irishstatutebook.ie/eli/1997/act/20/schedule/2/enacted/en/html
      *
      * @throws \InvalidArgumentException
      * @throws UnknownLocaleException
@@ -187,7 +218,7 @@ class Ireland extends AbstractProvider
      *
      * The day after Christmas celebrating the feast day of Saint Stephen.
      *
-     * @see http://www.irishstatutebook.ie/eli/1973/act/25/schedule/1/enacted/en/html#sched1
+     * @see https://www.irishstatutebook.ie/eli/1997/act/20/schedule/2/enacted/en/html
      * @see https://en.wikipedia.org/wiki/St._Stephen%27s_Day
      * @see  ChristianHolidays
      *
@@ -230,6 +261,7 @@ class Ireland extends AbstractProvider
      * Territory of Montserrat.
      *
      * @see https://en.wikipedia.org/wiki/Saint_Patrick%27s_Day
+     * @see https://www.irishstatutebook.ie/eli/1997/act/20/schedule/2/enacted/en/html
      *
      * @throws \InvalidArgumentException
      * @throws UnknownLocaleException
@@ -273,6 +305,7 @@ class Ireland extends AbstractProvider
      * and many other people in other counties still keep on this tradition.
      *
      * @see https://en.wikipedia.org/wiki/May_Day
+     * @see https://www.irishstatutebook.ie/eli/1993/si/91/made/en/html
      *
      * @throws \InvalidArgumentException
      * @throws UnknownLocaleException
@@ -323,7 +356,8 @@ class Ireland extends AbstractProvider
      *
      * The last Monday in October is considered a public holiday since 1977.
      *
-     * @see http://www.irishstatutebook.ie/eli/1973/act/25/schedule/1/enacted/en/html#sched1
+     * @see https://www.irishstatutebook.ie/eli/1977/si/193/made/en/html
+     * @see https://www.irishstatutebook.ie/eli/1997/act/20/schedule/2/enacted/en/html
      *
      * @throws \InvalidArgumentException
      * @throws UnknownLocaleException

--- a/tests/Ireland/IrelandTest.php
+++ b/tests/Ireland/IrelandTest.php
@@ -67,6 +67,10 @@ class IrelandTest extends IrelandBaseTestCase implements ProviderTestCase
             $officialHolidays[] = 'octoberHoliday';
         }
 
+        if ($this->year >= 2023) {
+            $officialHolidays[] = 'stBrigidsDay';
+        }
+
         $this->assertDefinedHolidays($officialHolidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
     }
 
@@ -108,6 +112,6 @@ class IrelandTest extends IrelandBaseTestCase implements ProviderTestCase
      */
     public function testSources(): void
     {
-        $this->assertSources(self::REGION, 1);
+        $this->assertSources(self::REGION, 3);
     }
 }

--- a/tests/Ireland/StBrigidsDayTest.php
+++ b/tests/Ireland/StBrigidsDayTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2025 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ireland;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing the Saint Brigid's Day in Ireland.
+ */
+class StBrigidsDayTest extends IrelandBaseTestCase implements HolidayTestCase
+{
+    /**
+     * The name of the holiday.
+     */
+    public const HOLIDAY = 'stBrigidsDay';
+
+    /**
+     * The year in which the holiday was first established.
+     */
+    public const ESTABLISHMENT_YEAR = 2023;
+
+    /**
+     * Tests the holiday defined in this test.
+     *
+     * @dataProvider HolidayDataProvider
+     *
+     * @param int    $year     the year for which the holiday defined in this test needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \Exception
+     */
+    public function testHoliday(int $year, string $expected): void
+    {
+        $dateTime = new \DateTime($expected, new \DateTimeZone(self::TIMEZONE));
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            $dateTime
+        );
+    }
+
+    /**
+     * Returns a list of test dates.
+     *
+     * @return array<array> list of test dates for the holiday defined in this test
+     *
+     * @throws \Exception
+     */
+    public function HolidayDataProvider(): array
+    {
+        $data = [];
+
+        for ($y = 0; $y < self::TEST_ITERATIONS; ++$y) {
+            $year = $this->generateRandomYear(self::ESTABLISHMENT_YEAR);
+            $date = new \DateTime("{$year}-02-01", new \DateTimeZone(self::TIMEZONE));
+            if ('Friday' !== $date->format('l')) {
+                $date = new \DateTime("{$year}-02-01 first monday", new \DateTimeZone(self::TIMEZONE));
+            }
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests the holiday defined in this test before establishment.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(1000, self::ESTABLISHMENT_YEAR - 1)
+        );
+    }
+
+    /**
+     * Tests the translated name of the holiday defined in this test.
+     *
+     * @throws \Exception
+     */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Saint Brigid’s Day']
+        );
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            ['ga' => 'Lá Fhéile Bríde']
+        );
+    }
+
+    /**
+     * Tests type of the holiday defined in this test.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            $this->generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}


### PR DESCRIPTION
Saint Brigid's Day has been a public holiday in Ireland since 2023.

Sources:
https://www.gov.ie/en/press-release/b926b-government-agrees-covid-recognition-payment-and-new-public-holiday/
https://www.irishstatutebook.ie/eli/2022/si/50/made/en/html
https://en.wikipedia.org/wiki/Imbolc



Also, the Holidays (Employees) Act, 1973, has been repealed and replaced by the Organisation of Working Time Act, 1993. I have updated references accordingly.

Source:
https://www.irishstatutebook.ie/eli/1997/act/20/schedule/4/enacted/en/html