### PR TITLE
Remove Whitsunday (pentecost) from Austria

### DIFF
--- a/src/Yasumi/Provider/Austria.php
+++ b/src/Yasumi/Provider/Austria.php
@@ -55,7 +55,6 @@ class Austria extends AbstractProvider
         $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->ascensionDay($this->year, $this->timezone, $this->locale));
-        $this->addHoliday($this->pentecost($this->year, $this->timezone, $this->locale, Holiday::TYPE_OBSERVANCE));
         $this->addHoliday($this->pentecostMonday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->corpusChristi($this->year, $this->timezone, $this->locale, Holiday::TYPE_OFFICIAL));
         $this->addHoliday($this->allSaintsDay($this->year, $this->timezone, $this->locale));


### PR DESCRIPTION
It's not a holiday:
[https://en.wikipedia.org/wiki/Public_holidays_in_Austria](https://en.wikipedia.org/wiki/Public_holidays_in_Austria)
[https://de.wikipedia.org/wiki/Feiertage_in_%C3%96sterreich](https://de.wikipedia.org/wiki/Feiertage_in_%C3%96sterreich)