### PR TITLE
Added provider for closures of New York Stock Exchange (NYSE) since 2000

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -199,5 +199,9 @@
         <testsuite name="USA">
             <directory>./tests/USA</directory>
         </testsuite>
+        <!-- Test Suite for holidays and closures of the New York Stock Exchange (NYSE) in United States -->
+        <testsuite name="NYSE">
+			<directory>./tests/USA/NYSE</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Yasumi/Provider/USA/NYSE.php
+++ b/src/Yasumi/Provider/USA/NYSE.php
@@ -25,6 +25,7 @@ namespace Yasumi\Provider\USA;
 use Yasumi\Provider\USA;
 use Yasumi\Holiday;
 use DateTime;
+use DateTimeZone;
 
 class NYSE extends USA
 {
@@ -61,31 +62,31 @@ class NYSE extends USA
 	private function addWeatherEvents()
 	{
 		if (2012 == $this->year) {
-			$this->addHoliday(new Holiday('hurricaneSandy1', [], new DateTime('2012-10-29')));
-			$this->addHoliday(new Holiday('hurricaneSandy2', [], new DateTime('2012-10-30')));
+			$this->addHoliday(new Holiday('hurricaneSandy1', [], new DateTime('2012-10-29', new DateTimeZone($this->timezone))));
+			$this->addHoliday(new Holiday('hurricaneSandy2', [], new DateTime('2012-10-30', new DateTimeZone($this->timezone))));
 		}
 	}
 
 	private function addEmergencies()
 	{
 		if (2001 == $this->year) {
-			$this->addHoliday(new Holiday('WTCAttack1', [], new DateTime('2001-09-11')));
-			$this->addHoliday(new Holiday('WTCAttack2', [], new DateTime('2001-09-12')));
-			$this->addHoliday(new Holiday('WTCAttack3', [], new DateTime('2001-09-13')));
-			$this->addHoliday(new Holiday('WTCAttack4', [], new DateTime('2001-09-14')));
+			$this->addHoliday(new Holiday('groundZero1', [], new DateTime('2001-09-11', new DateTimeZone($this->timezone))));
+			$this->addHoliday(new Holiday('groundZero2', [], new DateTime('2001-09-12', new DateTimeZone($this->timezone))));
+			$this->addHoliday(new Holiday('groundZero3', [], new DateTime('2001-09-13', new DateTimeZone($this->timezone))));
+			$this->addHoliday(new Holiday('groundZero4', [], new DateTime('2001-09-14', new DateTimeZone($this->timezone))));
 		}
 	}
 
 	private function addProclamations()
 	{
 		if (2004 == $this->year)
-			$this->addHoliday(new Holiday('ReaganMourning', [], new DateTime('2004-06-11')));
+			$this->addHoliday(new Holiday('ReaganMourning', [], new DateTime('2004-06-11', new DateTimeZone($this->timezone))));
 		if (2007 == $this->year)
-			$this->addHoliday(new Holiday('GRFordMourning', [], new DateTime('2007-01-02')));
+			$this->addHoliday(new Holiday('GRFordMourning', [], new DateTime('2007-01-02', new DateTimeZone($this->timezone))));
 		if (2018 == $this->year)
-			$this->addHoliday(new Holiday('HWBushMourning', [], new DateTime('2018-12-05')));
+			$this->addHoliday(new Holiday('HWBushMourning', [], new DateTime('2018-12-05', new DateTimeZone($this->timezone))));
 		if (2025 == $this->year)
-			$this->addHoliday(new Holiday('CarterMourning', [], new DateTime('2025-01-09')));
+			$this->addHoliday(new Holiday('CarterMourning', [], new DateTime('2025-01-09', new DateTimeZone($this->timezone))));
 	}
 
     public function getSources(): array

--- a/src/Yasumi/Provider/USA/NYSE.php
+++ b/src/Yasumi/Provider/USA/NYSE.php
@@ -7,26 +7,27 @@ declare(strict_types = 1);
  *
  * The easy PHP Library for calculating holidays.
  *
- * Copyright (c) 2025 Magic Web Group 
+ * Copyright (c) 2015 - 2025 AzuyaLabs
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Art Kurbakov <admin at mgwebgroup dot com>
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
-
-// This file in addition to regular holidays observed by US stock exchanges, 
-// includes full day special closure events due to:
-// weather, national emergencies and presidential proclamations.
-// All closure events are included from year 2000.
 
 namespace Yasumi\Provider\USA;
 
-use Yasumi\Provider\USA;
 use Yasumi\Holiday;
-use DateTime;
-use DateTimeZone;
+use Yasumi\Provider\USA;
 
+/**
+ * Class NYSE in addition to regular holidays observed by the New York Stock
+ * Exchange (NYSE), includes full day special closure events due to:
+ * weather, national emergencies and presidential proclamations.
+ * All trading closure events are included from year 2000.
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
+ */
 class NYSE extends USA
 {
     /**
@@ -36,28 +37,40 @@ class NYSE extends USA
      */
     public function initialize(): void
     {
-		$this->timezone = 'America/New_York';
+        $this->timezone = 'America/New_York';
 
-		// Add exhange-specific holidays
+        // Add exhange-specific holidays
         $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
         $this->calculateMartinLutherKingday();
         $this->calculateWashingtonsBirthday();
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
         $this->calculateMemorialDay();
-		if (2021 < $this->year)
-			$this->calculateJuneteenth();
+        if (2021 < $this->year) {
+            $this->calculateJuneteenth();
+        }
         $this->calculateIndependenceDay();
         $this->calculateLabourDay();
         $this->calculateThanksgivingDay();
         $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
 
         $this->calculateSubstituteHolidays();
-		
-		// Add other full-day closure events
-		$this->addWeatherEvents();
-		$this->addEmergencies();
-		$this->addProclamations();
-	}
+
+        // Add other full-day closure events
+        $this->addWeatherEvents();
+        $this->addEmergencies();
+        $this->addProclamations();
+    }
+
+    public function getSources(): array
+    {
+        return [
+            'https://www.nyse.com/trader-update/history#11507',
+            'https://s3.amazonaws.com/armstrongeconomics-wp/2013/07/NYSE-Closings.pdf',
+            'https://ir.theice.com/press/news-details/2018/New-York-Stock-Exchange-to-Honor-President-George-H-W-Bush/default.aspx',
+            'https://ir.theice.com/press/news-details/2024/The-New-York-Stock-Exchange-Will-Close-Markets-on-January-9-to-Honor-the-Passing-of-Former-President-Jimmy-Carter-on-National-Day-of-Mourning/default.aspx',
+            'https://www.thecorporatecounsel.net/blog/2021/10/nyse-makes-juneteenth-a-new-market-holiday.html',
+        ];
+    }
 
     private function addWeatherEvents(): void
     {
@@ -92,16 +105,4 @@ class NYSE extends USA
             $this->addHoliday(new Holiday('CarterMourning', [], new \DateTime('2025-01-09', new \DateTimeZone($this->timezone))));
         }
     }
