### PR TITLE
added "Czechia" provider as a short form of "Czech Republic"

### DIFF
--- a/src/Yasumi/Provider/Czechia.php
+++ b/src/Yasumi/Provider/Czechia.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\Provider;
+
+/**
+ * Provider for all holidays in Czechia. "Czechia" is the official short-name for "Czech Republic".
+ *
+ * Class Czechia
+ *
+ * @author  Pascal Paulis <ppaulis@gmail.com>
+ */
+class Czechia extends CzechRepublic
+{
+}


### PR DESCRIPTION
Hi,

This PR adds "Czechia" as a provider for "Czech Republic". "Czechia" is the official short name of "Czech Republic" and officially, both names can be used.

It is mostly the same as with "France" and "French Republic" or "Slovakia" and "Slovak Republic". Both names are correct. Only, one is more formal than the other.

The reason I'm submitting this is because libraries like https://iso3166.thephpleague.com/ are returning "Czechia" as country name, instead of "CzechRepublic".

The added class simply inherits from the CzechRepublic provider. There doesn't seem to be anything "final" or "private", so there shouldn't be any problems with this implementation.

Thanks and best regards,
Pascal