### PR TITLE
Fix not passing $this->locale for calculateProclamationOfRepublicDay()

### DIFF
--- a/src/Yasumi/Provider/Brazil.php
+++ b/src/Yasumi/Provider/Brazil.php
@@ -89,6 +89,7 @@ class Brazil extends AbstractProvider
                 'proclamationOfRepublicDay',
                 ['pt' => 'Dia da Proclamação da República'],
                 new \DateTime("{$this->year}-11-15", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale
             ));
         }
     }


### PR DESCRIPTION
Without this, the holiday's name won't be translated. All other calculateHoliday() methods properly provide this argument, thus being translated.

If you try this code:

```php
        $holiday = Yasumi::create(Brazil::class, 2025, 'pt_BR');
        $this->assertEquals(
            'Dia da Proclamação da República',
            $holiday->getHoliday(self::HOLIDAY)->getName()
        );
```

It'll fail.