-
-    public function getSources(): array
-    {
-        return [
-			'https://www.nyse.com/trader-update/history#11507',
-			'https://s3.amazonaws.com/armstrongeconomics-wp/2013/07/NYSE-Closings.pdf',
-			'https://ir.theice.com/press/news-details/2018/New-York-Stock-Exchange-to-Honor-President-George-H-W-Bush/default.aspx',
-			'https://ir.theice.com/press/news-details/2024/The-New-York-Stock-Exchange-Will-Close-Markets-on-January-9-to-Honor-the-Passing-of-Former-President-Jimmy-Carter-on-National-Day-of-Mourning/default.aspx',
-			'https://www.thecorporatecounsel.net/blog/2021/10/nyse-makes-juneteenth-a-new-market-holiday.html',
-        ];
-    }
 }
-

--- a/src/Yasumi/Provider/USA/NYSE.php
+++ b/src/Yasumi/Provider/USA/NYSE.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2025 Magic Web Group 
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
+ */
+
+// This file in addition to regular holidays observed by US stock exchanges, 
+// includes full day special closure events due to:
+// weather, national emergencies and presidential proclamations.
+// All closure events are included from year 2000.
+
+require 'vendor/autoload.php';
+
+class NYSE extends Yasumi\Provider\USA
+{
+    /**
+     * Initialize holidays for the NYSE.
+     *
+     * @throws Exception
+     */
+    public function initialize(): void
+    {
+        parent::initialize();
+
+		// Add exhange-specific holidays
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
+		
+		// Remove exchange-specific holidays
+        $this->removeHoliday('columbusDay');
+        $this->removeHoliday('veteransDay');
+		$this->holidaysCalculator->removeHoliday('substituteHoliday:veteransDay');
+		if (2022 < $this->year)
+			$this->removeHoliday('juneteenth');
+
+		// Add other full-day closure events
+		$this->addWeatherEvents();
+		$this->addEmergencies();
+		$this->addProclamations();
+	}
+
+	private function addWeatherEvents()
+	{
+		if (2012 == $this->year) {
+			$this->holidaysCalculator->addHoliday(new Holiday('HurricaneSandy1', [], new DateTime('2012-10-29')));
+			$this->holidaysCalculator->addHoliday(new Holiday('HurricaneSandy2', [], new DateTime('2012-10-30')));
+		}
+	}
+
+	private function addEmergencies()
+	{
+		if (2001 == $this->year) {
+			$this->holidaysCalculator->addHoliday(new Holiday('WTCAttack1', [], new DateTime('2001-09-11')));
+			$this->holidaysCalculator->addHoliday(new Holiday('WTCAttack2', [], new DateTime('2001-09-12')));
+			$this->holidaysCalculator->addHoliday(new Holiday('WTCAttack3', [], new DateTime('2001-09-13')));
+			$this->holidaysCalculator->addHoliday(new Holiday('WTCAttack4', [], new DateTime('2001-09-14')));
+		}
+	}
+
+	private function addProclamations()
+	{
+		if (2004 == $this->year)
+			$this->holidaysCalculator->addHoliday(new Holiday('ReaganMourning', [], new DateTime('2004-06-11')));
+		if (2007 == $this->year)
+			$this->holidaysCalculator->addHoliday(new Holiday('GRFordMourning', [], new DateTime('2007-01-02')));
+		if (2018 == $this->year)
+			$this->holidaysCalculator->addHoliday(new Holiday('HWBushMourning', [], new DateTime('2018-12-05')));
+		if (2025 == $this->year)
+			$this->holidaysCalculator->addHoliday(new Holiday('CarterMourning', [], new DateTime('2025-01-09')));
+	}
+
+    public function getSources(): array
+    {
+        return [
+			'https://www.nyse.com/trader-update/history#11507',
+			'https://s3.amazonaws.com/armstrongeconomics-wp/2013/07/NYSE-Closings.pdf',
+			'https://ir.theice.com/press/news-details/2018/New-York-Stock-Exchange-to-Honor-President-George-H-W-Bush/default.aspx',
+			'https://ir.theice.com/press/news-details/2024/The-New-York-Stock-Exchange-Will-Close-Markets-on-January-9-to-Honor-the-Passing-of-Former-President-Jimmy-Carter-on-National-Day-of-Mourning/default.aspx',
+			'https://www.thecorporatecounsel.net/blog/2021/10/nyse-makes-juneteenth-a-new-market-holiday.html',
+        ];
+    }
+
+
+}
+

