### PR TITLE
fix(ireland): New Year's Day on a Saturday also gives a substitute holiday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ changes.
 - For Ireland, Easter Sunday is not an official holiday. [\#373](https://github.com/azuyalabs/yasumi/pull/373) ([c960657](https://github.com/c960657))
 
 ### Fixed
+- For Ireland, New Year's Day has same substitute holidays rules as other holidays. [\#375](https://github.com/azuyalabs/yasumi/pull/375) ([c960657](https://github.com/c960657))
 
 ### Removed
 

--- a/src/Yasumi/Provider/Ireland.php
+++ b/src/Yasumi/Provider/Ireland.php
@@ -96,10 +96,6 @@ class Ireland extends AbstractProvider
      * @see https://www.timeanddate.com/holidays/ireland/new-year-day
      * @see https://www.irishstatutebook.ie/eli/1997/act/20/schedule/2/enacted/en/html
      *
-     * @TODO : Check substitution of New Years Day when it falls on a Saturday. The Holidays (Employees) Act 1973
-     *       states that New Years Day is substituted the *next* day if it does not fall on a weekday. So what if it
-     *       falls on a Saturday?
-     *
      * @throws \InvalidArgumentException
      * @throws UnknownLocaleException
      * @throws \Exception
@@ -113,8 +109,8 @@ class Ireland extends AbstractProvider
         $holiday = $this->newYearsDay($this->year, $this->timezone, $this->locale);
         $this->addHoliday($holiday);
 
-        // Substitute holiday is on the next available weekday if a holiday falls on a Sunday.
-        if (0 === (int) $holiday->format('w')) {
+        // Substitute holiday is on the next available weekday if a holiday falls on a weekend.
+        if (\in_array((int) $holiday->format('w'), [0, 6], true)) {
             $date = clone $holiday;
             $date->modify('next monday');
 

--- a/tests/Ireland/NewYearsDayTest.php
+++ b/tests/Ireland/NewYearsDayTest.php
@@ -50,7 +50,7 @@ class NewYearsDayTest extends IrelandBaseTestCase implements HolidayTestCase
         $date = new \DateTime($expected, new \DateTimeZone(self::TIMEZONE));
         $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $date);
 
-        if (0 === (int) $date->format('w')) {
+        if (\in_array((int) $date->format('w'), [0, 6], true)) {
             $date->modify('next monday');
             $this->assertHoliday(self::REGION, 'substituteHoliday:' . self::HOLIDAY, $year, $date);
         }


### PR DESCRIPTION
A “TODO” in the Ireland provider raises doubt whether a substitute holiday is added when New Year's Day falls on a Saturday.

The holiday was established in 1973 with a statutory instrument using the following wording:
https://www.irishstatutebook.ie/eli/1974/si/341
> The first day of January if falling on a week day or, if not, the next day is hereby appointed to be a public holiday

I assume the ambiguity arises from whether Saturday is considered a weekday. However, the Holiday (Employees) Act, 1973, also uses the term “weekday”:
https://www.irishstatutebook.ie/eli/1973/act/25/schedule/enacted/en/html
>  (a) Christmas Day if falling on a weekday or, if not, the next Tuesday,
>  (b) St. Stephen's Day if falling on a weekday or, if not, the next day,
> (c) St. Patrick's Day if falling on a weekday or, if not, the next day,

So I think it is fair to conclude that New Year's Day followed in same rules as the other holidays back then.

The new Organisation of Working Time Act, 1993 appear to have changed the rules on substitute holidays. AFAICT these are no longer moved to a specific Monday but may placed elsewhere at the discretion of the employer. However, it appears that most people have a day off on the same days as with the old rules. 
https://www.irishstatutebook.ie/eli/1997/act/20/section/21/enacted/en/html

Examples:
https://www.ictu.ie/news/has-long-weekend-had-its-day-and-other-questions-about-bank-holidays-answered
https://bpfi.ie/wp-content/uploads/2022/01/Bank-Holidays-Republic-of-Ireland-2022-2024.pdf
https://constructionnews.ie/wp-content/uploads/2022/01/Builders-Holidays-2022.pdf
https://cravingcork.ie/public-holidays-ireland-2022/
https://www.fm104.ie/news/buzz/full-breakdown-bank-holidays-for-ireland-in-2022/

I guess you could argue that the substitute holidays should be marked with a different type than `TYPE_OFFICIAL`. I did not change that in this PR, though.