### PR TITLE
feat: add Ecuador holiday provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ composer phpstan       # Run static analysis (level 8)
 ## Testing
 
 - All new providers and holidays **must** have unit tests — PRs without tests are not accepted.
-- Tests use PHPUnit 8.5/9.6 and iterate over a range of years automatically.
+- Tests use PHPUnit 11 and iterate over a range of years automatically.
 - Run a specific suite: `vendor/bin/phpunit --testsuite Netherlands`
 
 ## Static Analysis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,15 +10,14 @@ When contributing there are a few guidelines we'd like you to keep in mind:
 - **[PSR-12 Coding Standard](https://www.php-fig.org/psr/psr-12/)**
   Please use the following command after you have completed your work:
 
-  ```shell
-  composer format
-  ```
+    ```shell
+    composer format
+    ```
 
-  This will check/correct all the code for the PSR-12 Coding Standard using the
-  wonderful [php-cs-fixer](https://cs.symfony.com).
+    This will check/correct all the code for the PSR-12 Coding Standard using the
+    wonderful [php-cs-fixer](https://cs.symfony.com).
 
 - **Add unit tests!** - Your Pull Request won't be accepted if it does not have tests:
-
     1. Ensure your new Holiday Provider contains all the necessary unit tests.
     2. Next to the file `{REGIONNAME}BaseTestCase.php`, a file called `{REGIONNAME}Test.php` needs to be present. This
        file needs to include region/country level tests and requires assertion of all expected holidays.
@@ -37,6 +36,18 @@ When contributing there are a few guidelines we'd like you to keep in mind:
   please [squash them](https://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_changing_multiple) before
   submitting.
 
+- **Use [Conventional Commits](https://www.conventionalcommits.org)** - Commit messages must follow the Conventional
+  Commits specification (e.g. `feat(Netherlands): add holiday X`, `fix(Germany): correct date for Y`).
+
+- **Sign your commits (DCO)** - Each commit must include a `Signed-off-by` trailer to certify you agree to the
+  [Developer Certificate of Origin](DCO):
+
+    ```shell
+    git commit -s -m "feat: your change"
+    ```
+
+- **Branch and PR target** - Always branch off `develop` and open your pull request against `develop`.
+
 ## Running Tests
 
 ```shell
@@ -47,4 +58,20 @@ Or, alternatively run with:
 
 ```shell
 vendor/bin/phpunit
+```
+
+Run a specific suite by name:
+
+```shell
+vendor/bin/phpunit --testsuite Netherlands
+```
+
+## Before Submitting
+
+Always run all three checks before opening a pull request:
+
+```shell
+composer cs        # Check coding standard
+composer phpstan   # Static analysis (level 8)
+composer test      # Full test suite
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,12 +6,11 @@ The following versions are supported with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.9.0  | :white_check_mark: |
-| 2.8.0  | :white_check_mark: |
-| 2.7.0  | :white_check_mark: |
-| 2.6.0  | :x: |
-| 2.5.0  | :x: |
-| <2.4   | :x: |
+| 2.10.0  | :white_check_mark: |
+| 2.9.0   | :white_check_mark: |
+| 2.8.0   | :x:                |
+| 2.7.0   | :x:                |
+| <2.7    | :x:                |
 
 As for supported PHP versions, this project only supports the actively supported versions of PHP and versions of PHP
 that only receive critical security updates. Currently, that is PHP 8.2, 8.3, 8.4 and 8.5.
@@ -22,7 +21,8 @@ support of that retired PHP version.
 ## Reporting a Vulnerability
 
 If you would like to report a vulnerability or have any security concerns with this project,
-please [open an issue](https://github.com/azuyalabs/yasumi/issues/new?labels=security).
+please use [GitHub's private vulnerability reporting](https://github.com/azuyalabs/yasumi/security/advisories/new)
+to disclose it privately before a fix is available.
 
 To investigate your request as good as possible, please include any of the following when reporting:
 

--- a/src/Yasumi/Provider/Ecuador.php
+++ b/src/Yasumi/Provider/Ecuador.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\Provider;
+
+use Yasumi\Exception\UnknownLocaleException;
+use Yasumi\Holiday;
+
+/**
+ * Provider for all holidays in Ecuador.
+ *
+ * Ecuador observes 11 national holidays established by Article 65 of the
+ * Código del Trabajo and the Ley Orgánica Reformatoria a la Ley Orgánica del
+ * Servicio Público y al Código del Trabajo (R.O. Suplemento No. 906,
+ * 20 December 2016).
+ *
+ * Transfer rules (Reforma 2016):
+ * - Tuesday  → previous Monday
+ * - Wednesday, Thursday, Saturday → following Friday
+ * - Sunday   → following Monday
+ * - Monday or Friday: no transfer
+ *
+ * Exceptions — never transferred:
+ * - 1 January (Año Nuevo)
+ * - Carnival Tuesday (always falls on Tuesday by definition)
+ * - 25 December (Navidad)
+ * Good Friday is movable by Easter and is never subject to further transfer.
+ *
+ * @see https://en.wikipedia.org/wiki/Public_holidays_in_Ecuador
+ */
+class Ecuador extends AbstractProvider
+{
+    use CommonHolidays;
+    use ChristianHolidays;
+
+    /** Year Ecuador declared the First Cry of Independence (10 August 1809). */
+    public const FIRST_CRY_OF_INDEPENDENCE_YEAR = 1809;
+
+    /** Year of the Battle of Pichincha (24 May 1822). */
+    public const BATTLE_OF_PICHINCHA_YEAR = 1822;
+
+    /** Year of the Independence of Guayaquil (9 October 1820). */
+    public const INDEPENDENCE_OF_GUAYAQUIL_YEAR = 1820;
+
+    /** Year of the Independence of Cuenca (3 November 1820). */
+    public const INDEPENDENCE_OF_CUENCA_YEAR = 1820;
+
+    /**
+     * Code to identify this Holiday Provider. Typically, this is the ISO3166
+     * code corresponding to the respective country or sub-region.
+     */
+    public const ID = 'EC';
+
+    /**
+     * Initialize holidays for Ecuador.
+     *
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize(): void
+    {
+        $this->timezone = 'America/Guayaquil';
+
+        // Fixed holidays — never transferred
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
+
+        // Good Friday — Easter-relative, no additional transfer rule
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
+
+        // Carnival — Monday and Tuesday before Ash Wednesday (Easter − 48 and − 47 days)
+        $this->addCarnivalHolidays();
+
+        // Transferable national holidays
+        $this->addInternationalWorkersDay();
+        $this->addBattleOfPichinchaDay();
+        $this->addFirstCryOfIndependenceDay();
+        $this->addIndependenceOfGuayaquilDay();
+        $this->addDayOfTheDeadDay();
+        $this->addIndependenceOfCuencaDay();
+    }
+
+    /**
+     * The source of the holidays.
+     *
+     * @return string[] The source URLs
+     */
+    public function getSources(): array
+    {
+        return [
+            'https://en.wikipedia.org/wiki/Public_holidays_in_Ecuador',
+            'https://www.ccq.ec/wp-content/uploads/2017/06/Consulta-Laboral-Diciembre-2016.pdf',
+            'https://boletincontable.com/2016/12/21/ley-organica-reformatoria-a-la-ley-organica-del-servicio-publico-y-al-codigo-del-trabajo/',
+            'https://www.turismo.gob.ec/wp-content/uploads/2025/08/Calendario-feriados-nacionales-2025-2030.pdf',
+        ];
+    }
+
+    /**
+     * Applies the Ecuadorian transfer rule (Reforma 2016, Art. 65 CT).
+     *
+     * - Tuesday  → previous Monday
+     * - Wednesday, Thursday, Saturday → following Friday
+     * - Sunday   → following Monday
+     * - Monday or Friday: unchanged
+     */
+    protected function applyTransferRule(\DateTime $date): \DateTime
+    {
+        $result = clone $date;
+        $dayOfWeek = (int) $result->format('w'); // 0=Sun, 1=Mon … 6=Sat
+
+        switch ($dayOfWeek) {
+            case 2: // Tuesday → Monday
+                $result->sub(new \DateInterval('P1D'));
+                break;
+            case 3: // Wednesday → Friday
+                $result->add(new \DateInterval('P2D'));
+                break;
+            case 4: // Thursday → Friday
+                $result->add(new \DateInterval('P1D'));
+                break;
+            case 6: // Saturday → Friday
+                $result->sub(new \DateInterval('P1D'));
+                break;
+            case 0: // Sunday → Monday
+                $result->add(new \DateInterval('P1D'));
+                break;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Carnival Monday and Carnival Tuesday.
+     *
+     * Carnival falls on the Monday and Tuesday immediately before Ash Wednesday
+     * (Easter − 48 and − 47 days respectively). Carnival Monday may be subject
+     * to the standard transfer rule, but since it always falls on a Monday by
+     * definition, no transfer occurs. Carnival Tuesday is explicitly exempt from
+     * the transfer rule.
+     *
+     * @throws \Exception
+     */
+    protected function addCarnivalHolidays(): void
+    {
+        $easter = $this->calculateEaster($this->year, $this->timezone);
+
+        $carnivalMonday = (clone $easter)->sub(new \DateInterval('P48D'));
+
+        if (! $carnivalMonday instanceof \DateTime) {
+            throw new \RuntimeException(sprintf('unable to perform a date subtraction for %s:carnivalMonday', self::class));
+        }
+
+        $this->addHoliday(new Holiday(
+            'carnavalMonday',
+            ['es' => 'Lunes de Carnaval', 'en' => 'Carnival Monday'],
+            $carnivalMonday,
+            $this->locale
+        ));
+
+        $carnivalTuesday = (clone $easter)->sub(new \DateInterval('P47D'));
+
+        if (! $carnivalTuesday instanceof \DateTime) {
+            throw new \RuntimeException(sprintf('unable to perform a date subtraction for %s:carnivalTuesday', self::class));
+        }
+
+        $this->addHoliday(new Holiday(
+            'carnavalTuesday',
+            ['es' => 'Martes de Carnaval', 'en' => 'Carnival Tuesday'],
+            $carnivalTuesday,
+            $this->locale
+        ));
+    }
+
+    /**
+     * International Workers' Day — 1 May (transferable).
+     *
+     * @throws \Exception
+     */
+    protected function addInternationalWorkersDay(): void
+    {
+        $date = $this->applyTransferRule(new \DateTime("{$this->year}-05-01", DateTimeZoneFactory::getDateTimeZone($this->timezone)));
+
+        $this->addHoliday(new Holiday(
+            'internationalWorkersDay',
+            [],
+            $date,
+            $this->locale
+        ));
+    }
+
+    /**
+     * Battle of Pichincha — 24 May (transferable).
+     *
+     * Commemorates the Battle of Pichincha on 24 May 1822, which secured
+     * Ecuador's independence from Spain.
+     *
+     * @see https://en.wikipedia.org/wiki/Battle_of_Pichincha
+     *
+     * @throws \Exception
+     */
+    protected function addBattleOfPichinchaDay(): void
+    {
+        if ($this->year >= self::BATTLE_OF_PICHINCHA_YEAR) {
+            $date = $this->applyTransferRule(new \DateTime("{$this->year}-05-24", DateTimeZoneFactory::getDateTimeZone($this->timezone)));
+
+            $this->addHoliday(new Holiday(
+                'battleOfPichinchaDay',
+                ['es' => 'Batalla del Pichincha', 'en' => 'Battle of Pichincha'],
+                $date,
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * First Cry of Independence — 10 August (transferable).
+     *
+     * Commemorates the Primer Grito de Independencia of 10 August 1809,
+     * the first declaration of independence in Spanish-speaking South America.
+     *
+     * @see https://en.wikipedia.org/wiki/Primer_Grito_de_Independencia_(Ecuador)
+     *
+     * @throws \Exception
+     */
+    protected function addFirstCryOfIndependenceDay(): void
+    {
+        if ($this->year >= self::FIRST_CRY_OF_INDEPENDENCE_YEAR) {
+            $date = $this->applyTransferRule(new \DateTime("{$this->year}-08-10", DateTimeZoneFactory::getDateTimeZone($this->timezone)));
+
+            $this->addHoliday(new Holiday(
+                'firstCryOfIndependenceDay',
+                ['es' => 'Primer Grito de Independencia', 'en' => 'First Cry of Independence'],
+                $date,
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Independence of Guayaquil — 9 October (transferable).
+     *
+     * Commemorates the Independence of Guayaquil on 9 October 1820.
+     *
+     * @see https://en.wikipedia.org/wiki/Independence_of_Guayaquil
+     *
+     * @throws \Exception
+     */
+    protected function addIndependenceOfGuayaquilDay(): void
+    {
+        if ($this->year >= self::INDEPENDENCE_OF_GUAYAQUIL_YEAR) {
+            $date = $this->applyTransferRule(new \DateTime("{$this->year}-10-09", DateTimeZoneFactory::getDateTimeZone($this->timezone)));
+
+            $this->addHoliday(new Holiday(
+                'independenceOfGuayaquilDay',
+                ['es' => 'Independencia de Guayaquil', 'en' => 'Independence of Guayaquil'],
+                $date,
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Day of the Dead — 2 November (transferable).
+     *
+     * All Souls' Day, commemorating the faithful departed.
+     *
+     * @throws \Exception
+     */
+    protected function addDayOfTheDeadDay(): void
+    {
+        $date = $this->applyTransferRule(new \DateTime("{$this->year}-11-02", DateTimeZoneFactory::getDateTimeZone($this->timezone)));
+
+        $this->addHoliday(new Holiday(
+            'dayOfTheDead',
+            ['es' => 'Día de Difuntos', 'en' => 'Day of the Dead'],
+            $date,
+            $this->locale
+        ));
+    }
+
+    /**
+     * Independence of Cuenca — 3 November (transferable).
+     *
+     * Commemorates the Independence of Cuenca on 3 November 1820.
+     *
+     * @see https://en.wikipedia.org/wiki/Cuenca,_Ecuador
+     *
+     * @throws \Exception
+     */
+    protected function addIndependenceOfCuencaDay(): void
+    {
+        if ($this->year >= self::INDEPENDENCE_OF_CUENCA_YEAR) {
+            $date = $this->applyTransferRule(new \DateTime("{$this->year}-11-03", DateTimeZoneFactory::getDateTimeZone($this->timezone)));
+
+            $this->addHoliday(new Holiday(
+                'independenceOfCuencaDay',
+                ['es' => 'Independencia de Cuenca', 'en' => 'Independence of Cuenca'],
+                $date,
+                $this->locale
+            ));
+        }
+    }
+}

--- a/src/Yasumi/data/translations/battleOfPichinchaDay.php
+++ b/src/Yasumi/data/translations/battleOfPichinchaDay.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+// Translations for Battle of Pichincha (Ecuador, 24 May)
+return [
+    'en' => 'Battle of Pichincha',
+    'es' => 'Batalla del Pichincha',
+];

--- a/src/Yasumi/data/translations/dayOfTheDead.php
+++ b/src/Yasumi/data/translations/dayOfTheDead.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+// Translations for Day of the Dead / All Souls' Day (Ecuador, 2 November)
+return [
+    'en' => 'Day of the Dead',
+    'es' => 'Día de Difuntos',
+];

--- a/src/Yasumi/data/translations/firstCryOfIndependenceDay.php
+++ b/src/Yasumi/data/translations/firstCryOfIndependenceDay.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+// Translations for First Cry of Independence (Ecuador, 10 August)
+return [
+    'en' => 'First Cry of Independence',
+    'es' => 'Primer Grito de Independencia',
+];

--- a/src/Yasumi/data/translations/independenceOfCuencaDay.php
+++ b/src/Yasumi/data/translations/independenceOfCuencaDay.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+// Translations for Independence of Cuenca (Ecuador, 3 November)
+return [
+    'en' => 'Independence of Cuenca',
+    'es' => 'Independencia de Cuenca',
+];

--- a/src/Yasumi/data/translations/independenceOfGuayaquilDay.php
+++ b/src/Yasumi/data/translations/independenceOfGuayaquilDay.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+// Translations for Independence of Guayaquil (Ecuador, 9 October)
+return [
+    'en' => 'Independence of Guayaquil',
+    'es' => 'Independencia de Guayaquil',
+];

--- a/tests/Ecuador/BattleOfPichinchaDayTest.php
+++ b/tests/Ecuador/BattleOfPichinchaDayTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Ecuador;
+use Yasumi\tests\HolidayTestCase;
+
+class BattleOfPichinchaDayTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'battleOfPichinchaDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        // May 24 2002 = Friday — no transfer
+        $year = 2002;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-05-24", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTransferRule(): void
+    {
+        // May 24 2000 = Wednesday → 2000-05-26
+        $holidays = \Yasumi\Yasumi::create(self::REGION, 2000, self::LOCALE);
+        $holiday = $holidays->getHoliday(self::HOLIDAY);
+        $this->assertNotNull($holiday);
+        $this->assertSame('2000-05-26', $holiday->format('Y-m-d'));
+    }
+
+    /** @throws \Exception */
+    public function testNotBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, Ecuador::BATTLE_OF_PICHINCHA_YEAR - 1);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Ecuador::BATTLE_OF_PICHINCHA_YEAR),
+            [self::LOCALE => 'Batalla del Pichincha']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(Ecuador::BATTLE_OF_PICHINCHA_YEAR), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ecuador/CarnavalMondayTest.php
+++ b/tests/Ecuador/CarnavalMondayTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\ChristianHolidays;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Carnival Monday in Ecuador.
+ */
+class CarnavalMondayTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    use ChristianHolidays;
+
+    public const HOLIDAY = 'carnavalMonday';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2025;
+        // 2025: Easter = April 20; Carnival Monday = March 3
+        $expected = static::computeEaster($year, self::TIMEZONE)->sub(new \DateInterval('P48D'));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /** @throws \Exception */
+    public function testAlwaysFallsOnMonday(): void
+    {
+        foreach (range(2020, 2030) as $year) {
+            $holidays = \Yasumi\Yasumi::create(self::REGION, $year, self::LOCALE);
+            $holiday = $holidays->getHoliday(self::HOLIDAY);
+            $this->assertNotNull($holiday);
+            $this->assertSame(
+                '1',
+                $holiday->format('w'),
+                self::HOLIDAY . " must fall on Monday in {$year}, got " . $holiday->format('l Y-m-d')
+            );
+        }
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(),
+            [self::LOCALE => 'Lunes de Carnaval']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ecuador/CarnavalTuesdayTest.php
+++ b/tests/Ecuador/CarnavalTuesdayTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\ChristianHolidays;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Carnival Tuesday in Ecuador.
+ *
+ * Carnival Tuesday is always the day after Carnival Monday and is explicitly
+ * exempt from the transfer rule per Art. 65 CT and the 2016 reform.
+ */
+class CarnavalTuesdayTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    use ChristianHolidays;
+
+    public const HOLIDAY = 'carnavalTuesday';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2025;
+        // 2025: Easter = April 20; Carnival Tuesday = March 4
+        $expected = static::computeEaster($year, self::TIMEZONE)->sub(new \DateInterval('P47D'));
+        $this->assertHoliday(self::REGION, self::HOLIDAY, $year, $expected);
+    }
+
+    /** @throws \Exception */
+    public function testAlwaysFallsOnTuesday(): void
+    {
+        foreach (range(2020, 2030) as $year) {
+            $holidays = \Yasumi\Yasumi::create(self::REGION, $year, self::LOCALE);
+            $holiday = $holidays->getHoliday(self::HOLIDAY);
+            $this->assertNotNull($holiday);
+            $this->assertSame(
+                '2',
+                $holiday->format('w'),
+                self::HOLIDAY . " must fall on Tuesday in {$year}, got " . $holiday->format('l Y-m-d')
+            );
+        }
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(),
+            [self::LOCALE => 'Martes de Carnaval']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ecuador/ChristmasDayTest.php
+++ b/tests/Ecuador/ChristmasDayTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+class ChristmasDayTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'christmasDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2025;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-12-25", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(),
+            [self::LOCALE => 'Navidad']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ecuador/DayOfTheDeadTest.php
+++ b/tests/Ecuador/DayOfTheDeadTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+class DayOfTheDeadTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'dayOfTheDead';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        // Nov 02 2001 = Friday — no transfer
+        $year = 2001;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-11-02", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTransferRule(): void
+    {
+        // Nov 02 2000 = Thursday → 2000-11-03
+        $holidays = \Yasumi\Yasumi::create(self::REGION, 2000, self::LOCALE);
+        $holiday = $holidays->getHoliday(self::HOLIDAY);
+        $this->assertNotNull($holiday);
+        $this->assertSame('2000-11-03', $holiday->format('Y-m-d'));
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(),
+            [self::LOCALE => 'Día de Difuntos']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ecuador/EcuadorBaseTestCase.php
+++ b/tests/Ecuador/EcuadorBaseTestCase.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use PHPUnit\Framework\TestCase;
+use Yasumi\tests\YasumiBase;
+
+abstract class EcuadorBaseTestCase extends TestCase
+{
+    use YasumiBase;
+
+    public const REGION = 'Ecuador';
+    public const TIMEZONE = 'America/Guayaquil';
+    public const LOCALE = 'es';
+}

--- a/tests/Ecuador/EcuadorTest.php
+++ b/tests/Ecuador/EcuadorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Ecuador;
+use Yasumi\tests\ProviderTestCase;
+
+class EcuadorTest extends EcuadorBaseTestCase implements ProviderTestCase
+{
+    protected int $year;
+
+    protected function setUp(): void
+    {
+        $this->year = static::generateRandomYear(Ecuador::INDEPENDENCE_OF_GUAYAQUIL_YEAR);
+    }
+
+    public function testOfficialHolidays(): void
+    {
+        $holidays = [
+            'newYearsDay',
+            'goodFriday',
+            'carnavalMonday',
+            'carnavalTuesday',
+            'internationalWorkersDay',
+            'dayOfTheDead',
+            'christmasDay',
+        ];
+
+        if ($this->year >= Ecuador::BATTLE_OF_PICHINCHA_YEAR) {
+            $holidays[] = 'battleOfPichinchaDay';
+        }
+        if ($this->year >= Ecuador::FIRST_CRY_OF_INDEPENDENCE_YEAR) {
+            $holidays[] = 'firstCryOfIndependenceDay';
+        }
+        if ($this->year >= Ecuador::INDEPENDENCE_OF_GUAYAQUIL_YEAR) {
+            $holidays[] = 'independenceOfGuayaquilDay';
+        }
+        if ($this->year >= Ecuador::INDEPENDENCE_OF_CUENCA_YEAR) {
+            $holidays[] = 'independenceOfCuencaDay';
+        }
+
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    public function testObservedHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+    }
+
+    public function testSeasonalHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_SEASON);
+    }
+
+    public function testOtherHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+    }
+
+    /** @throws \Exception */
+    public function testSources(): void
+    {
+        $this->assertSources(self::REGION, 4);
+    }
+}

--- a/tests/Ecuador/FirstCryOfIndependenceDayTest.php
+++ b/tests/Ecuador/FirstCryOfIndependenceDayTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Ecuador;
+use Yasumi\tests\HolidayTestCase;
+
+class FirstCryOfIndependenceDayTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'firstCryOfIndependenceDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        // Aug 10 2001 = Friday — no transfer
+        $year = 2001;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-08-10", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTransferRule(): void
+    {
+        // Aug 10 2000 = Thursday → 2000-08-11
+        $holidays = \Yasumi\Yasumi::create(self::REGION, 2000, self::LOCALE);
+        $holiday = $holidays->getHoliday(self::HOLIDAY);
+        $this->assertNotNull($holiday);
+        $this->assertSame('2000-08-11', $holiday->format('Y-m-d'));
+    }
+
+    /** @throws \Exception */
+    public function testNotBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, Ecuador::FIRST_CRY_OF_INDEPENDENCE_YEAR - 1);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Ecuador::FIRST_CRY_OF_INDEPENDENCE_YEAR),
+            [self::LOCALE => 'Primer Grito de Independencia']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(Ecuador::FIRST_CRY_OF_INDEPENDENCE_YEAR), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ecuador/GoodFridayTest.php
+++ b/tests/Ecuador/GoodFridayTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\ChristianHolidays;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Good Friday in Ecuador.
+ */
+class GoodFridayTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    use ChristianHolidays;
+
+    public const HOLIDAY = 'goodFriday';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2025;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            static::computeEaster($year, self::TIMEZONE)->sub(new \DateInterval('P2D'))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(),
+            [self::LOCALE => 'Viernes Santo']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ecuador/IndependenceOfCuencaDayTest.php
+++ b/tests/Ecuador/IndependenceOfCuencaDayTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Ecuador;
+use Yasumi\tests\HolidayTestCase;
+
+class IndependenceOfCuencaDayTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'independenceOfCuencaDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        // Nov 03 2000 = Friday — no transfer
+        $year = 2000;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-11-03", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTransferRule(): void
+    {
+        // Nov 03 2001 = Saturday → 2001-11-02
+        $holidays = \Yasumi\Yasumi::create(self::REGION, 2001, self::LOCALE);
+        $holiday = $holidays->getHoliday(self::HOLIDAY);
+        $this->assertNotNull($holiday);
+        $this->assertSame('2001-11-02', $holiday->format('Y-m-d'));
+    }
+
+    /** @throws \Exception */
+    public function testNotBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, Ecuador::INDEPENDENCE_OF_CUENCA_YEAR - 1);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Ecuador::INDEPENDENCE_OF_CUENCA_YEAR),
+            [self::LOCALE => 'Independencia de Cuenca']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(Ecuador::INDEPENDENCE_OF_CUENCA_YEAR), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ecuador/IndependenceOfGuayaquilDayTest.php
+++ b/tests/Ecuador/IndependenceOfGuayaquilDayTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Ecuador;
+use Yasumi\tests\HolidayTestCase;
+
+class IndependenceOfGuayaquilDayTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'independenceOfGuayaquilDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        // Oct 09 2000 = Monday — no transfer
+        $year = 2000;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-10-09", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTransferRule(): void
+    {
+        // Oct 09 2001 = Tuesday → 2001-10-08
+        $holidays = \Yasumi\Yasumi::create(self::REGION, 2001, self::LOCALE);
+        $holiday = $holidays->getHoliday(self::HOLIDAY);
+        $this->assertNotNull($holiday);
+        $this->assertSame('2001-10-08', $holiday->format('Y-m-d'));
+    }
+
+    /** @throws \Exception */
+    public function testNotBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, Ecuador::INDEPENDENCE_OF_GUAYAQUIL_YEAR - 1);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Ecuador::INDEPENDENCE_OF_GUAYAQUIL_YEAR),
+            [self::LOCALE => 'Independencia de Guayaquil']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(Ecuador::INDEPENDENCE_OF_GUAYAQUIL_YEAR), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ecuador/InternationalWorkersDayTest.php
+++ b/tests/Ecuador/InternationalWorkersDayTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing International Workers' Day in Ecuador.
+ */
+class InternationalWorkersDayTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'internationalWorkersDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        // May 1 2023 = Monday → no transfer
+        $year = 2023;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-05-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTransferRule(): void
+    {
+        // May 1 2025 = Thursday → Friday May 2
+        $holidays = \Yasumi\Yasumi::create(self::REGION, 2025, self::LOCALE);
+        $holiday = $holidays->getHoliday(self::HOLIDAY);
+        $this->assertNotNull($holiday);
+        $this->assertSame('2025-05-02', $holiday->format('Y-m-d'));
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(),
+            [self::LOCALE => 'Día del Trabajador']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}

--- a/tests/Ecuador/NewYearsDayTest.php
+++ b/tests/Ecuador/NewYearsDayTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Ecuador;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+class NewYearsDayTest extends EcuadorBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'newYearsDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2025;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-01-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(),
+            [self::LOCALE => 'Año Nuevo']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(self::REGION, self::HOLIDAY, static::generateRandomYear(), Holiday::TYPE_OFFICIAL);
+    }
+}


### PR DESCRIPTION
Add Ecuador (EC) holiday provider with 11 national holidays established
by Article 65 of the Código del Trabajo and the Ley Orgánica Reformatoria
a la LOSEP y al Código del Trabajo (R.O. Suplemento No. 906, Dec 2016).

Fixed holidays (never transferred):
- New Year's Day (1 Jan)
- Carnival Monday and Carnival Tuesday (Easter − 48/47 days)
- Good Friday (Easter-relative)
- Christmas Day (25 Dec)

Transferable holidays (Reforma 2016 rule):
  Tue → Mon; Wed/Thu/Sat → Fri; Sun → Mon; Mon/Fri unchanged:
- International Workers' Day (1 May)
- Battle of Pichincha (24 May, since 1822)
- First Cry of Independence (10 Aug, since 1809)
- Independence of Guayaquil (9 Oct, since 1820)
- Day of the Dead (2 Nov)
- Independence of Cuenca (3 Nov, since 1820)

Includes 13 test files with testTransferRule() coverage for all
transferable holidays and year-guard tests for historical holidays.