--- a/src/Yasumi/Provider/USA/NYSE.php
+++ b/src/Yasumi/Provider/USA/NYSE.php
@@ -31,6 +31,12 @@ use Yasumi\Provider\USA;
 class NYSE extends USA
 {
     /**
+     * Code to identify this Holiday Provider. Typically, this is the ISO3166 code corresponding to the respective
+     * country or sub-region.
+     */
+    public const ID = 'US-NYSE';
+
+    /**
      * Initialize holidays for the NYSE.
      *
      * @throws \Exception

--- a/src/Yasumi/Provider/USA/NYSE.php
+++ b/src/Yasumi/Provider/USA/NYSE.php
@@ -32,7 +32,7 @@ class NYSE extends USA
     /**
      * Initialize holidays for the NYSE.
      *
-     * @throws Exception
+     * @throws \Exception
      */
     public function initialize(): void
     {
@@ -59,35 +59,39 @@ class NYSE extends USA
 		$this->addProclamations();
 	}
 
-	private function addWeatherEvents()
-	{
-		if (2012 == $this->year) {
-			$this->addHoliday(new Holiday('hurricaneSandy1', [], new DateTime('2012-10-29', new DateTimeZone($this->timezone))));
-			$this->addHoliday(new Holiday('hurricaneSandy2', [], new DateTime('2012-10-30', new DateTimeZone($this->timezone))));
-		}
-	}
+    private function addWeatherEvents(): void
+    {
+        if (2012 == $this->year) {
+            $this->addHoliday(new Holiday('hurricaneSandy1', [], new \DateTime('2012-10-29', new \DateTimeZone($this->timezone))));
+            $this->addHoliday(new Holiday('hurricaneSandy2', [], new \DateTime('2012-10-30', new \DateTimeZone($this->timezone))));
+        }
+    }
 
-	private function addEmergencies()
-	{
-		if (2001 == $this->year) {
-			$this->addHoliday(new Holiday('groundZero1', [], new DateTime('2001-09-11', new DateTimeZone($this->timezone))));
-			$this->addHoliday(new Holiday('groundZero2', [], new DateTime('2001-09-12', new DateTimeZone($this->timezone))));
-			$this->addHoliday(new Holiday('groundZero3', [], new DateTime('2001-09-13', new DateTimeZone($this->timezone))));
-			$this->addHoliday(new Holiday('groundZero4', [], new DateTime('2001-09-14', new DateTimeZone($this->timezone))));
-		}
-	}
+    private function addEmergencies(): void
+    {
+        if (2001 == $this->year) {
+            $this->addHoliday(new Holiday('groundZero1', [], new \DateTime('2001-09-11', new \DateTimeZone($this->timezone))));
+            $this->addHoliday(new Holiday('groundZero2', [], new \DateTime('2001-09-12', new \DateTimeZone($this->timezone))));
+            $this->addHoliday(new Holiday('groundZero3', [], new \DateTime('2001-09-13', new \DateTimeZone($this->timezone))));
+            $this->addHoliday(new Holiday('groundZero4', [], new \DateTime('2001-09-14', new \DateTimeZone($this->timezone))));
+        }
+    }
 
-	private function addProclamations()
-	{
-		if (2004 == $this->year)
-			$this->addHoliday(new Holiday('ReaganMourning', [], new DateTime('2004-06-11', new DateTimeZone($this->timezone))));
-		if (2007 == $this->year)
-			$this->addHoliday(new Holiday('GRFordMourning', [], new DateTime('2007-01-02', new DateTimeZone($this->timezone))));
-		if (2018 == $this->year)
-			$this->addHoliday(new Holiday('HWBushMourning', [], new DateTime('2018-12-05', new DateTimeZone($this->timezone))));
-		if (2025 == $this->year)
-			$this->addHoliday(new Holiday('CarterMourning', [], new DateTime('2025-01-09', new DateTimeZone($this->timezone))));
-	}
+    private function addProclamations(): void
+    {
+        if (2004 == $this->year) {
+            $this->addHoliday(new Holiday('ReaganMourning', [], new \DateTime('2004-06-11', new \DateTimeZone($this->timezone))));
+        }
+        if (2007 == $this->year) {
+            $this->addHoliday(new Holiday('GRFordMourning', [], new \DateTime('2007-01-02', new \DateTimeZone($this->timezone))));
+        }
+        if (2018 == $this->year) {
+            $this->addHoliday(new Holiday('HWBushMourning', [], new \DateTime('2018-12-05', new \DateTimeZone($this->timezone))));
+        }
+        if (2025 == $this->year) {
+            $this->addHoliday(new Holiday('CarterMourning', [], new \DateTime('2025-01-09', new \DateTimeZone($this->timezone))));
+        }
+    }
 
     public function getSources(): array
     {

--- a/src/Yasumi/Provider/USA/NYSE.php
+++ b/src/Yasumi/Provider/USA/NYSE.php
@@ -20,9 +20,13 @@ declare(strict_types = 1);
 // weather, national emergencies and presidential proclamations.
 // All closure events are included from year 2000.
 
-require 'vendor/autoload.php';
+namespace Yasumi\Provider\USA;
 
-class NYSE extends Yasumi\Provider\USA
+use Yasumi\Provider\USA;
+use Yasumi\Holiday;
+use DateTime;
+
+class NYSE extends USA
 {
     /**
      * Initialize holidays for the NYSE.
@@ -31,18 +35,23 @@ class NYSE extends Yasumi\Provider\USA
      */
     public function initialize(): void
     {
-        parent::initialize();
+		$this->timezone = 'America/New_York';
 
 		// Add exhange-specific holidays
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->calculateMartinLutherKingday();
+        $this->calculateWashingtonsBirthday();
         $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
-		
-		// Remove exchange-specific holidays
-        $this->removeHoliday('columbusDay');
-        $this->removeHoliday('veteransDay');
-		$this->holidaysCalculator->removeHoliday('substituteHoliday:veteransDay');
-		if (2022 < $this->year)
-			$this->removeHoliday('juneteenth');
+        $this->calculateMemorialDay();
+		if (2021 < $this->year)
+			$this->calculateJuneteenth();
+        $this->calculateIndependenceDay();
+        $this->calculateLabourDay();
+        $this->calculateThanksgivingDay();
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
 
+        $this->calculateSubstituteHolidays();
+		
 		// Add other full-day closure events
 		$this->addWeatherEvents();
 		$this->addEmergencies();
@@ -52,31 +61,31 @@ class NYSE extends Yasumi\Provider\USA
 	private function addWeatherEvents()
 	{
 		if (2012 == $this->year) {
-			$this->holidaysCalculator->addHoliday(new Holiday('HurricaneSandy1', [], new DateTime('2012-10-29')));
-			$this->holidaysCalculator->addHoliday(new Holiday('HurricaneSandy2', [], new DateTime('2012-10-30')));
+			$this->addHoliday(new Holiday('hurricaneSandy1', [], new DateTime('2012-10-29')));
+			$this->addHoliday(new Holiday('hurricaneSandy2', [], new DateTime('2012-10-30')));
 		}
 	}
 
 	private function addEmergencies()
 	{
 		if (2001 == $this->year) {
-			$this->holidaysCalculator->addHoliday(new Holiday('WTCAttack1', [], new DateTime('2001-09-11')));
-			$this->holidaysCalculator->addHoliday(new Holiday('WTCAttack2', [], new DateTime('2001-09-12')));
-			$this->holidaysCalculator->addHoliday(new Holiday('WTCAttack3', [], new DateTime('2001-09-13')));
-			$this->holidaysCalculator->addHoliday(new Holiday('WTCAttack4', [], new DateTime('2001-09-14')));
+			$this->addHoliday(new Holiday('WTCAttack1', [], new DateTime('2001-09-11')));
+			$this->addHoliday(new Holiday('WTCAttack2', [], new DateTime('2001-09-12')));
+			$this->addHoliday(new Holiday('WTCAttack3', [], new DateTime('2001-09-13')));
+			$this->addHoliday(new Holiday('WTCAttack4', [], new DateTime('2001-09-14')));
 		}
 	}
 
 	private function addProclamations()
 	{
 		if (2004 == $this->year)
-			$this->holidaysCalculator->addHoliday(new Holiday('ReaganMourning', [], new DateTime('2004-06-11')));
+			$this->addHoliday(new Holiday('ReaganMourning', [], new DateTime('2004-06-11')));
 		if (2007 == $this->year)
-			$this->holidaysCalculator->addHoliday(new Holiday('GRFordMourning', [], new DateTime('2007-01-02')));
+			$this->addHoliday(new Holiday('GRFordMourning', [], new DateTime('2007-01-02')));
 		if (2018 == $this->year)
-			$this->holidaysCalculator->addHoliday(new Holiday('HWBushMourning', [], new DateTime('2018-12-05')));
+			$this->addHoliday(new Holiday('HWBushMourning', [], new DateTime('2018-12-05')));
 		if (2025 == $this->year)
-			$this->holidaysCalculator->addHoliday(new Holiday('CarterMourning', [], new DateTime('2025-01-09')));
+			$this->addHoliday(new Holiday('CarterMourning', [], new DateTime('2025-01-09')));
 	}
 
     public function getSources(): array
@@ -89,7 +98,5 @@ class NYSE extends Yasumi\Provider\USA
 			'https://www.thecorporatecounsel.net/blog/2021/10/nyse-makes-juneteenth-a-new-market-holiday.html',
         ];
     }
-
-
 }
 

--- a/tests/USA/NYSE/CarterMourningTest.php
+++ b/tests/USA/NYSE/CarterMourningTest.php
@@ -7,24 +7,22 @@ declare(strict_types = 1);
  *
  * The easy PHP Library for calculating holidays.
  *
- * Copyright (c) 2025 Magic Web Group
+ * Copyright (c) 2015 - 2025 AzuyaLabs
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Art Kurbakov <admin at mgwebgroup dot com>
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
 namespace Yasumi\tests\USA\NYSE;
 
-use Yasumi\Holiday;
-use Yasumi\tests\HolidayTestCase;
 use Yasumi\tests\USA\USABaseTestCase;
-use DateTime;
-use DateTimeZone;
 
 /**
  * Class to test day of closure of NYSE due to Jimmy Carter mourning proclamation
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
  */
 class CarterMourningTest extends USABaseTestCase
 {
@@ -49,7 +47,7 @@ class CarterMourningTest extends USABaseTestCase
             self::REGION,
             'CarterMourning',
             self::OBSERVED_YEAR,
-            new DateTime("2025-01-09", new DateTimeZone(self::TIMEZONE))
+            new \DateTime('2025-01-09', new \DateTimeZone(self::TIMEZONE))
         );
     }
 
