### PR TITLE
add NL equivalent days 2026 till 2028

### DIFF
--- a/src/Yasumi/Provider/Netherlands.php
+++ b/src/Yasumi/Provider/Netherlands.php
@@ -84,6 +84,7 @@ class Netherlands extends AbstractProvider
         $this->calculateQueensday();
         $this->calculateKingsday();
         $this->calculateCommemorationLiberationDay();
+        $this->addEquivalentDays();
     }
 
     public function getSources(): array
@@ -280,6 +281,59 @@ class Netherlands extends AbstractProvider
                 new \DateTime("{$this->year}-5-5", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
                 $this->locale,
                 $holidayType
+            ));
+        }
+    }
+
+    /**
+     * Extra days that are added for the "Algemene termijnenwet".
+     * These extra days are in the current cases the Friday after an official holiday, but these "day after"
+     * are not official and just administrative.
+     *
+     * @see https://wetten.overheid.nl/BWBR0002448/2010-10-10/
+     * @see https://wetten.overheid.nl/BWBR0051300/2025-07-22
+     */
+    protected function addEquivalentDays(): void
+    {
+        if (2026 == $this->year) {
+            $this->addHoliday(new Holiday(
+                'dayAfterNewYearsDay',
+                [],
+                new \DateTime("{$this->year}-1-2", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_OTHER
+            ));
+            $this->addHoliday(new Holiday(
+                'dayAfterAscensionDay',
+                ['en' => 'Day after Ascension Day', 'nl' => 'Dag na Hemelvaart'],
+                new \DateTime("{$this->year}-5-15", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_OTHER
+            ));
+        }
+        if (2027 == $this->year) {
+            $this->addHoliday(new Holiday(
+                'dayAfterAscensionDay',
+                ['en' => 'Day after Ascension Day', 'nl' => 'Dag na Hemelvaart'],
+                new \DateTime("{$this->year}-5-7", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_OTHER
+            ));
+        }
+        if (2028 == $this->year) {
+            $this->addHoliday(new Holiday(
+                'dayAfterKingsDay',
+                ['en' => 'Day after Kings Day', 'nl' => 'Dag na Koningsdag'],
+                new \DateTime("{$this->year}-4-28", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_OTHER
+            ));
+            $this->addHoliday(new Holiday(
+                'dayAfterAscensionDay',
+                ['en' => 'Day after Ascension Day', 'nl' => 'Dag na Hemelvaart'],
+                new \DateTime("{$this->year}-5-26", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale,
+                Holiday::TYPE_OTHER
             ));
         }
     }

--- a/tests/Netherlands/NetherlandsTest.php
+++ b/tests/Netherlands/NetherlandsTest.php
@@ -105,6 +105,20 @@ class NetherlandsTest extends NetherlandsBaseTestCase implements ProviderTestCas
             'epiphany',
             'princesDay',
         ], self::REGION, $this->year, Holiday::TYPE_OTHER);
+
+        $this->assertDefinedHolidays([
+            'dayAfterNewYearsDay',
+            'dayAfterAscensionDay',
+        ], self::REGION, 2026, Holiday::TYPE_OTHER);
+
+        $this->assertDefinedHolidays([
+            'dayAfterAscensionDay',
+        ], self::REGION, 2027, Holiday::TYPE_OTHER);
+
+        $this->assertDefinedHolidays([
+            'dayAfterKingsDay',
+            'dayAfterAscensionDay',
+        ], self::REGION, 2028, Holiday::TYPE_OTHER);
     }
 
     /**


### PR DESCRIPTION
There are some other holidays I would like to add. 
https://wetten.overheid.nl/BWBR0051300/2025-07-22

These days are needed when for example calculating the number of days some has to pay their bill or days you cannot contact some about their open debt;  https://nvi.nl/nieuws/de-wki-en-de-algemene-termijnenwet