@@ -61,7 +59,7 @@ class CarterMourningTest extends USABaseTestCase
     public function testCarterMourningBefore2025(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'CarterMourning',
             self::OBSERVED_YEAR - 1
         );
@@ -75,7 +73,7 @@ class CarterMourningTest extends USABaseTestCase
     public function testCarterMourningAfter2025(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'CarterMourning',
             self::OBSERVED_YEAR + 1
         );

--- a/tests/USA/NYSE/CarterMourningTest.php
+++ b/tests/USA/NYSE/CarterMourningTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2025 Magic Web Group
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
+ */
+
+namespace Yasumi\tests\USA\NYSE;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\tests\USA\USABaseTestCase;
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Class to test day of closure of NYSE due to Jimmy Carter mourning proclamation
+ */
+class CarterMourningTest extends USABaseTestCase
+{
+    /**
+     * Name of provider to be tested.
+     */
+    public const REGION = 'USA/NYSE';
+
+    /**
+     * The year when the closure was observed.
+     */
+    public const OBSERVED_YEAR = 2025;
+
+    /**
+     * Tests day of closure on January 9th 2025
+     *
+     * @throws \Exception
+     */
+    public function testCarterMourning(): void
+    {
+        $this->assertHoliday(
+            self::REGION,
+            'CarterMourning',
+            self::OBSERVED_YEAR,
+            new DateTime("2025-01-09", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests years before 2025
+     *
+     * @throws \Exception
+     */
+    public function testCarterMourningBefore2025(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'CarterMourning',
+            self::OBSERVED_YEAR - 1
+        );
+    }
+
+    /**
+     * Tests years after 2025
+     *
+     * @throws \Exception
+     */
+    public function testCarterMourningAfter2025(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'CarterMourning',
+            self::OBSERVED_YEAR + 1
+        );
+    }
+}

--- a/tests/USA/NYSE/GRFordMourningTest.php
+++ b/tests/USA/NYSE/GRFordMourningTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2025 Magic Web Group
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
+ */
+
+namespace Yasumi\tests\USA\NYSE;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\tests\USA\USABaseTestCase;
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Class to test day of closure of NYSE due to G.R. Ford Mourning proclamation
+ */
+class GRFordMourningTest extends USABaseTestCase
+{
+    /**
+     * Name of provider to be tested.
+     */
+    public const REGION = 'USA/NYSE';
+
+    /**
+     * The year when the closure was observed.
+     */
+    public const OBSERVED_YEAR = 2007;
+
+    /**
+     * Tests day of closure on January 2nd 2007
+     *
+     * @throws \Exception
+     */
+    public function testGRFordMourning(): void
+    {
+        $this->assertHoliday(
+            self::REGION,
+            'GRFordMourning',
+            self::OBSERVED_YEAR,
+            new DateTime("2007-01-02", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests years before 2007
+     *
+     * @throws \Exception
+     */
+    public function testGRFordMourningBefore2007(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'GRFordMourning',
+            self::OBSERVED_YEAR - 1
+        );
+    }
+
+    /**
+     * Tests years after 2007
+     *
+     * @throws \Exception
+     */
+    public function testGRFordMourningAfter2007(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'GRFordMourning',
+            self::OBSERVED_YEAR + 1
+        );
+    }
+}

--- a/tests/USA/NYSE/GRFordMourningTest.php
+++ b/tests/USA/NYSE/GRFordMourningTest.php
@@ -7,24 +7,22 @@ declare(strict_types = 1);
  *
  * The easy PHP Library for calculating holidays.
  *
- * Copyright (c) 2025 Magic Web Group
+ * Copyright (c) 2015 - 2025 AzuyaLabs
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Art Kurbakov <admin at mgwebgroup dot com>
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
 namespace Yasumi\tests\USA\NYSE;
 
-use Yasumi\Holiday;
-use Yasumi\tests\HolidayTestCase;
 use Yasumi\tests\USA\USABaseTestCase;
-use DateTime;
-use DateTimeZone;
 
 /**
  * Class to test day of closure of NYSE due to G.R. Ford Mourning proclamation
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
  */
 class GRFordMourningTest extends USABaseTestCase
 {
@@ -49,7 +47,7 @@ class GRFordMourningTest extends USABaseTestCase
             self::REGION,
             'GRFordMourning',
             self::OBSERVED_YEAR,
-            new DateTime("2007-01-02", new DateTimeZone(self::TIMEZONE))
+            new \DateTime('2007-01-02', new \DateTimeZone(self::TIMEZONE))
         );
     }
 
@@ -61,7 +59,7 @@ class GRFordMourningTest extends USABaseTestCase
     public function testGRFordMourningBefore2007(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'GRFordMourning',
             self::OBSERVED_YEAR - 1
         );
@@ -75,7 +73,7 @@ class GRFordMourningTest extends USABaseTestCase
     public function testGRFordMourningAfter2007(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'GRFordMourning',
             self::OBSERVED_YEAR + 1
         );

--- a/tests/USA/NYSE/GroundZeroTest.php
+++ b/tests/USA/NYSE/GroundZeroTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2025 Magic Web Group
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
+ */
+
+namespace Yasumi\tests\USA\NYSE;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\tests\USA\USABaseTestCase;
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Class to test 4 days of closure of NYSE due to September 11th attacks
+ */
+class GroundZeroTest extends USABaseTestCase
+{
+    /**
+     * Name of provider to be tested.
+     */
+    public const REGION = 'USA/NYSE';
+
+    /**
+     * The year when the closure was observed.
+     */
+    public const OBSERVED_YEAR = 2001;
+
+    /**
+     * Tests 4 days of closure on September 11th 2001
+     *
+     * @throws \Exception
+     */
+    public function testGroundZero(): void
+    {
+        $this->assertHoliday(
+            self::REGION,
+            'groundZero1',
+            self::OBSERVED_YEAR,
+            new DateTime("2001-09-11", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            'groundZero2',
+            self::OBSERVED_YEAR,
+            new DateTime("2001-09-12", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            'groundZero3',
+            self::OBSERVED_YEAR,
+            new DateTime("2001-09-13", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            'groundZero4',
+            self::OBSERVED_YEAR,
+            new DateTime("2001-09-14", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests years before 2001  
+     *
+     * @throws \Exception
+     */
+    public function testGroundZeroBefore2001(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'groundZero1',
+            self::OBSERVED_YEAR - 1
+        );
+
+        $this->assertNotHoliday(
+           	self::REGION,
+            'groundZero2',
+            self::OBSERVED_YEAR - 1
+        );
+
+        $this->assertNotHoliday(
+           	self::REGION,
+            'groundZero3',
+            self::OBSERVED_YEAR - 1
+        );
+
+        $this->assertNotHoliday(
+           	self::REGION,
+            'groundZero4',
+            self::OBSERVED_YEAR - 1
+        );
+    }
+
+    /**
+     * Tests years after 2001  
+     *
+     * @throws \Exception
+     */
+    public function testGroundZeroAfter2001(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'groundZero1',
+            self::OBSERVED_YEAR + 1
+        );
+
+        $this->assertNotHoliday(
+           	self::REGION,
+            'groundZero2',
+            self::OBSERVED_YEAR + 1
+        );
+
+        $this->assertNotHoliday(
+           	self::REGION,
+            'groundZero3',
+            self::OBSERVED_YEAR + 1
+        );
+
+        $this->assertNotHoliday(
+           	self::REGION,
+            'groundZero4',
+            self::OBSERVED_YEAR + 1
+        );
+    }
+}

--- a/tests/USA/NYSE/GroundZeroTest.php
+++ b/tests/USA/NYSE/GroundZeroTest.php
@@ -7,24 +7,22 @@ declare(strict_types = 1);
  *
  * The easy PHP Library for calculating holidays.
  *
- * Copyright (c) 2025 Magic Web Group
+ * Copyright (c) 2015 - 2025 AzuyaLabs
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Art Kurbakov <admin at mgwebgroup dot com>
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
 namespace Yasumi\tests\USA\NYSE;
 
-use Yasumi\Holiday;
-use Yasumi\tests\HolidayTestCase;
 use Yasumi\tests\USA\USABaseTestCase;
-use DateTime;
-use DateTimeZone;
 
 /**
  * Class to test 4 days of closure of NYSE due to September 11th attacks
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
  */
 class GroundZeroTest extends USABaseTestCase
 {
@@ -49,90 +47,90 @@ class GroundZeroTest extends USABaseTestCase
             self::REGION,
             'groundZero1',
             self::OBSERVED_YEAR,
-            new DateTime("2001-09-11", new DateTimeZone(self::TIMEZONE))
+            new \DateTime('2001-09-11', new \DateTimeZone(self::TIMEZONE))
         );
 
         $this->assertHoliday(
             self::REGION,
             'groundZero2',
             self::OBSERVED_YEAR,
-            new DateTime("2001-09-12", new DateTimeZone(self::TIMEZONE))
+            new \DateTime('2001-09-12', new \DateTimeZone(self::TIMEZONE))
         );
 
         $this->assertHoliday(
             self::REGION,
             'groundZero3',
             self::OBSERVED_YEAR,
-            new DateTime("2001-09-13", new DateTimeZone(self::TIMEZONE))
+            new \DateTime('2001-09-13', new \DateTimeZone(self::TIMEZONE))
         );
 
         $this->assertHoliday(
             self::REGION,
             'groundZero4',
             self::OBSERVED_YEAR,
-            new DateTime("2001-09-14", new DateTimeZone(self::TIMEZONE))
+            new \DateTime('2001-09-14', new \DateTimeZone(self::TIMEZONE))
         );
     }
 
     /**
-     * Tests years before 2001  
+     * Tests years before 2001
      *
      * @throws \Exception
      */
     public function testGroundZeroBefore2001(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'groundZero1',
             self::OBSERVED_YEAR - 1
         );
 
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'groundZero2',
             self::OBSERVED_YEAR - 1
         );
 
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'groundZero3',
             self::OBSERVED_YEAR - 1
         );
 
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'groundZero4',
             self::OBSERVED_YEAR - 1
         );
     }
 
     /**
-     * Tests years after 2001  
+     * Tests years after 2001
      *
      * @throws \Exception
      */
     public function testGroundZeroAfter2001(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'groundZero1',
             self::OBSERVED_YEAR + 1
         );
 
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'groundZero2',
             self::OBSERVED_YEAR + 1
         );
 
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'groundZero3',
             self::OBSERVED_YEAR + 1
         );
 
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'groundZero4',
             self::OBSERVED_YEAR + 1
         );

--- a/tests/USA/NYSE/HWBushMourningTest.php
+++ b/tests/USA/NYSE/HWBushMourningTest.php
@@ -7,24 +7,22 @@ declare(strict_types = 1);
  *
  * The easy PHP Library for calculating holidays.
  *
- * Copyright (c) 2025 Magic Web Group
+ * Copyright (c) 2015 - 2025 AzuyaLabs
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Art Kurbakov <admin at mgwebgroup dot com>
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
 namespace Yasumi\tests\USA\NYSE;
 
-use Yasumi\Holiday;
-use Yasumi\tests\HolidayTestCase;
 use Yasumi\tests\USA\USABaseTestCase;
-use DateTime;
-use DateTimeZone;
 
 /**
  * Class to test day of closure of NYSE due to H.W. Bush Mourning proclamation
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
  */
 class HWBushMourningTest extends USABaseTestCase
 {
@@ -49,7 +47,7 @@ class HWBushMourningTest extends USABaseTestCase
             self::REGION,
             'HWBushMourning',
             self::OBSERVED_YEAR,
-            new DateTime("2018-12-05", new DateTimeZone(self::TIMEZONE))
+            new \DateTime('2018-12-05', new \DateTimeZone(self::TIMEZONE))
         );
     }
 
@@ -61,7 +59,7 @@ class HWBushMourningTest extends USABaseTestCase
     public function testHWBushMourningBefore2018(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'HWBushMourning',
             self::OBSERVED_YEAR - 1
         );
@@ -75,7 +73,7 @@ class HWBushMourningTest extends USABaseTestCase
     public function testHWBushMourningAfter2018(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'HWBushMourning',
             self::OBSERVED_YEAR + 1
         );

--- a/tests/USA/NYSE/HWBushMourningTest.php
+++ b/tests/USA/NYSE/HWBushMourningTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2025 Magic Web Group
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
+ */
+
+namespace Yasumi\tests\USA\NYSE;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\tests\USA\USABaseTestCase;
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Class to test day of closure of NYSE due to H.W. Bush Mourning proclamation
+ */
+class HWBushMourningTest extends USABaseTestCase
+{
+    /**
+     * Name of provider to be tested.
+     */
+    public const REGION = 'USA/NYSE';
+
+    /**
+     * The year when the closure was observed.
+     */
+    public const OBSERVED_YEAR = 2018;
+
+    /**
+     * Tests day of closure on December 5th 2018
+     *
+     * @throws \Exception
+     */
+    public function testHWBushMourning(): void
+    {
+        $this->assertHoliday(
+            self::REGION,
+            'HWBushMourning',
+            self::OBSERVED_YEAR,
+            new DateTime("2018-12-05", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests years before 2018
+     *
+     * @throws \Exception
+     */
+    public function testHWBushMourningBefore2018(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'HWBushMourning',
+            self::OBSERVED_YEAR - 1
+        );
+    }
+
+    /**
+     * Tests years after 2018
+     *
+     * @throws \Exception
+     */
+    public function testHWBushMourningAfter2018(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'HWBushMourning',
+            self::OBSERVED_YEAR + 1
+        );
+    }
+}

--- a/tests/USA/NYSE/HurricaneSandyTest.php
+++ b/tests/USA/NYSE/HurricaneSandyTest.php
@@ -7,24 +7,22 @@ declare(strict_types = 1);
  *
  * The easy PHP Library for calculating holidays.
  *
- * Copyright (c) 2025 Magic Web Group
+ * Copyright (c) 2015 - 2025 AzuyaLabs
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Art Kurbakov <admin at mgwebgroup dot com>
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
 namespace Yasumi\tests\USA\NYSE;
 
-use Yasumi\Holiday;
-use Yasumi\tests\HolidayTestCase;
 use Yasumi\tests\USA\USABaseTestCase;
-use DateTime;
-use DateTimeZone;
 
 /**
  * Class to test 2 days of closure of NYSE due to Hurricane Sandy
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
  */
 class HurricaneSandyTest extends USABaseTestCase
 {
@@ -49,52 +47,52 @@ class HurricaneSandyTest extends USABaseTestCase
             self::REGION,
             'hurricaneSandy1',
             self::OBSERVED_YEAR,
-            new DateTime("2012-10-29", new DateTimeZone(self::TIMEZONE))
+            new \DateTime('2012-10-29', new \DateTimeZone(self::TIMEZONE))
         );
 
         $this->assertHoliday(
             self::REGION,
             'hurricaneSandy2',
             self::OBSERVED_YEAR,
-            new DateTime("2012-10-30", new DateTimeZone(self::TIMEZONE))
+            new \DateTime('2012-10-30', new \DateTimeZone(self::TIMEZONE))
         );
     }
 
     /**
-     * Tests years before 2012  
+     * Tests years before 2012
      *
      * @throws \Exception
      */
     public function testHurricaneSandyBefore2012(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'hurricaneSandy1',
             self::OBSERVED_YEAR - 1
         );
 
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'hurricaneSandy2',
             self::OBSERVED_YEAR - 1
         );
     }
 
     /**
-     * Tests years after 2012  
+     * Tests years after 2012
      *
      * @throws \Exception
      */
     public function testHurricaneSandyAfter2012(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'hurricaneSandy1',
             self::OBSERVED_YEAR + 1
         );
 
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'hurricaneSandy2',
             self::OBSERVED_YEAR + 1
         );

--- a/tests/USA/NYSE/HurricaneSandyTest.php
+++ b/tests/USA/NYSE/HurricaneSandyTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2025 Magic Web Group
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
+ */
+
+namespace Yasumi\tests\USA\NYSE;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\tests\USA\USABaseTestCase;
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Class to test 2 days of closure of NYSE due to Hurricane Sandy
+ */
+class HurricaneSandyTest extends USABaseTestCase
+{
+    /**
+     * Name of provider to be tested.
+     */
+    public const REGION = 'USA/NYSE';
+
+    /**
+     * The year when the closure was observed.
+     */
+    public const OBSERVED_YEAR = 2012;
+
+    /**
+     * Tests both days of closure of October 29-30th, 2012
+     *
+     * @throws \Exception
+     */
+    public function testHurricaneSandyDays(): void
+    {
+        $this->assertHoliday(
+            self::REGION,
+            'hurricaneSandy1',
+            self::OBSERVED_YEAR,
+            new DateTime("2012-10-29", new DateTimeZone(self::TIMEZONE))
+        );
+
+        $this->assertHoliday(
+            self::REGION,
+            'hurricaneSandy2',
+            self::OBSERVED_YEAR,
+            new DateTime("2012-10-30", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests years before 2012  
+     *
+     * @throws \Exception
+     */
+    public function testHurricaneSandyBefore2012(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'hurricaneSandy1',
+            self::OBSERVED_YEAR - 1
+        );
+
+        $this->assertNotHoliday(
+           	self::REGION,
+            'hurricaneSandy2',
+            self::OBSERVED_YEAR - 1
+        );
+    }
+
+    /**
+     * Tests years after 2012  
+     *
+     * @throws \Exception
+     */
+    public function testHurricaneSandyAfter2012(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'hurricaneSandy1',
+            self::OBSERVED_YEAR + 1
+        );
+
+        $this->assertNotHoliday(
+           	self::REGION,
+            'hurricaneSandy2',
+            self::OBSERVED_YEAR + 1
+        );
+    }
+}

--- a/tests/USA/NYSE/JuneteenthTest.php
+++ b/tests/USA/NYSE/JuneteenthTest.php
@@ -7,22 +7,23 @@ declare(strict_types = 1);
  *
  * The easy PHP Library for calculating holidays.
  *
- * Copyright (c) 2025 Magic Web Group
+ * Copyright (c) 2015 - 2025 AzuyaLabs
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Art Kurbakov <admin at mgwebgroup dot com>
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
 namespace Yasumi\tests\USA\NYSE;
 
 use Yasumi\Holiday;
-use Yasumi\tests\HolidayTestCase;
 use Yasumi\tests\USA\USABaseTestCase;
 
 /**
- * Class to test Juneteenth.
+ * Class to test Juneteenth holiday
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
  */
 class JuneteenthTest extends USABaseTestCase
 {
@@ -97,7 +98,7 @@ class JuneteenthTest extends USABaseTestCase
     public function testJuneteenthBefore2022(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             self::HOLIDAY,
             self::ESTABLISHMENT_YEAR - 1
         );

--- a/tests/USA/NYSE/JuneteenthTest.php
+++ b/tests/USA/NYSE/JuneteenthTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2025 Magic Web Group
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
+ */
+
+namespace Yasumi\tests\USA\NYSE;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\tests\USA\USABaseTestCase;
+
+/**
+ * Class to test Juneteenth.
+ */
+class JuneteenthTest extends USABaseTestCase
+{
+    /**
+     * Country (name) to be tested.
+     */
+    public const REGION = 'USA/NYSE';
+
+    /**
+     * The name of the holiday.
+     */
+    public const HOLIDAY = 'juneteenth';
+
+    /**
+     * The year in which the holiday was first established for NYSE.
+     */
+    public const ESTABLISHMENT_YEAR = 2022;
+
+    /**
+     * Tests Juneteenth on or after 2022. For NYSE Juneteenth is celebrated since 2022 on June 19th.
+     *
+     * @throws \Exception
+     */
+    public function testJuneteenthOnAfter2022(): void
+    {
+        $year = 2023;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-6-19", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests Juneteenth on or after 2022 when substituted on Monday (when Juneteenth falls on Sunday).
+     *
+     * @throws \Exception
+     */
+    public function testJuneteenthOnAfter2022SubstitutedMonday(): void
+    {
+        $year = 2022;
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-6-20", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests Juneteenth on or after 2022 when substituted on Friday (when Juneteenth falls on Saturday).
+     *
+     * @throws \Exception
+     */
+    public function testJuneteenthOnAfter2022SubstitutedFriday(): void
+    {
+        $year = 2027;
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-6-18", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests Juneteenth before 2022. For NYSE Juneteenth is celebrated since 2022 on June 19th.
+     *
+     * @throws \Exception
+     */
+    public function testJuneteenthBefore2022(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            self::HOLIDAY,
+            self::ESTABLISHMENT_YEAR - 1
+        );
+    }
+}

--- a/tests/USA/NYSE/NYSETest.php
+++ b/tests/USA/NYSE/NYSETest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2025 Magic Web Group
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
+ */
+
+namespace Yasumi\tests\USA\NYSE;
+
+use Yasumi\Holiday;
+use Yasumi\tests\ProviderTestCase;
+use Yasumi\tests\USA\USABaseTestCase;
+
+/**
+ * Class for testing closure days for NYSE
+ */
+class NYSETest extends USABaseTestCase implements ProviderTestCase
+{
+    /**
+     * Country (name) to be tested.
+     */
+    public const REGION = 'USA/NYSE';
+
+    /**
+     * @var int year random year number used for all tests in this Test Case
+     */
+    protected int $year;
+
+    /**
+     * Initial setup of this Test Case.
+     *
+     * @throws \Exception
+     */
+    protected function setUp(): void
+    {
+        $this->year = $this->generateRandomYear(2000);
+    }
+
+    /**
+     * Tests if all official holidays in the USA are defined by the provider class.
+     */
+    public function testOfficialHolidays(): void
+    {
+        $holidays = [
+            'newYearsDay',
+            'martinLutherKingDay',
+            'washingtonsBirthday',
+			'goodFriday',
+			'memorialDay',
+            'independenceDay',
+            'labourDay',
+            'thanksgivingDay',
+            'christmasDay',
+        ];
+
+        if (2001 == $this->year) {
+            $holidays[] = 'WTCAttack1';
+            $holidays[] = 'WTCAttack2';
+            $holidays[] = 'WTCAttack3';
+            $holidays[] = 'WTCAttack4';
+		}
+
+        if (2004 == $this->year) {
+            $holidays[] = 'ReaganMourning';
+		}
+
+        if (2007 == $this->year) {
+            $holidays[] = 'GRFordMourning';
+		}
+
+        if (2012 == $this->year) {
+            $holidays[] = 'hurricaneSandy1';
+            $holidays[] = 'hurricaneSandy2';
+		}
+
+        if (2018 == $this->year) {
+            $holidays[] = 'HWBushMourning';
+		}
+
+        if (2021 > $this->year) {
+            $holidays[] = 'juneteenth';
+        }
+
+        if (2025 > $this->year) {
+            $holidays[] = 'CarterMourning';
+        }
+
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public function testSources(): void
+    {
+        $this->assertSources(self::REGION, 5);
+    }
+}

--- a/tests/USA/NYSE/NYSETest.php
+++ b/tests/USA/NYSE/NYSETest.php
@@ -7,12 +7,12 @@ declare(strict_types = 1);
  *
  * The easy PHP Library for calculating holidays.
  *
- * Copyright (c) 2025 Magic Web Group
+ * Copyright (c) 2015 - 2025 AzuyaLabs
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Art Kurbakov <admin at mgwebgroup dot com>
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
 namespace Yasumi\tests\USA\NYSE;
@@ -23,6 +23,8 @@ use Yasumi\tests\USA\USABaseTestCase;
 
 /**
  * Class for testing closure days for NYSE
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
  */
 class NYSETest extends USABaseTestCase implements ProviderTestCase
 {
@@ -55,8 +57,8 @@ class NYSETest extends USABaseTestCase implements ProviderTestCase
             'newYearsDay',
             'martinLutherKingDay',
             'washingtonsBirthday',
-			'goodFriday',
-			'memorialDay',
+            'goodFriday',
+            'memorialDay',
             'independenceDay',
             'labourDay',
             'thanksgivingDay',
@@ -68,24 +70,24 @@ class NYSETest extends USABaseTestCase implements ProviderTestCase
             $holidays[] = 'WTCAttack2';
             $holidays[] = 'WTCAttack3';
             $holidays[] = 'WTCAttack4';
-		}
+        }
 
         if (2004 == $this->year) {
             $holidays[] = 'ReaganMourning';
-		}
+        }
 
         if (2007 == $this->year) {
             $holidays[] = 'GRFordMourning';
-		}
+        }
 
         if (2012 == $this->year) {
             $holidays[] = 'hurricaneSandy1';
             $holidays[] = 'hurricaneSandy2';
-		}
+        }
 
         if (2018 == $this->year) {
             $holidays[] = 'HWBushMourning';
-		}
+        }
 
         if (2021 > $this->year) {
             $holidays[] = 'juneteenth';

--- a/tests/USA/NYSE/ReaganMourningTest.php
+++ b/tests/USA/NYSE/ReaganMourningTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2025 Magic Web Group
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
+ */
+
+namespace Yasumi\tests\USA\NYSE;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+use Yasumi\tests\USA\USABaseTestCase;
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Class to test day of closure of NYSE due to Reagan Mourning proclamation
+ */
+class ReaganMourningTest extends USABaseTestCase
+{
+    /**
+     * Name of provider to be tested.
+     */
+    public const REGION = 'USA/NYSE';
+
+    /**
+     * The year when the closure was observed.
+     */
+    public const OBSERVED_YEAR = 2004;
+
+    /**
+     * Tests day of closure on June 11th 2004
+     *
+     * @throws \Exception
+     */
+    public function testReaganMourning(): void
+    {
+        $this->assertHoliday(
+            self::REGION,
+            'ReaganMourning',
+            self::OBSERVED_YEAR,
+            new DateTime("2004-06-11", new DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests years before 2004
+     *
+     * @throws \Exception
+     */
+    public function testReaganMourningBefore2004(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'ReaganMourning',
+            self::OBSERVED_YEAR - 1
+        );
+    }
+
+    /**
+     * Tests years after 2004  
+     *
+     * @throws \Exception
+     */
+    public function testReaganMourningAfter2004(): void
+    {
+        $this->assertNotHoliday(
+           	self::REGION,
+            'ReaganMourning',
+            self::OBSERVED_YEAR + 1
+        );
+    }
+}

--- a/tests/USA/NYSE/ReaganMourningTest.php
+++ b/tests/USA/NYSE/ReaganMourningTest.php
@@ -7,24 +7,22 @@ declare(strict_types = 1);
  *
  * The easy PHP Library for calculating holidays.
  *
- * Copyright (c) 2025 Magic Web Group
+ * Copyright (c) 2015 - 2025 AzuyaLabs
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @author Art Kurbakov <admin at mgwebgroup dot com>
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
 namespace Yasumi\tests\USA\NYSE;
 
-use Yasumi\Holiday;
-use Yasumi\tests\HolidayTestCase;
 use Yasumi\tests\USA\USABaseTestCase;
-use DateTime;
-use DateTimeZone;
 
 /**
  * Class to test day of closure of NYSE due to Reagan Mourning proclamation
+ *
+ * @author Art Kurbakov <admin at mgwebgroup dot com>
  */
 class ReaganMourningTest extends USABaseTestCase
 {
@@ -49,7 +47,7 @@ class ReaganMourningTest extends USABaseTestCase
             self::REGION,
             'ReaganMourning',
             self::OBSERVED_YEAR,
-            new DateTime("2004-06-11", new DateTimeZone(self::TIMEZONE))
+            new \DateTime('2004-06-11', new \DateTimeZone(self::TIMEZONE))
         );
     }
 
@@ -61,21 +59,21 @@ class ReaganMourningTest extends USABaseTestCase
     public function testReaganMourningBefore2004(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'ReaganMourning',
             self::OBSERVED_YEAR - 1
         );
     }
 
     /**
-     * Tests years after 2004  
+     * Tests years after 2004
      *
      * @throws \Exception
      */
     public function testReaganMourningAfter2004(): void
     {
         $this->assertNotHoliday(
-           	self::REGION,
+            self::REGION,
             'ReaganMourning',
             self::OBSERVED_YEAR + 1
         );


### PR DESCRIPTION
This PR supersedes PR #382.
Added a holiday provider to track holidays and closures for the New York Stock Exchange. In addition to observed holidays, the closures include emergency, weather and presidential proclamation events since year 2000. Other US exchanges like NASDAQ and CBOE normally follow suit for holidays and closures.
