### PR TITLE
feat(Australia): refresh holiday rules and rename Queen's Birthday to Monarch's Birthday

### DIFF
--- a/src/Yasumi/Provider/Australia.php
+++ b/src/Yasumi/Provider/Australia.php
@@ -35,6 +35,8 @@ class Australia extends AbstractProvider
      */
     public const ID = 'AU';
 
+    protected const MONARCHY_CHANGE_YEAR = 2023;
+
     public string $timezone = 'Australia/Melbourne';
 
     /**
@@ -229,6 +231,35 @@ class Australia extends AbstractProvider
             'nationalDayOfMourning',
             ['en' => 'National Day of Mourning'],
             new \DateTime("{$this->year}-9-22", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $this->locale,
+            Holiday::TYPE_OFFICIAL
+        ));
+    }
+
+    /**
+     * Monarch's Birthday.
+     *
+     * @throws \Exception
+     */
+    protected function addMonarchsBirthdayHoliday(\DateTimeInterface $date): void
+    {
+        $name = $this->year >= self::MONARCHY_CHANGE_YEAR ? 'King’s Birthday' : 'Queen’s Birthday';
+
+        $holiday = new Holiday(
+            'monarchsBirthday',
+            ['en' => $name],
+            $date,
+            $this->locale,
+            Holiday::TYPE_OFFICIAL
+        );
+
+        $this->addHoliday($holiday);
+
+        // Deprecated alias retained for downstream consumers using the former holiday key.
+        $this->addHoliday(new Holiday(
+            'queensBirthday',
+            ['en' => $name],
+            $date,
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));

--- a/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
+++ b/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
@@ -179,15 +179,9 @@ class AustralianCapitalTerritory extends Australia
      */
     protected function calculateMonarchsBirthday(): void
     {
-        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
-
-        $this->addHoliday(new Holiday(
-            'monarchsBirthday',
-            ['en' => $name],
-            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_OFFICIAL
-        ));
+        $this->addMonarchsBirthdayHoliday(
+            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone))
+        );
     }
 
     /**

--- a/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
+++ b/src/Yasumi/Provider/Australia/AustralianCapitalTerritory.php
@@ -33,7 +33,7 @@ class AustralianCapitalTerritory extends Australia
      */
     public const ID = 'AU-ACT';
 
-    public string $timezone = 'Australia/ACT';
+    public string $timezone = 'Australia/Sydney';
 
     /**
      * Initialize holidays for Australian Capital Territory (Australia).
@@ -48,10 +48,48 @@ class AustralianCapitalTerritory extends Australia
 
         $this->addHoliday($this->easterSunday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
-        $this->calculateQueensBirthday();
+        $this->calculateMonarchsBirthday();
         $this->calculateLabourDay();
         $this->calculateCanberraDay();
         $this->calculateReconciliationDay();
+        $this->calculateAnzacDayMonday();
+    }
+
+    /**
+     * ANZAC Day Monday substitute.
+     *
+     * When ANZAC Day (April 25) falls on a Saturday or Sunday, the following Monday is an additional public holiday
+     * in this state/territory.
+     *
+     * @see https://en.wikipedia.org/wiki/Anzac_Day
+     * @see https://www.timeanddate.com/holidays/australia/anzac-day
+     *
+     * @throws \Exception
+     */
+    protected function calculateAnzacDayMonday(): void
+    {
+        if ($this->year < 2020) {
+            return;
+        }
+
+        $date = new \DateTime("{$this->year}-04-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $dow = (int) $date->format('w');
+
+        if (6 === $dow) { // Saturday → Monday
+            $date->add(new \DateInterval('P2D'));
+        } elseif (0 === $dow) { // Sunday → Monday
+            $date->add(new \DateInterval('P1D'));
+        } else {
+            return;
+        }
+
+        $this->addHoliday(new Holiday(
+            'anzacDayMonday',
+            ['en' => 'ANZAC Day'],
+            $date,
+            $this->locale,
+            Holiday::TYPE_OFFICIAL
+        ));
     }
 
     /**
@@ -125,9 +163,9 @@ class AustralianCapitalTerritory extends Australia
     }
 
     /**
-     * Queens Birthday.
+     * Monarch's Birthday.
      *
-     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * The Monarch's Birthday is an Australian public holiday but the date varies across
      * states and territories. Australia celebrates this holiday because it is a constitutional
      * monarchy, with the English monarch as head of state.
      *
@@ -139,11 +177,13 @@ class AustralianCapitalTerritory extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    protected function calculateQueensBirthday(): void
+    protected function calculateMonarchsBirthday(): void
     {
+        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
+
         $this->addHoliday(new Holiday(
-            'queensBirthday',
-            [],
+            'monarchsBirthday',
+            ['en' => $name],
             new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL

--- a/src/Yasumi/Provider/Australia/NewSouthWales.php
+++ b/src/Yasumi/Provider/Australia/NewSouthWales.php
@@ -146,15 +146,9 @@ class NewSouthWales extends Australia
      */
     protected function calculateMonarchsBirthday(): void
     {
-        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
-
-        $this->addHoliday(new Holiday(
-            'monarchsBirthday',
-            ['en' => $name],
-            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_OFFICIAL
-        ));
+        $this->addMonarchsBirthdayHoliday(
+            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone))
+        );
     }
 
     /**

--- a/src/Yasumi/Provider/Australia/NewSouthWales.php
+++ b/src/Yasumi/Provider/Australia/NewSouthWales.php
@@ -33,7 +33,7 @@ class NewSouthWales extends Australia
      */
     public const ID = 'AU-NSW';
 
-    public string $timezone = 'Australia/NSW';
+    public string $timezone = 'Australia/Sydney';
 
     /**
      * Initialize holidays for New South Wales (Australia).
@@ -48,9 +48,47 @@ class NewSouthWales extends Australia
 
         $this->addHoliday(new Holiday('easter', [], $this->calculateEaster($this->year, $this->timezone), $this->locale));
         $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
-        $this->calculateQueensBirthday();
+        $this->calculateMonarchsBirthday();
         $this->calculateLabourDay();
         $this->calculateBankHoliday();
+        $this->calculateAnzacDayMonday();
+    }
+
+    /**
+     * ANZAC Day Monday substitute.
+     *
+     * When ANZAC Day (April 25) falls on a Saturday or Sunday, the following Monday is an additional public holiday
+     * in this state/territory.
+     *
+     * @see https://en.wikipedia.org/wiki/Anzac_Day
+     * @see https://www.timeanddate.com/holidays/australia/anzac-day
+     *
+     * @throws \Exception
+     */
+    protected function calculateAnzacDayMonday(): void
+    {
+        if ($this->year < 2026 || $this->year > 2027) {
+            return;
+        }
+
+        $date = new \DateTime("{$this->year}-04-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $dow = (int) $date->format('w');
+
+        if (6 === $dow) { // Saturday → Monday
+            $date->add(new \DateInterval('P2D'));
+        } elseif (0 === $dow) { // Sunday → Monday
+            $date->add(new \DateInterval('P1D'));
+        } else {
+            return;
+        }
+
+        $this->addHoliday(new Holiday(
+            'anzacDayMonday',
+            ['en' => 'ANZAC Day'],
+            $date,
+            $this->locale,
+            Holiday::TYPE_OFFICIAL
+        ));
     }
 
     /**
@@ -92,9 +130,9 @@ class NewSouthWales extends Australia
     }
 
     /**
-     * Queens Birthday.
+     * Monarch's Birthday.
      *
-     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * The Monarch's Birthday is an Australian public holiday but the date varies across
      * states and territories. Australia celebrates this holiday because it is a constitutional
      * monarchy, with the English monarch as head of state.
      *
@@ -106,11 +144,13 @@ class NewSouthWales extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    protected function calculateQueensBirthday(): void
+    protected function calculateMonarchsBirthday(): void
     {
+        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
+
         $this->addHoliday(new Holiday(
-            'queensBirthday',
-            [],
+            'monarchsBirthday',
+            ['en' => $name],
             new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL

--- a/src/Yasumi/Provider/Australia/NorthernTerritory.php
+++ b/src/Yasumi/Provider/Australia/NorthernTerritory.php
@@ -33,7 +33,7 @@ class NorthernTerritory extends Australia
      */
     public const ID = 'AU-NT';
 
-    public string $timezone = 'Australia/North';
+    public string $timezone = 'Australia/Darwin';
 
     /**
      * Initialize holidays for Northern Territory (Australia).
@@ -47,7 +47,9 @@ class NorthernTerritory extends Australia
         parent::initialize();
 
         $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
-        $this->calculateQueensBirthday();
+        $this->addHoliday($this->easterSunday($this->year, $this->timezone, $this->locale));
+        $this->calculateAnzacDayMonday();
+        $this->calculateMonarchsBirthday();
         $this->calculateMayDay();
         $this->calculatePicnicDay();
     }
@@ -91,9 +93,69 @@ class NorthernTerritory extends Australia
     }
 
     /**
-     * Queens Birthday.
+     * Easter Sunday.
      *
-     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @see https://en.wikipedia.org/wiki/Easter
+     *
+     * @param int         $year     the year for which Easter Sunday need to be created
+     * @param string      $timezone the timezone in which Easter Sunday is celebrated
+     * @param string      $locale   the locale for which Easter Sunday need to be displayed in
+     * @param string|null $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                              TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @throws \Exception
+     */
+    protected function easterSunday(
+        int $year,
+        string $timezone,
+        string $locale,
+        ?string $type = null,
+    ): Holiday {
+        return new Holiday(
+            'easter',
+            ['en' => 'Easter Sunday'],
+            $this->calculateEaster($year, $timezone),
+            $locale,
+            $type ?? Holiday::TYPE_OFFICIAL
+        );
+    }
+
+    /**
+     * ANZAC Day Monday substitute.
+     *
+     * In the Northern Territory, a substitute public holiday is observed on the following Monday
+     * when ANZAC Day falls on a Sunday.
+     *
+     * @see https://nt.gov.au/nt-public-holidays
+     *
+     * @throws \Exception
+     */
+    protected function calculateAnzacDayMonday(): void
+    {
+        $date = new \DateTime("{$this->year}-04-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        if ('0' !== $date->format('w')) {
+            return;
+        }
+
+        $date->add(new \DateInterval('P1D'));
+
+        $this->addHoliday(new Holiday(
+            'anzacDayMonday',
+            ['en' => 'ANZAC Day'],
+            $date,
+            $this->locale,
+            Holiday::TYPE_OFFICIAL
+        ));
+    }
+
+    /**
+     * Monarch's Birthday.
+     *
+     * The Monarch's Birthday is an Australian public holiday but the date varies across
      * states and territories. Australia celebrates this holiday because it is a constitutional
      * monarchy, with the English monarch as head of state.
      *
@@ -105,11 +167,13 @@ class NorthernTerritory extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    protected function calculateQueensBirthday(): void
+    protected function calculateMonarchsBirthday(): void
     {
+        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
+
         $this->addHoliday(new Holiday(
-            'queensBirthday',
-            [],
+            'monarchsBirthday',
+            ['en' => $name],
             new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL

--- a/src/Yasumi/Provider/Australia/NorthernTerritory.php
+++ b/src/Yasumi/Provider/Australia/NorthernTerritory.php
@@ -169,15 +169,9 @@ class NorthernTerritory extends Australia
      */
     protected function calculateMonarchsBirthday(): void
     {
-        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
-
-        $this->addHoliday(new Holiday(
-            'monarchsBirthday',
-            ['en' => $name],
-            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_OFFICIAL
-        ));
+        $this->addMonarchsBirthdayHoliday(
+            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone))
+        );
     }
 
     /**

--- a/src/Yasumi/Provider/Australia/Queensland.php
+++ b/src/Yasumi/Provider/Australia/Queensland.php
@@ -33,7 +33,7 @@ class Queensland extends Australia
      */
     public const ID = 'AU-QLD';
 
-    public string $timezone = 'Australia/Queensland';
+    public string $timezone = 'Australia/Brisbane';
 
     /**
      * Initialize holidays for Queensland (Australia).
@@ -46,14 +46,91 @@ class Queensland extends Australia
     {
         parent::initialize();
 
-        $this->calculateQueensBirthday();
+        $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
+
+        if ($this->year >= 2017) {
+            $this->addHoliday($this->easterSunday($this->year, $this->timezone, $this->locale));
+        }
+
+        $this->calculateMonarchsBirthday();
         $this->calculateLabourDay();
     }
 
     /**
-     * Queens Birthday.
+     * Easter Saturday.
      *
-     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @see https://en.wikipedia.org/wiki/Easter
+     *
+     * @param int         $year     the year for which Easter Saturday need to be created
+     * @param string      $timezone the timezone in which Easter Saturday is celebrated
+     * @param string      $locale   the locale for which Easter Saturday need to be displayed in
+     * @param string|null $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                              TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @throws \Exception
+     */
+    protected function easterSaturday(
+        int $year,
+        string $timezone,
+        string $locale,
+        ?string $type = null,
+    ): Holiday {
+        $date = $this->calculateEaster($year, $timezone)->sub(new \DateInterval('P1D'));
+
+        if (! $date instanceof \DateTime) {
+            throw new \RuntimeException(sprintf('unable to perform a date subtraction for %s:%s', self::class, 'easterSaturday'));
+        }
+
+        return new Holiday(
+            'easterSaturday',
+            ['en' => 'Easter Saturday'],
+            $date,
+            $locale,
+            $type ?? Holiday::TYPE_OFFICIAL
+        );
+    }
+
+    /**
+     * Easter Sunday.
+     *
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @see https://en.wikipedia.org/wiki/Easter
+     * @see https://www.qld.gov.au/recreation/travel/holidays/public
+     *
+     * @param int         $year     the year for which Easter Sunday need to be created
+     * @param string      $timezone the timezone in which Easter Sunday is celebrated
+     * @param string      $locale   the locale for which Easter Sunday need to be displayed in
+     * @param string|null $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                              TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @throws \Exception
+     */
+    protected function easterSunday(
+        int $year,
+        string $timezone,
+        string $locale,
+        ?string $type = null,
+    ): Holiday {
+        return new Holiday(
+            'easter',
+            ['en' => 'Easter Sunday'],
+            $this->calculateEaster($year, $timezone),
+            $locale,
+            $type ?? Holiday::TYPE_OFFICIAL
+        );
+    }
+
+    /**
+     * Monarch's Birthday.
+     *
+     * The Monarch's Birthday is an Australian public holiday but the date varies across
      * states and territories. Australia celebrates this holiday because it is a constitutional
      * monarchy, with the English monarch as head of state.
      *
@@ -65,7 +142,7 @@ class Queensland extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    protected function calculateQueensBirthday(): void
+    protected function calculateMonarchsBirthday(): void
     {
         $birthDay = "first monday of october {$this->year}";
 
@@ -73,9 +150,11 @@ class Queensland extends Australia
             $birthDay = "second monday of june {$this->year}";
         }
 
+        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
+
         $this->addHoliday(new Holiday(
-            'queensBirthday',
-            [],
+            'monarchsBirthday',
+            ['en' => $name],
             new \DateTime($birthDay, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL

--- a/src/Yasumi/Provider/Australia/Queensland.php
+++ b/src/Yasumi/Provider/Australia/Queensland.php
@@ -150,15 +150,9 @@ class Queensland extends Australia
             $birthDay = "second monday of june {$this->year}";
         }
 
-        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
-
-        $this->addHoliday(new Holiday(
-            'monarchsBirthday',
-            ['en' => $name],
-            new \DateTime($birthDay, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_OFFICIAL
-        ));
+        $this->addMonarchsBirthdayHoliday(
+            new \DateTime($birthDay, DateTimeZoneFactory::getDateTimeZone($this->timezone))
+        );
     }
 
     /**

--- a/src/Yasumi/Provider/Australia/SouthAustralia.php
+++ b/src/Yasumi/Provider/Australia/SouthAustralia.php
@@ -33,7 +33,7 @@ class SouthAustralia extends Australia
      */
     public const ID = 'AU-SA';
 
-    public string $timezone = 'Australia/South';
+    public string $timezone = 'Australia/Adelaide';
 
     /**
      * Initialize holidays for South Australia (Australia).
@@ -47,7 +47,12 @@ class SouthAustralia extends Australia
         parent::initialize();
 
         $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
-        $this->calculateQueensBirthday();
+
+        if ($this->year >= 2024) {
+            $this->addHoliday($this->easterSunday($this->year, $this->timezone, $this->locale));
+        }
+
+        $this->calculateMonarchsBirthday();
         $this->calculateLabourDay();
         $this->calculateAdelaideCupDay();
 
@@ -99,9 +104,44 @@ class SouthAustralia extends Australia
     }
 
     /**
-     * Queens Birthday.
+     * Easter Sunday.
      *
-     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * Only a public holiday from 2024 onwards (via Public Holidays Act 2023).
+     *
+     * @see https://en.wikipedia.org/wiki/Easter
+     * @see https://www.safework.sa.gov.au/resources/public-holidays
+     *
+     * @param int         $year     the year for which Easter Sunday need to be created
+     * @param string      $timezone the timezone in which Easter Sunday is celebrated
+     * @param string      $locale   the locale for which Easter Sunday need to be displayed in
+     * @param string|null $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                              TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @throws \Exception
+     */
+    protected function easterSunday(
+        int $year,
+        string $timezone,
+        string $locale,
+        ?string $type = null,
+    ): Holiday {
+        return new Holiday(
+            'easter',
+            ['en' => 'Easter Sunday'],
+            $this->calculateEaster($year, $timezone),
+            $locale,
+            $type ?? Holiday::TYPE_OFFICIAL
+        );
+    }
+
+    /**
+     * Monarch's Birthday.
+     *
+     * The Monarch's Birthday is an Australian public holiday but the date varies across
      * states and territories. Australia celebrates this holiday because it is a constitutional
      * monarchy, with the English monarch as head of state.
      *
@@ -113,11 +153,13 @@ class SouthAustralia extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    protected function calculateQueensBirthday(): void
+    protected function calculateMonarchsBirthday(): void
     {
+        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
+
         $this->addHoliday(new Holiday(
-            'queensBirthday',
-            [],
+            'monarchsBirthday',
+            ['en' => $name],
             new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL

--- a/src/Yasumi/Provider/Australia/SouthAustralia.php
+++ b/src/Yasumi/Provider/Australia/SouthAustralia.php
@@ -21,6 +21,7 @@ use Yasumi\Exception\UnknownLocaleException;
 use Yasumi\Holiday;
 use Yasumi\Provider\Australia;
 use Yasumi\Provider\DateTimeZoneFactory;
+use Yasumi\SubstituteHoliday;
 
 /**
  * Provider for all holidays in South Australia (Australia).
@@ -32,6 +33,10 @@ class SouthAustralia extends Australia
      * country or sub-region.
      */
     public const ID = 'AU-SA';
+
+    private const EASTER_SUNDAY_ESTABLISHMENT_YEAR = 2024;
+
+    private const PROCLAMATION_DAY_SUBSTITUTE_YEAR = 2024;
 
     public string $timezone = 'Australia/Adelaide';
 
@@ -48,7 +53,7 @@ class SouthAustralia extends Australia
 
         $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
 
-        if ($this->year >= 2024) {
+        if ($this->year >= self::EASTER_SUNDAY_ESTABLISHMENT_YEAR) {
             $this->addHoliday($this->easterSunday($this->year, $this->timezone, $this->locale));
         }
 
@@ -155,15 +160,9 @@ class SouthAustralia extends Australia
      */
     protected function calculateMonarchsBirthday(): void
     {
-        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
-
-        $this->addHoliday(new Holiday(
-            'monarchsBirthday',
-            ['en' => $name],
-            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_OFFICIAL
-        ));
+        $this->addMonarchsBirthdayHoliday(
+            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone))
+        );
     }
 
     /**
@@ -213,6 +212,7 @@ class SouthAustralia extends Australia
     protected function calculateProclamationDay(): void
     {
         $christmasDay = new \DateTime("{$this->year}-12-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $proclamationDay = new \DateTime("{$this->year}-12-26", DateTimeZoneFactory::getDateTimeZone($this->timezone));
 
         $this->addHoliday(new Holiday(
             'christmasDay',
@@ -221,6 +221,29 @@ class SouthAustralia extends Australia
             $this->locale,
             Holiday::TYPE_OFFICIAL
         ));
+
+        if ($this->year >= self::PROCLAMATION_DAY_SUBSTITUTE_YEAR && 5 === (int) $christmasDay->format('w')) {
+            $holiday = new Holiday(
+                'proclamationDay',
+                ['en' => 'Proclamation Day'],
+                $proclamationDay,
+                $this->locale,
+                Holiday::TYPE_OFFICIAL
+            );
+
+            $this->addHoliday($holiday);
+
+            $proclamationDay->add(new \DateInterval('P2D'));
+            $this->addHoliday(new SubstituteHoliday(
+                $holiday,
+                [],
+                $proclamationDay,
+                $this->locale,
+                Holiday::TYPE_OFFICIAL
+            ));
+
+            return;
+        }
 
         switch ($christmasDay->format('w')) {
             case 0: // sunday

--- a/src/Yasumi/Provider/Australia/Tasmania.php
+++ b/src/Yasumi/Provider/Australia/Tasmania.php
@@ -80,15 +80,9 @@ class Tasmania extends Australia
      */
     protected function calculateMonarchsBirthday(): void
     {
-        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
-
-        $this->addHoliday(new Holiday(
-            'monarchsBirthday',
-            ['en' => $name],
-            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_OFFICIAL
-        ));
+        $this->addMonarchsBirthdayHoliday(
+            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone))
+        );
     }
 
     /**

--- a/src/Yasumi/Provider/Australia/Tasmania.php
+++ b/src/Yasumi/Provider/Australia/Tasmania.php
@@ -33,7 +33,7 @@ class Tasmania extends Australia
      */
     public const ID = 'AU-TAS';
 
-    public string $timezone = 'Australia/Tasmania';
+    public string $timezone = 'Australia/Hobart';
 
     /**
      * Initialize holidays for Tasmania (Australia).
@@ -47,7 +47,7 @@ class Tasmania extends Australia
         parent::initialize();
 
         $this->calculateEightHoursDay();
-        $this->calculateQueensBirthday();
+        $this->calculateMonarchsBirthday();
         $this->calculateRecreationDay();
     }
 
@@ -64,9 +64,9 @@ class Tasmania extends Australia
     }
 
     /**
-     * Queens Birthday.
+     * Monarch's Birthday.
      *
-     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * The Monarch's Birthday is an Australian public holiday but the date varies across
      * states and territories. Australia celebrates this holiday because it is a constitutional
      * monarchy, with the English monarch as head of state.
      *
@@ -78,11 +78,13 @@ class Tasmania extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    protected function calculateQueensBirthday(): void
+    protected function calculateMonarchsBirthday(): void
     {
+        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
+
         $this->addHoliday(new Holiday(
-            'queensBirthday',
-            [],
+            'monarchsBirthday',
+            ['en' => $name],
             new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL

--- a/src/Yasumi/Provider/Australia/Victoria.php
+++ b/src/Yasumi/Provider/Australia/Victoria.php
@@ -153,15 +153,9 @@ class Victoria extends Australia
      */
     protected function calculateMonarchsBirthday(): void
     {
-        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
-
-        $this->addHoliday(new Holiday(
-            'monarchsBirthday',
-            ['en' => $name],
-            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_OFFICIAL
-        ));
+        $this->addMonarchsBirthdayHoliday(
+            new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone))
+        );
     }
 
     /**

--- a/src/Yasumi/Provider/Australia/Victoria.php
+++ b/src/Yasumi/Provider/Australia/Victoria.php
@@ -33,7 +33,7 @@ class Victoria extends Australia
      */
     public const ID = 'AU-VIC';
 
-    public string $timezone = 'Australia/Victoria';
+    public string $timezone = 'Australia/Melbourne';
 
     /**
      * Initialize holidays for Victoria (Australia).
@@ -49,7 +49,7 @@ class Victoria extends Australia
         $this->addHoliday($this->easterSunday($this->year, $this->timezone, $this->locale));
         $this->addHoliday($this->easterSaturday($this->year, $this->timezone, $this->locale));
         $this->calculateLabourDay();
-        $this->calculateQueensBirthday();
+        $this->calculateMonarchsBirthday();
         $this->calculateMelbourneCupDay();
         $this->calculateAFLGrandFinalDay();
     }
@@ -137,9 +137,9 @@ class Victoria extends Australia
     }
 
     /**
-     * Queens Birthday.
+     * Monarch's Birthday.
      *
-     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * The Monarch's Birthday is an Australian public holiday but the date varies across
      * states and territories. Australia celebrates this holiday because it is a constitutional
      * monarchy, with the English monarch as head of state.
      *
@@ -151,11 +151,13 @@ class Victoria extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    protected function calculateQueensBirthday(): void
+    protected function calculateMonarchsBirthday(): void
     {
+        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
+
         $this->addHoliday(new Holiday(
-            'queensBirthday',
-            [],
+            'monarchsBirthday',
+            ['en' => $name],
             new \DateTime("second monday of june {$this->year}", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL
@@ -177,39 +179,35 @@ class Victoria extends Australia
     /**
      * AFL Grand Final Day.
      *
+     * The Friday before the AFL Grand Final is a public holiday in Victoria. The date varies each year
+     * depending on the AFL schedule.
+     *
      * @throws \Exception
      */
     protected function calculateAFLGrandFinalDay(): void
     {
-        switch ($this->year) {
-            case 2015:
-                $aflGrandFinalFriday = '2015-10-02';
-                break;
-            case 2016:
-                $aflGrandFinalFriday = '2016-09-30';
-                break;
-            case 2017:
-                $aflGrandFinalFriday = '2017-09-29';
-                break;
-            case 2018:
-                $aflGrandFinalFriday = '2018-09-28';
-                break;
-            case 2019:
-                $aflGrandFinalFriday = '2019-09-27';
-                break;
-            case 2020:
-                $aflGrandFinalFriday = '2020-09-25';
-                break;
-            default:
-                return;
-        }
+        $dates = [
+            2015 => '2015-10-02',
+            2016 => '2016-09-30',
+            2017 => '2017-09-29',
+            2018 => '2018-09-28',
+            2019 => '2019-09-27',
+            2020 => '2020-09-25',
+            2021 => '2021-09-24',
+            2022 => '2022-09-23',
+            2023 => '2023-09-29',
+            2024 => '2024-09-27',
+            2025 => '2025-09-26',
+        ];
 
-        $date = new \DateTime($aflGrandFinalFriday, DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        if (! isset($dates[$this->year])) {
+            return;
+        }
 
         $this->addHoliday(new Holiday(
             'aflGrandFinalFriday',
             ['en' => 'AFL Grand Final Friday'],
-            $date,
+            new \DateTime($dates[$this->year], DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale
         ));
     }

--- a/src/Yasumi/Provider/Australia/WesternAustralia.php
+++ b/src/Yasumi/Provider/Australia/WesternAustralia.php
@@ -156,15 +156,9 @@ class WesternAustralia extends Australia
             $birthDay = '2024-09-23';
         }
 
-        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
-
-        $this->addHoliday(new Holiday(
-            'monarchsBirthday',
-            ['en' => $name],
-            new \DateTime($birthDay, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
-            $this->locale,
-            Holiday::TYPE_OFFICIAL
-        ));
+        $this->addMonarchsBirthdayHoliday(
+            new \DateTime($birthDay, DateTimeZoneFactory::getDateTimeZone($this->timezone))
+        );
     }
 
     /**

--- a/src/Yasumi/Provider/Australia/WesternAustralia.php
+++ b/src/Yasumi/Provider/Australia/WesternAustralia.php
@@ -33,7 +33,7 @@ class WesternAustralia extends Australia
      */
     public const ID = 'AU-WA';
 
-    public string $timezone = 'Australia/West';
+    public string $timezone = 'Australia/Perth';
 
     /**
      * Initialize holidays for Western Australia (Australia).
@@ -46,15 +46,90 @@ class WesternAustralia extends Australia
     {
         parent::initialize();
 
-        $this->calculateQueensBirthday();
+        if ($this->year >= 2022) {
+            $this->addHoliday($this->easterSunday($this->year, $this->timezone, $this->locale));
+        }
+
+        $this->calculateMonarchsBirthday();
         $this->calculateLabourDay();
         $this->calculateWesternAustraliaDay();
+        $this->calculateAnzacDayMonday();
     }
 
     /**
-     * Queens Birthday.
+     * Easter Sunday.
      *
-     * The Queen's Birthday is an Australian public holiday but the date varies across
+     * Easter is a festival and holiday celebrating the resurrection of Jesus Christ from the dead. Easter is celebrated
+     * on a date based on a certain number of days after March 21st. The date of Easter Day was defined by the Council
+     * of Nicaea in AD325 as the Sunday after the first full moon which falls on or after the Spring Equinox.
+     *
+     * @see https://en.wikipedia.org/wiki/Easter
+     * @see https://www.wa.gov.au/service/employment/workplace-arrangements/public-holidays-western-australia
+     *
+     * @param int         $year     the year for which Easter Sunday need to be created
+     * @param string      $timezone the timezone in which Easter Sunday is celebrated
+     * @param string      $locale   the locale for which Easter Sunday need to be displayed in
+     * @param string|null $type     The type of holiday. Use the following constants: TYPE_OFFICIAL, TYPE_OBSERVANCE,
+     *                              TYPE_SEASON, TYPE_BANK or TYPE_OTHER. By default an official holiday is considered.
+     *
+     * @throws \Exception
+     */
+    protected function easterSunday(
+        int $year,
+        string $timezone,
+        string $locale,
+        ?string $type = null,
+    ): Holiday {
+        return new Holiday(
+            'easter',
+            ['en' => 'Easter Sunday'],
+            $this->calculateEaster($year, $timezone),
+            $locale,
+            $type ?? Holiday::TYPE_OFFICIAL
+        );
+    }
+
+    /**
+     * ANZAC Day Monday substitute.
+     *
+     * When ANZAC Day (April 25) falls on a Saturday or Sunday, the following Monday is an additional public holiday
+     * in this state/territory.
+     *
+     * @see https://en.wikipedia.org/wiki/Anzac_Day
+     * @see https://www.timeanddate.com/holidays/australia/anzac-day
+     *
+     * @throws \Exception
+     */
+    protected function calculateAnzacDayMonday(): void
+    {
+        if ($this->year < 1972) {
+            return;
+        }
+
+        $date = new \DateTime("{$this->year}-04-25", DateTimeZoneFactory::getDateTimeZone($this->timezone));
+        $dow = (int) $date->format('w');
+
+        if (6 === $dow) { // Saturday → Monday
+            $date->add(new \DateInterval('P2D'));
+        } elseif (0 === $dow) { // Sunday → Monday
+            $date->add(new \DateInterval('P1D'));
+        } else {
+            return;
+        }
+
+        $this->addHoliday(new Holiday(
+            'anzacDayMonday',
+            ['en' => 'ANZAC Day'],
+            $date,
+            $this->locale,
+            Holiday::TYPE_OFFICIAL
+        ));
+    }
+
+    /**
+     * Monarch's Birthday.
+     *
+     * The Monarch's Birthday is an Australian public holiday but the date varies across
      * states and territories. Australia celebrates this holiday because it is a constitutional
      * monarchy, with the English monarch as head of state.
      *
@@ -66,7 +141,7 @@ class WesternAustralia extends Australia
      * @throws \InvalidArgumentException
      * @throws \Exception
      */
-    protected function calculateQueensBirthday(): void
+    protected function calculateMonarchsBirthday(): void
     {
         $birthDay = "last monday of september {$this->year}";
         if (2011 === $this->year) {
@@ -77,9 +152,15 @@ class WesternAustralia extends Australia
             $birthDay = '2012-10-01';
         }
 
+        if (2024 === $this->year) {
+            $birthDay = '2024-09-23';
+        }
+
+        $name = $this->year >= 2023 ? 'King’s Birthday' : 'Queen’s Birthday';
+
         $this->addHoliday(new Holiday(
-            'queensBirthday',
-            [],
+            'monarchsBirthday',
+            ['en' => $name],
             new \DateTime($birthDay, DateTimeZoneFactory::getDateTimeZone($this->timezone)),
             $this->locale,
             Holiday::TYPE_OFFICIAL

--- a/src/Yasumi/data/translations/monarchsBirthday.php
+++ b/src/Yasumi/data/translations/monarchsBirthday.php
@@ -15,11 +15,11 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-namespace Yasumi\tests\Australia\Tasmania\South\Southeast;
-
-/**
- * Class for testing Monarch's Birthday in southeastern Tasmania (Australia)..
- */
-class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\South\QueensBirthdayTest
-{
-}
+// Translations for Monarch's Birthday
+return [
+    'da' => 'Dronningens fødselsdag',
+    'en' => 'Monarch’s Birthday',
+    'fr' => 'Anniversaire officiel de la reine',
+    'pt' => 'Aniversário da Rainha',
+    'ru' => 'Официальный день рождения королевы',
+];

--- a/tests/Australia/AustralianCapitalTerritory/AnzacDayMondayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/AnzacDayMondayTest.php
@@ -15,28 +15,25 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-namespace Yasumi\tests\Australia\Victoria;
+namespace Yasumi\tests\Australia\AustralianCapitalTerritory;
 
 use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Monarch's Birthday in Victoria (Australia)..
+ * Class for testing ANZAC Day Monday substitute in Australian Capital Territory (Australia).
+ *
+ * When ANZAC Day (April 25) falls on a Saturday or Sunday, the following Monday is a public holiday.
  */
-class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
+class AnzacDayMondayTest extends AustralianCapitalTerritoryBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'monarchsBirthday';
+    public const HOLIDAY = 'anzacDayMonday';
 
     /**
-     * The year in which the holiday was first established.
-     */
-    public const ESTABLISHMENT_YEAR = 1950;
-
-    /**
-     * Tests Monarch's Birthday.
+     * Tests ANZAC Day Monday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -62,24 +59,21 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
     public static function HolidayDataProvider(): array
     {
         return [
-            [2010, '2010-06-14'],
-            [2011, '2011-06-13'],
-            [2012, '2012-06-11'],
-            [2013, '2013-06-10'],
-            [2014, '2014-06-09'],
-            [2015, '2015-06-08'],
-            [2016, '2016-06-13'],
-            [2017, '2017-06-12'],
-            [2018, '2018-06-11'],
-            [2019, '2019-06-10'],
-            [2020, '2020-06-08'],
-            [2021, '2021-06-14'],
-            [2022, '2022-06-13'],
-            [2023, '2023-06-12'],
-            [2024, '2024-06-10'],
-            [2025, '2025-06-09'],
-            [2026, '2026-06-08'],
+            [2020, '2020-04-27'], // April 25 = Saturday → Monday 27th
+            [2021, '2021-04-26'], // April 25 = Sunday → Monday 26th
+            [2026, '2026-04-27'], // April 25 = Saturday → Monday 27th
         ];
+    }
+
+    /**
+     * Tests that ANZAC Day Monday is NOT a holiday when April 25 is a weekday.
+     *
+     * @throws \Exception
+     */
+    public function testNotHoliday(): void
+    {
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2019);
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2022);
     }
 
     /**
@@ -92,14 +86,8 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
-            [self::LOCALE => 'Queen’s Birthday']
-        );
-        $this->assertTranslatedHolidayName(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(2023),
-            [self::LOCALE => 'King’s Birthday']
+            2026,
+            [self::LOCALE => 'ANZAC Day']
         );
     }
 
@@ -110,11 +98,6 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_OFFICIAL
-        );
+        $this->assertHolidayType($this->region, self::HOLIDAY, 2026, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryBaseTestCase.php
+++ b/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryBaseTestCase.php
@@ -28,10 +28,10 @@ abstract class AustralianCapitalTerritoryBaseTestCase extends AustraliaBaseTestC
     use YasumiBase;
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'Australia/ACT';
+    public const TIMEZONE = 'Australia/Sydney';
 
     /** Name of the region (e.g. country / state) to be tested. */
     public string $region = 'Australia\AustralianCapitalTerritory';
 
-    public string $timezone = 'Australia/ACT';
+    public string $timezone = 'Australia/Sydney';
 }

--- a/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/AustralianCapitalTerritoryTest.php
@@ -55,7 +55,7 @@ class AustralianCapitalTerritoryTest extends AustralianCapitalTerritoryBaseTestC
             'anzacDay',
             'easter',
             'easterSaturday',
-            'queensBirthday',
+            'monarchsBirthday',
             'labourDay',
             'canberraDay',
             'reconciliationDay',
@@ -63,6 +63,11 @@ class AustralianCapitalTerritoryTest extends AustralianCapitalTerritoryBaseTestC
 
         if (2022 === $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+
+        $anzacDay = new \DateTime("{$this->year}-04-25", new \DateTimeZone(self::TIMEZONE));
+        if ($this->year >= 2020 && in_array((int) $anzacDay->format('w'), [0, 6], true)) {
+            $expectedHolidays[] = 'anzacDayMonday';
         }
 
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/AustralianCapitalTerritory/QueensBirthdayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/QueensBirthdayTest.php
@@ -21,14 +21,14 @@ use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Queen's Birthday in Australian Capital Territory (Australia)..
+ * Class for testing Monarch's Birthday in Australian Capital Territory (Australia)..
  */
 class QueensBirthdayTest extends AustralianCapitalTerritoryBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'queensBirthday';
+    public const HOLIDAY = 'monarchsBirthday';
 
     /**
      * The year in which the holiday was first established.
@@ -36,7 +36,7 @@ class QueensBirthdayTest extends AustralianCapitalTerritoryBaseTestCase implemen
     public const ESTABLISHMENT_YEAR = 1950;
 
     /**
-     * Tests Queen's Birthday.
+     * Tests Monarch's Birthday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -73,6 +73,12 @@ class QueensBirthdayTest extends AustralianCapitalTerritoryBaseTestCase implemen
             [2018, '2018-06-11'],
             [2019, '2019-06-10'],
             [2020, '2020-06-08'],
+            [2021, '2021-06-14'],
+            [2022, '2022-06-13'],
+            [2023, '2023-06-12'],
+            [2024, '2024-06-10'],
+            [2025, '2025-06-09'],
+            [2026, '2026-06-08'],
         ];
     }
 
@@ -86,8 +92,14 @@ class QueensBirthdayTest extends AustralianCapitalTerritoryBaseTestCase implemen
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
             [self::LOCALE => 'Queen’s Birthday']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            static::generateRandomYear(2023),
+            [self::LOCALE => 'King’s Birthday']
         );
     }
 

--- a/tests/Australia/AustralianCapitalTerritory/QueensBirthdayTest.php
+++ b/tests/Australia/AustralianCapitalTerritory/QueensBirthdayTest.php
@@ -18,6 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\AustralianCapitalTerritory;
 
 use Yasumi\Holiday;
+use Yasumi\tests\Australia\MonarchsBirthdayTransitionTestTrait;
 use Yasumi\tests\HolidayTestCase;
 
 /**
@@ -25,6 +26,8 @@ use Yasumi\tests\HolidayTestCase;
  */
 class QueensBirthdayTest extends AustralianCapitalTerritoryBaseTestCase implements HolidayTestCase
 {
+    use MonarchsBirthdayTransitionTestTrait;
+
     /**
      * The name of the holiday.
      */
@@ -57,7 +60,7 @@ class QueensBirthdayTest extends AustralianCapitalTerritoryBaseTestCase implemen
     /**
      * Returns a list of test dates.
      *
-     * @return array<array> list of test dates for the holiday defined in this test
+     * @return array<int, array{int, string}> list of test dates for the holiday defined in this test
      */
     public static function HolidayDataProvider(): array
     {

--- a/tests/Australia/MonarchsBirthdayTransitionTestTrait.php
+++ b/tests/Australia/MonarchsBirthdayTransitionTestTrait.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Australia;
+
+use Yasumi\Holiday;
+use Yasumi\Yasumi;
+
+trait MonarchsBirthdayTransitionTestTrait
+{
+    /**
+     * Tests the 2022 to 2023 monarchy transition and deprecated holiday alias.
+     *
+     * @throws \Exception
+     */
+    public function testMonarchsBirthdayNameTransition(): void
+    {
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            'monarchsBirthday',
+            2022,
+            ['en_AU' => 'Queen’s Birthday']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            'monarchsBirthday',
+            2023,
+            ['en_AU' => 'King’s Birthday']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            'queensBirthday',
+            2022,
+            ['en_AU' => 'Queen’s Birthday']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            'queensBirthday',
+            2023,
+            ['en_AU' => 'King’s Birthday']
+        );
+    }
+
+    /**
+     * Tests the deprecated Queen's Birthday key aliases the Monarch's Birthday date.
+     *
+     * @throws \Exception
+     */
+    public function testQueensBirthdayAliasMatchesMonarchsBirthday(): void
+    {
+        foreach ([2022, 2023] as $year) {
+            $holidays = Yasumi::create($this->region, $year);
+            $monarchsBirthday = $holidays->getHoliday('monarchsBirthday');
+            $queensBirthday = $holidays->getHoliday('queensBirthday');
+
+            self::assertInstanceOf(Holiday::class, $monarchsBirthday);
+            self::assertInstanceOf(Holiday::class, $queensBirthday);
+            self::assertSame($monarchsBirthday->format('Y-m-d'), $queensBirthday->format('Y-m-d'));
+        }
+    }
+}

--- a/tests/Australia/NewSouthWales/AnzacDayMondayTest.php
+++ b/tests/Australia/NewSouthWales/AnzacDayMondayTest.php
@@ -15,28 +15,25 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-namespace Yasumi\tests\Australia\Victoria;
+namespace Yasumi\tests\Australia\NewSouthWales;
 
 use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Monarch's Birthday in Victoria (Australia)..
+ * Class for testing ANZAC Day Monday substitute in New South Wales (Australia).
+ *
+ * When ANZAC Day (April 25) falls on a Saturday or Sunday, the following Monday is a public holiday.
  */
-class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
+class AnzacDayMondayTest extends NewSouthWalesBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'monarchsBirthday';
+    public const HOLIDAY = 'anzacDayMonday';
 
     /**
-     * The year in which the holiday was first established.
-     */
-    public const ESTABLISHMENT_YEAR = 1950;
-
-    /**
-     * Tests Monarch's Birthday.
+     * Tests ANZAC Day Monday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -62,24 +59,21 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
     public static function HolidayDataProvider(): array
     {
         return [
-            [2010, '2010-06-14'],
-            [2011, '2011-06-13'],
-            [2012, '2012-06-11'],
-            [2013, '2013-06-10'],
-            [2014, '2014-06-09'],
-            [2015, '2015-06-08'],
-            [2016, '2016-06-13'],
-            [2017, '2017-06-12'],
-            [2018, '2018-06-11'],
-            [2019, '2019-06-10'],
-            [2020, '2020-06-08'],
-            [2021, '2021-06-14'],
-            [2022, '2022-06-13'],
-            [2023, '2023-06-12'],
-            [2024, '2024-06-10'],
-            [2025, '2025-06-09'],
-            [2026, '2026-06-08'],
+            [2026, '2026-04-27'], // April 25 = Saturday → Monday 27th
+            [2027, '2027-04-26'], // April 25 = Sunday → Monday 26th
         ];
+    }
+
+    /**
+     * Tests that ANZAC Day Monday is NOT a holiday when April 25 is a weekday.
+     *
+     * @throws \Exception
+     */
+    public function testNotHoliday(): void
+    {
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2021);
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2025);
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2022);
     }
 
     /**
@@ -92,14 +86,8 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
-            [self::LOCALE => 'Queen’s Birthday']
-        );
-        $this->assertTranslatedHolidayName(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(2023),
-            [self::LOCALE => 'King’s Birthday']
+            2027,
+            [self::LOCALE => 'ANZAC Day']
         );
     }
 
@@ -110,11 +98,6 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_OFFICIAL
-        );
+        $this->assertHolidayType($this->region, self::HOLIDAY, 2027, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/NewSouthWales/NewSouthWalesBaseTestCase.php
+++ b/tests/Australia/NewSouthWales/NewSouthWalesBaseTestCase.php
@@ -28,10 +28,10 @@ abstract class NewSouthWalesBaseTestCase extends AustraliaBaseTestCase
     use YasumiBase;
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'Australia/NSW';
+    public const TIMEZONE = 'Australia/Sydney';
 
     /** Name of the region (e.g. country / state) to be tested. */
     public string $region = 'Australia\NewSouthWales';
 
-    public string $timezone = 'Australia/NSW';
+    public string $timezone = 'Australia/Sydney';
 }

--- a/tests/Australia/NewSouthWales/NewSouthWalesTest.php
+++ b/tests/Australia/NewSouthWales/NewSouthWalesTest.php
@@ -55,12 +55,16 @@ class NewSouthWalesTest extends NewSouthWalesBaseTestCase implements ProviderTes
             'anzacDay',
             'easter',
             'easterSaturday',
-            'queensBirthday',
+            'monarchsBirthday',
             'labourDay',
         ];
 
         if (2022 === $this->year) {
             $holidays[] = 'nationalDayOfMourning';
+        }
+
+        if (2026 === $this->year || 2027 === $this->year) {
+            $holidays[] = 'anzacDayMonday';
         }
 
         $this->assertDefinedHolidays($holidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/NewSouthWales/QueensBirthdayTest.php
+++ b/tests/Australia/NewSouthWales/QueensBirthdayTest.php
@@ -21,14 +21,14 @@ use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Queen's Birthday in New South Wales (Australia)..
+ * Class for testing Monarch's Birthday in New South Wales (Australia)..
  */
 class QueensBirthdayTest extends NewSouthWalesBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'queensBirthday';
+    public const HOLIDAY = 'monarchsBirthday';
 
     /**
      * The year in which the holiday was first established.
@@ -36,7 +36,7 @@ class QueensBirthdayTest extends NewSouthWalesBaseTestCase implements HolidayTes
     public const ESTABLISHMENT_YEAR = 1950;
 
     /**
-     * Tests Queen's Birthday.
+     * Tests Monarch's Birthday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -73,6 +73,12 @@ class QueensBirthdayTest extends NewSouthWalesBaseTestCase implements HolidayTes
             [2018, '2018-06-11'],
             [2019, '2019-06-10'],
             [2020, '2020-06-08'],
+            [2021, '2021-06-14'],
+            [2022, '2022-06-13'],
+            [2023, '2023-06-12'],
+            [2024, '2024-06-10'],
+            [2025, '2025-06-09'],
+            [2026, '2026-06-08'],
         ];
     }
 
@@ -86,8 +92,14 @@ class QueensBirthdayTest extends NewSouthWalesBaseTestCase implements HolidayTes
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
             [self::LOCALE => 'Queen’s Birthday']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            static::generateRandomYear(2023),
+            [self::LOCALE => 'King’s Birthday']
         );
     }
 

--- a/tests/Australia/NewSouthWales/QueensBirthdayTest.php
+++ b/tests/Australia/NewSouthWales/QueensBirthdayTest.php
@@ -18,6 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\NewSouthWales;
 
 use Yasumi\Holiday;
+use Yasumi\tests\Australia\MonarchsBirthdayTransitionTestTrait;
 use Yasumi\tests\HolidayTestCase;
 
 /**
@@ -25,6 +26,8 @@ use Yasumi\tests\HolidayTestCase;
  */
 class QueensBirthdayTest extends NewSouthWalesBaseTestCase implements HolidayTestCase
 {
+    use MonarchsBirthdayTransitionTestTrait;
+
     /**
      * The name of the holiday.
      */
@@ -57,7 +60,7 @@ class QueensBirthdayTest extends NewSouthWalesBaseTestCase implements HolidayTes
     /**
      * Returns a list of test dates.
      *
-     * @return array<array> list of test dates for the holiday defined in this test
+     * @return array<int, array{int, string}> list of test dates for the holiday defined in this test
      */
     public static function HolidayDataProvider(): array
     {

--- a/tests/Australia/NorthernTerritory/AnzacDayMondayTest.php
+++ b/tests/Australia/NorthernTerritory/AnzacDayMondayTest.php
@@ -15,28 +15,23 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-namespace Yasumi\tests\Australia\Victoria;
+namespace Yasumi\tests\Australia\NorthernTerritory;
 
 use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Monarch's Birthday in Victoria (Australia)..
+ * Class for testing ANZAC Day Monday substitute in Northern Territory (Australia).
  */
-class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
+class AnzacDayMondayTest extends NorthernTerritoryBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'monarchsBirthday';
+    public const HOLIDAY = 'anzacDayMonday';
 
     /**
-     * The year in which the holiday was first established.
-     */
-    public const ESTABLISHMENT_YEAR = 1950;
-
-    /**
-     * Tests Monarch's Birthday.
+     * Tests ANZAC Day Monday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -62,24 +57,20 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
     public static function HolidayDataProvider(): array
     {
         return [
-            [2010, '2010-06-14'],
-            [2011, '2011-06-13'],
-            [2012, '2012-06-11'],
-            [2013, '2013-06-10'],
-            [2014, '2014-06-09'],
-            [2015, '2015-06-08'],
-            [2016, '2016-06-13'],
-            [2017, '2017-06-12'],
-            [2018, '2018-06-11'],
-            [2019, '2019-06-10'],
-            [2020, '2020-06-08'],
-            [2021, '2021-06-14'],
-            [2022, '2022-06-13'],
-            [2023, '2023-06-12'],
-            [2024, '2024-06-10'],
-            [2025, '2025-06-09'],
-            [2026, '2026-06-08'],
+            [2027, '2027-04-26'],
+            [2032, '2032-04-26'],
         ];
+    }
+
+    /**
+     * Tests that ANZAC Day Monday is not defined when April 25 is not a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testNotHoliday(): void
+    {
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2026);
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2028);
     }
 
     /**
@@ -92,14 +83,8 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
-            [self::LOCALE => 'Queen’s Birthday']
-        );
-        $this->assertTranslatedHolidayName(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(2023),
-            [self::LOCALE => 'King’s Birthday']
+            2027,
+            [self::LOCALE => 'ANZAC Day']
         );
     }
 
@@ -110,11 +95,6 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_OFFICIAL
-        );
+        $this->assertHolidayType($this->region, self::HOLIDAY, 2027, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/NorthernTerritory/EasterSundayTest.php
+++ b/tests/Australia/NorthernTerritory/EasterSundayTest.php
@@ -15,28 +15,23 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-namespace Yasumi\tests\Australia\Victoria;
+namespace Yasumi\tests\Australia\NorthernTerritory;
 
 use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Monarch's Birthday in Victoria (Australia)..
+ * Class for testing Easter Sunday in Northern Territory (Australia).
  */
-class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
+class EasterSundayTest extends NorthernTerritoryBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'monarchsBirthday';
+    public const HOLIDAY = 'easter';
 
     /**
-     * The year in which the holiday was first established.
-     */
-    public const ESTABLISHMENT_YEAR = 1950;
-
-    /**
-     * Tests Monarch's Birthday.
+     * Tests Easter Sunday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -58,28 +53,21 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      * Returns a list of test dates.
      *
      * @return array<array> list of test dates for the holiday defined in this test
+     *
+     * @throws \Exception
      */
     public static function HolidayDataProvider(): array
     {
-        return [
-            [2010, '2010-06-14'],
-            [2011, '2011-06-13'],
-            [2012, '2012-06-11'],
-            [2013, '2013-06-10'],
-            [2014, '2014-06-09'],
-            [2015, '2015-06-08'],
-            [2016, '2016-06-13'],
-            [2017, '2017-06-12'],
-            [2018, '2018-06-11'],
-            [2019, '2019-06-10'],
-            [2020, '2020-06-08'],
-            [2021, '2021-06-14'],
-            [2022, '2022-06-13'],
-            [2023, '2023-06-12'],
-            [2024, '2024-06-10'],
-            [2025, '2025-06-09'],
-            [2026, '2026-06-08'],
-        ];
+        $data = [];
+
+        for ($y = 0; $y < 50; ++$y) {
+            $year = static::generateRandomYear();
+            $date = static::computeEaster($year, self::TIMEZONE);
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
     }
 
     /**
@@ -92,14 +80,8 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
-            [self::LOCALE => 'Queen’s Birthday']
-        );
-        $this->assertTranslatedHolidayName(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(2023),
-            [self::LOCALE => 'King’s Birthday']
+            static::generateRandomYear(),
+            [self::LOCALE => 'Easter Sunday']
         );
     }
 
@@ -110,11 +92,6 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_OFFICIAL
-        );
+        $this->assertHolidayType($this->region, self::HOLIDAY, static::generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/NorthernTerritory/NorthernTerritoryBaseTestCase.php
+++ b/tests/Australia/NorthernTerritory/NorthernTerritoryBaseTestCase.php
@@ -28,10 +28,10 @@ abstract class NorthernTerritoryBaseTestCase extends AustraliaBaseTestCase
     use YasumiBase;
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'Australia/North';
+    public const TIMEZONE = 'Australia/Darwin';
 
     /** Name of the region (e.g. country / state) to be tested. */
     public string $region = 'Australia\NorthernTerritory';
 
-    public string $timezone = 'Australia/North';
+    public string $timezone = 'Australia/Darwin';
 }

--- a/tests/Australia/NorthernTerritory/NorthernTerritoryTest.php
+++ b/tests/Australia/NorthernTerritory/NorthernTerritoryTest.php
@@ -54,13 +54,19 @@ class NorthernTerritoryTest extends NorthernTerritoryBaseTestCase implements Pro
             'australiaDay',
             'anzacDay',
             'easterSaturday',
-            'queensBirthday',
+            'easter',
+            'monarchsBirthday',
             'mayDay',
             'picnicDay',
         ];
 
         if (2022 === $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
+        }
+
+        $anzacDay = new \DateTime("{$this->year}-04-25", new \DateTimeZone(self::TIMEZONE));
+        if (0 === (int) $anzacDay->format('w')) {
+            $expectedHolidays[] = 'anzacDayMonday';
         }
 
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);

--- a/tests/Australia/NorthernTerritory/QueensBirthdayTest.php
+++ b/tests/Australia/NorthernTerritory/QueensBirthdayTest.php
@@ -18,6 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\NorthernTerritory;
 
 use Yasumi\Holiday;
+use Yasumi\tests\Australia\MonarchsBirthdayTransitionTestTrait;
 use Yasumi\tests\HolidayTestCase;
 
 /**
@@ -25,6 +26,8 @@ use Yasumi\tests\HolidayTestCase;
  */
 class QueensBirthdayTest extends NorthernTerritoryBaseTestCase implements HolidayTestCase
 {
+    use MonarchsBirthdayTransitionTestTrait;
+
     /**
      * The name of the holiday.
      */
@@ -57,7 +60,7 @@ class QueensBirthdayTest extends NorthernTerritoryBaseTestCase implements Holida
     /**
      * Returns a list of test dates.
      *
-     * @return array<array> list of test dates for the holiday defined in this test
+     * @return array<int, array{int, string}> list of test dates for the holiday defined in this test
      */
     public static function HolidayDataProvider(): array
     {

--- a/tests/Australia/NorthernTerritory/QueensBirthdayTest.php
+++ b/tests/Australia/NorthernTerritory/QueensBirthdayTest.php
@@ -21,14 +21,14 @@ use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Queen's Birthday in Northern Territory (Australia).
+ * Class for testing Monarch's Birthday in Northern Territory (Australia).
  */
 class QueensBirthdayTest extends NorthernTerritoryBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'queensBirthday';
+    public const HOLIDAY = 'monarchsBirthday';
 
     /**
      * The year in which the holiday was first established.
@@ -36,7 +36,7 @@ class QueensBirthdayTest extends NorthernTerritoryBaseTestCase implements Holida
     public const ESTABLISHMENT_YEAR = 1950;
 
     /**
-     * Tests Queen's Birthday.
+     * Tests Monarch's Birthday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -73,6 +73,12 @@ class QueensBirthdayTest extends NorthernTerritoryBaseTestCase implements Holida
             [2018, '2018-06-11'],
             [2019, '2019-06-10'],
             [2020, '2020-06-08'],
+            [2021, '2021-06-14'],
+            [2022, '2022-06-13'],
+            [2023, '2023-06-12'],
+            [2024, '2024-06-10'],
+            [2025, '2025-06-09'],
+            [2026, '2026-06-08'],
         ];
     }
 
@@ -86,8 +92,14 @@ class QueensBirthdayTest extends NorthernTerritoryBaseTestCase implements Holida
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
             [self::LOCALE => 'Queen’s Birthday']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            static::generateRandomYear(2023),
+            [self::LOCALE => 'King’s Birthday']
         );
     }
 

--- a/tests/Australia/Queensland/Brisbane/BrisbaneTest.php
+++ b/tests/Australia/Queensland/Brisbane/BrisbaneTest.php
@@ -53,7 +53,7 @@ class BrisbaneTest extends BrisbaneBaseTestCase implements ProviderTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'labourDay',
             'peoplesDay',
         ];

--- a/tests/Australia/Queensland/Brisbane/QueensBirthdayTest.php
+++ b/tests/Australia/Queensland/Brisbane/QueensBirthdayTest.php
@@ -18,7 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Queensland\Brisbane;
 
 /**
- * Class for testing Queen's Birthday in Brisbane (Australia)..
+ * Class for testing Monarch's Birthday in Brisbane (Australia)..
  */
 class QueensBirthdayTest extends \Yasumi\tests\Australia\Queensland\QueensBirthdayTest
 {

--- a/tests/Australia/Queensland/EasterSaturdayTest.php
+++ b/tests/Australia/Queensland/EasterSaturdayTest.php
@@ -15,28 +15,23 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-namespace Yasumi\tests\Australia\Victoria;
+namespace Yasumi\tests\Australia\Queensland;
 
 use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Monarch's Birthday in Victoria (Australia)..
+ * Class for testing Easter Saturday in Queensland (Australia).
  */
-class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
+class EasterSaturdayTest extends QueenslandBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'monarchsBirthday';
+    public const HOLIDAY = 'easterSaturday';
 
     /**
-     * The year in which the holiday was first established.
-     */
-    public const ESTABLISHMENT_YEAR = 1950;
-
-    /**
-     * Tests Monarch's Birthday.
+     * Tests Easter Saturday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -58,28 +53,22 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      * Returns a list of test dates.
      *
      * @return array<array> list of test dates for the holiday defined in this test
+     *
+     * @throws \Exception
      */
     public static function HolidayDataProvider(): array
     {
-        return [
-            [2010, '2010-06-14'],
-            [2011, '2011-06-13'],
-            [2012, '2012-06-11'],
-            [2013, '2013-06-10'],
-            [2014, '2014-06-09'],
-            [2015, '2015-06-08'],
-            [2016, '2016-06-13'],
-            [2017, '2017-06-12'],
-            [2018, '2018-06-11'],
-            [2019, '2019-06-10'],
-            [2020, '2020-06-08'],
-            [2021, '2021-06-14'],
-            [2022, '2022-06-13'],
-            [2023, '2023-06-12'],
-            [2024, '2024-06-10'],
-            [2025, '2025-06-09'],
-            [2026, '2026-06-08'],
-        ];
+        $data = [];
+
+        for ($y = 0; $y < 50; ++$y) {
+            $year = static::generateRandomYear();
+            $date = static::computeEaster($year, self::TIMEZONE);
+            $date->sub(new \DateInterval('P1D'));
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
     }
 
     /**
@@ -92,14 +81,8 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
-            [self::LOCALE => 'Queen’s Birthday']
-        );
-        $this->assertTranslatedHolidayName(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(2023),
-            [self::LOCALE => 'King’s Birthday']
+            static::generateRandomYear(),
+            [self::LOCALE => 'Easter Saturday']
         );
     }
 
@@ -110,11 +93,6 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_OFFICIAL
-        );
+        $this->assertHolidayType($this->region, self::HOLIDAY, static::generateRandomYear(), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/Queensland/EasterSundayTest.php
+++ b/tests/Australia/Queensland/EasterSundayTest.php
@@ -15,28 +15,23 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-namespace Yasumi\tests\Australia\Victoria;
+namespace Yasumi\tests\Australia\Queensland;
 
 use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Monarch's Birthday in Victoria (Australia)..
+ * Class for testing Easter Sunday in Queensland (Australia).
  */
-class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
+class EasterSundayTest extends QueenslandBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'monarchsBirthday';
+    public const HOLIDAY = 'easter';
 
     /**
-     * The year in which the holiday was first established.
-     */
-    public const ESTABLISHMENT_YEAR = 1950;
-
-    /**
-     * Tests Monarch's Birthday.
+     * Tests Easter Sunday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -58,28 +53,21 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      * Returns a list of test dates.
      *
      * @return array<array> list of test dates for the holiday defined in this test
+     *
+     * @throws \Exception
      */
     public static function HolidayDataProvider(): array
     {
-        return [
-            [2010, '2010-06-14'],
-            [2011, '2011-06-13'],
-            [2012, '2012-06-11'],
-            [2013, '2013-06-10'],
-            [2014, '2014-06-09'],
-            [2015, '2015-06-08'],
-            [2016, '2016-06-13'],
-            [2017, '2017-06-12'],
-            [2018, '2018-06-11'],
-            [2019, '2019-06-10'],
-            [2020, '2020-06-08'],
-            [2021, '2021-06-14'],
-            [2022, '2022-06-13'],
-            [2023, '2023-06-12'],
-            [2024, '2024-06-10'],
-            [2025, '2025-06-09'],
-            [2026, '2026-06-08'],
-        ];
+        $data = [];
+
+        for ($y = 0; $y < 50; ++$y) {
+            $year = static::generateRandomYear(2017);
+            $date = static::computeEaster($year, self::TIMEZONE);
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
     }
 
     /**
@@ -92,15 +80,17 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
-            [self::LOCALE => 'Queen’s Birthday']
+            static::generateRandomYear(2017),
+            [self::LOCALE => 'Easter Sunday']
         );
-        $this->assertTranslatedHolidayName(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(2023),
-            [self::LOCALE => 'King’s Birthday']
-        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testNotHoliday(): void
+    {
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2016);
     }
 
     /**
@@ -110,11 +100,6 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_OFFICIAL
-        );
+        $this->assertHolidayType($this->region, self::HOLIDAY, static::generateRandomYear(2017), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/Queensland/LabourDayTest.php
+++ b/tests/Australia/Queensland/LabourDayTest.php
@@ -52,7 +52,7 @@ class LabourDayTest extends QueenslandBaseTestCase implements HolidayTestCase
     /**
      * Returns a list of test dates.
      *
-     * @return array<array> list of test dates for the holiday defined in this test
+     * @return array<int, array{int, string}> list of test dates for the holiday defined in this test
      */
     public static function HolidayDataProvider(): array
     {
@@ -68,6 +68,9 @@ class LabourDayTest extends QueenslandBaseTestCase implements HolidayTestCase
             [2018, '2018-05-07'],
             [2019, '2019-05-06'],
             [2020, '2020-05-04'],
+            [2024, '2024-05-06'],
+            [2025, '2025-05-05'],
+            [2026, '2026-05-04'],
         ];
     }
 

--- a/tests/Australia/Queensland/QueensBirthdayTest.php
+++ b/tests/Australia/Queensland/QueensBirthdayTest.php
@@ -18,6 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Queensland;
 
 use Yasumi\Holiday;
+use Yasumi\tests\Australia\MonarchsBirthdayTransitionTestTrait;
 use Yasumi\tests\HolidayTestCase;
 
 /**
@@ -25,6 +26,8 @@ use Yasumi\tests\HolidayTestCase;
  */
 class QueensBirthdayTest extends QueenslandBaseTestCase implements HolidayTestCase
 {
+    use MonarchsBirthdayTransitionTestTrait;
+
     /**
      * The name of the holiday.
      */
@@ -57,7 +60,7 @@ class QueensBirthdayTest extends QueenslandBaseTestCase implements HolidayTestCa
     /**
      * Returns a list of test dates.
      *
-     * @return array<array> list of test dates for the holiday defined in this test
+     * @return array<int, array{int, string}> list of test dates for the holiday defined in this test
      */
     public static function HolidayDataProvider(): array
     {

--- a/tests/Australia/Queensland/QueensBirthdayTest.php
+++ b/tests/Australia/Queensland/QueensBirthdayTest.php
@@ -21,14 +21,14 @@ use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Queen's Birthday in Queensland (Australia)..
+ * Class for testing Monarch's Birthday in Queensland (Australia)..
  */
 class QueensBirthdayTest extends QueenslandBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'queensBirthday';
+    public const HOLIDAY = 'monarchsBirthday';
 
     /**
      * The year in which the holiday was first established.
@@ -36,7 +36,7 @@ class QueensBirthdayTest extends QueenslandBaseTestCase implements HolidayTestCa
     public const ESTABLISHMENT_YEAR = 1950;
 
     /**
-     * Tests Queen's Birthday.
+     * Tests Monarch's Birthday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -73,6 +73,12 @@ class QueensBirthdayTest extends QueenslandBaseTestCase implements HolidayTestCa
             [2018, '2018-10-01'],
             [2019, '2019-10-07'],
             [2020, '2020-10-05'],
+            [2021, '2021-10-04'],
+            [2022, '2022-10-03'],
+            [2023, '2023-10-02'],
+            [2024, '2024-10-07'],
+            [2025, '2025-10-06'],
+            [2026, '2026-10-05'],
         ];
     }
 
@@ -86,8 +92,14 @@ class QueensBirthdayTest extends QueenslandBaseTestCase implements HolidayTestCa
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
             [self::LOCALE => 'Queen’s Birthday']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            static::generateRandomYear(2023),
+            [self::LOCALE => 'King’s Birthday']
         );
     }
 

--- a/tests/Australia/Queensland/QueenslandBaseTestCase.php
+++ b/tests/Australia/Queensland/QueenslandBaseTestCase.php
@@ -28,10 +28,10 @@ abstract class QueenslandBaseTestCase extends AustraliaBaseTestCase
     use YasumiBase;
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'Australia/Queensland';
+    public const TIMEZONE = 'Australia/Brisbane';
 
     /** Name of the region (e.g. country / state) to be tested. */
     public string $region = 'Australia\Queensland';
 
-    public string $timezone = 'Australia/Queensland';
+    public string $timezone = 'Australia/Brisbane';
 }

--- a/tests/Australia/Queensland/QueenslandTest.php
+++ b/tests/Australia/Queensland/QueenslandTest.php
@@ -53,9 +53,15 @@ class QueenslandTest extends QueenslandBaseTestCase implements ProviderTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'labourDay',
+            'easterSaturday',
         ];
+
+        if ($this->year >= 2017) {
+            $expectedHolidays[] = 'easter';
+        }
+
         if (2022 === $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }

--- a/tests/Australia/SouthAustralia/EasterSundayTest.php
+++ b/tests/Australia/SouthAustralia/EasterSundayTest.php
@@ -15,28 +15,25 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-namespace Yasumi\tests\Australia\Victoria;
+namespace Yasumi\tests\Australia\SouthAustralia;
 
 use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Monarch's Birthday in Victoria (Australia)..
+ * Class for testing Easter Sunday in South Australia (Australia).
+ *
+ * Easter Sunday is only a public holiday from 2024 onwards (via Public Holidays Act 2023).
  */
-class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
+class EasterSundayTest extends SouthAustraliaBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'monarchsBirthday';
+    public const HOLIDAY = 'easter';
 
     /**
-     * The year in which the holiday was first established.
-     */
-    public const ESTABLISHMENT_YEAR = 1950;
-
-    /**
-     * Tests Monarch's Birthday.
+     * Tests Easter Sunday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -58,28 +55,31 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      * Returns a list of test dates.
      *
      * @return array<array> list of test dates for the holiday defined in this test
+     *
+     * @throws \Exception
      */
     public static function HolidayDataProvider(): array
     {
-        return [
-            [2010, '2010-06-14'],
-            [2011, '2011-06-13'],
-            [2012, '2012-06-11'],
-            [2013, '2013-06-10'],
-            [2014, '2014-06-09'],
-            [2015, '2015-06-08'],
-            [2016, '2016-06-13'],
-            [2017, '2017-06-12'],
-            [2018, '2018-06-11'],
-            [2019, '2019-06-10'],
-            [2020, '2020-06-08'],
-            [2021, '2021-06-14'],
-            [2022, '2022-06-13'],
-            [2023, '2023-06-12'],
-            [2024, '2024-06-10'],
-            [2025, '2025-06-09'],
-            [2026, '2026-06-08'],
-        ];
+        $data = [];
+
+        for ($y = 0; $y < 50; ++$y) {
+            $year = static::generateRandomYear(2024);
+            $date = static::computeEaster($year, self::TIMEZONE);
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
+    }
+
+    /**
+     * Tests that Easter Sunday is NOT a holiday before 2024.
+     *
+     * @throws \Exception
+     */
+    public function testNotHoliday(): void
+    {
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2023);
     }
 
     /**
@@ -92,14 +92,8 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
-            [self::LOCALE => 'Queen’s Birthday']
-        );
-        $this->assertTranslatedHolidayName(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(2023),
-            [self::LOCALE => 'King’s Birthday']
+            static::generateRandomYear(2024),
+            [self::LOCALE => 'Easter Sunday']
         );
     }
 
@@ -110,11 +104,6 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_OFFICIAL
-        );
+        $this->assertHolidayType($this->region, self::HOLIDAY, static::generateRandomYear(2024), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/SouthAustralia/ProclamationDayTest.php
+++ b/tests/Australia/SouthAustralia/ProclamationDayTest.php
@@ -52,7 +52,7 @@ class ProclamationDayTest extends SouthAustraliaBaseTestCase implements HolidayT
     /**
      * Returns a list of test dates.
      *
-     * @return array<array> list of test dates for the holiday defined in this test
+     * @return array<int, array{int, string}> list of test dates for the holiday defined in this test
      */
     public static function HolidayDataProvider(): array
     {
@@ -68,6 +68,40 @@ class ProclamationDayTest extends SouthAustraliaBaseTestCase implements HolidayT
             [2018, '2018-12-26'],
             [2019, '2019-12-26'],
             [2020, '2020-12-28'],
+            [2024, '2024-12-26'],
+            [2025, '2025-12-26'],
+            [2026, '2026-12-26'],
+        ];
+    }
+
+    /**
+     * Tests substitute Proclamation Day.
+     *
+     * @param int    $year     the year for which the substitute holiday needs to be tested
+     * @param string $expected the expected date
+     *
+     * @throws \Exception
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('SubstituteHolidayDataProvider')]
+    public function testSubstituteHoliday(int $year, string $expected): void
+    {
+        $this->assertSubstituteHoliday(
+            $this->region,
+            self::HOLIDAY,
+            $year,
+            new \DateTime($expected, new \DateTimeZone($this->timezone))
+        );
+    }
+
+    /**
+     * Returns a list of substitute holiday test dates.
+     *
+     * @return array<int, array{int, string}> list of test dates for substitute Proclamation Day
+     */
+    public static function SubstituteHolidayDataProvider(): array
+    {
+        return [
+            [2026, '2026-12-28'],
         ];
     }
 

--- a/tests/Australia/SouthAustralia/QueensBirthdayTest.php
+++ b/tests/Australia/SouthAustralia/QueensBirthdayTest.php
@@ -18,6 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\SouthAustralia;
 
 use Yasumi\Holiday;
+use Yasumi\tests\Australia\MonarchsBirthdayTransitionTestTrait;
 use Yasumi\tests\HolidayTestCase;
 
 /**
@@ -25,6 +26,8 @@ use Yasumi\tests\HolidayTestCase;
  */
 class QueensBirthdayTest extends SouthAustraliaBaseTestCase implements HolidayTestCase
 {
+    use MonarchsBirthdayTransitionTestTrait;
+
     /**
      * The name of the holiday.
      */
@@ -57,7 +60,7 @@ class QueensBirthdayTest extends SouthAustraliaBaseTestCase implements HolidayTe
     /**
      * Returns a list of test dates.
      *
-     * @return array<array> list of test dates for the holiday defined in this test
+     * @return array<int, array{int, string}> list of test dates for the holiday defined in this test
      */
     public static function HolidayDataProvider(): array
     {

--- a/tests/Australia/SouthAustralia/QueensBirthdayTest.php
+++ b/tests/Australia/SouthAustralia/QueensBirthdayTest.php
@@ -21,14 +21,14 @@ use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Queen's Birthday in South Australia (Australia)..
+ * Class for testing Monarch's Birthday in South Australia (Australia)..
  */
 class QueensBirthdayTest extends SouthAustraliaBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'queensBirthday';
+    public const HOLIDAY = 'monarchsBirthday';
 
     /**
      * The year in which the holiday was first established.
@@ -36,7 +36,7 @@ class QueensBirthdayTest extends SouthAustraliaBaseTestCase implements HolidayTe
     public const ESTABLISHMENT_YEAR = 1950;
 
     /**
-     * Tests Queen's Birthday.
+     * Tests Monarch's Birthday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -73,6 +73,12 @@ class QueensBirthdayTest extends SouthAustraliaBaseTestCase implements HolidayTe
             [2018, '2018-06-11'],
             [2019, '2019-06-10'],
             [2020, '2020-06-08'],
+            [2021, '2021-06-14'],
+            [2022, '2022-06-13'],
+            [2023, '2023-06-12'],
+            [2024, '2024-06-10'],
+            [2025, '2025-06-09'],
+            [2026, '2026-06-08'],
         ];
     }
 
@@ -86,8 +92,14 @@ class QueensBirthdayTest extends SouthAustraliaBaseTestCase implements HolidayTe
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
             [self::LOCALE => 'Queen’s Birthday']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            static::generateRandomYear(2023),
+            [self::LOCALE => 'King’s Birthday']
         );
     }
 

--- a/tests/Australia/SouthAustralia/SouthAustraliaBaseTestCase.php
+++ b/tests/Australia/SouthAustralia/SouthAustraliaBaseTestCase.php
@@ -28,10 +28,10 @@ abstract class SouthAustraliaBaseTestCase extends AustraliaBaseTestCase
     use YasumiBase;
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'Australia/South';
+    public const TIMEZONE = 'Australia/Adelaide';
 
     /** Name of the region (e.g. country / state) to be tested. */
     public string $region = 'Australia\SouthAustralia';
 
-    public string $timezone = 'Australia/South';
+    public string $timezone = 'Australia/Adelaide';
 }

--- a/tests/Australia/SouthAustralia/SouthAustraliaTest.php
+++ b/tests/Australia/SouthAustralia/SouthAustraliaTest.php
@@ -54,13 +54,18 @@ class SouthAustraliaTest extends SouthAustraliaBaseTestCase implements ProviderT
             'australiaDay',
             'anzacDay',
             'easterSaturday',
-            'queensBirthday',
+            'monarchsBirthday',
             'labourDay',
             'adelaideCup',
         ];
         if (2022 === $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
+
+        if ($this->year >= 2024) {
+            $expectedHolidays[] = 'easter';
+        }
+
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 

--- a/tests/Australia/SouthAustralia/SouthAustraliaTest.php
+++ b/tests/Australia/SouthAustralia/SouthAustraliaTest.php
@@ -66,6 +66,10 @@ class SouthAustraliaTest extends SouthAustraliaBaseTestCase implements ProviderT
             $expectedHolidays[] = 'easter';
         }
 
+        if (2026 === $this->year) {
+            $expectedHolidays[] = 'substituteHoliday:proclamationDay';
+        }
+
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 

--- a/tests/Australia/Tasmania/CentralNorth/CentralNorthTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/CentralNorthTest.php
@@ -53,7 +53,7 @@ class CentralNorthTest extends CentralNorthBaseTestCase implements ProviderTestC
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'eightHourDay',
             'recreationDay',
             'devonportShow',

--- a/tests/Australia/Tasmania/CentralNorth/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/CentralNorth/QueensBirthdayTest.php
@@ -18,7 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Tasmania\CentralNorth;
 
 /**
- * Class for testing Queen's Birthday in central north Tasmania (Australia)..
+ * Class for testing Monarch's Birthday in central north Tasmania (Australia)..
  */
 class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
 {

--- a/tests/Australia/Tasmania/FlindersIsland/FlindersIslandTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/FlindersIslandTest.php
@@ -53,7 +53,7 @@ class FlindersIslandTest extends FlindersIslandBaseTestCase implements ProviderT
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'eightHourDay',
             'recreationDay',
             'flindersIslandShow',

--- a/tests/Australia/Tasmania/FlindersIsland/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/FlindersIsland/QueensBirthdayTest.php
@@ -18,7 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Tasmania\FlindersIsland;
 
 /**
- * Class for testing Queen's Birthday in Flinders Island (Australia)..
+ * Class for testing Monarch's Birthday in Flinders Island (Australia)..
  */
 class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
 {

--- a/tests/Australia/Tasmania/KingIsland/KingIslandTest.php
+++ b/tests/Australia/Tasmania/KingIsland/KingIslandTest.php
@@ -53,7 +53,7 @@ class KingIslandTest extends KingIslandBaseTestCase implements ProviderTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'eightHourDay',
             'recreationDay',
             'kingIslandShow',

--- a/tests/Australia/Tasmania/KingIsland/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/KingIsland/QueensBirthdayTest.php
@@ -18,7 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Tasmania\KingIsland;
 
 /**
- * Class for testing Queen's Birthday in King Island (Australia)..
+ * Class for testing Monarch's Birthday in King Island (Australia)..
  */
 class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
 {

--- a/tests/Australia/Tasmania/Northeast/NortheastTest.php
+++ b/tests/Australia/Tasmania/Northeast/NortheastTest.php
@@ -53,7 +53,7 @@ class NortheastTest extends NortheastBaseTestCase implements ProviderTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'eightHourDay',
             'recreationDay',
             'launcestonShow',

--- a/tests/Australia/Tasmania/Northeast/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/Northeast/QueensBirthdayTest.php
@@ -18,7 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Tasmania\Northeast;
 
 /**
- * Class for testing Queen's Birthday in northeast Tasmania (Australia)..
+ * Class for testing Monarch's Birthday in northeast Tasmania (Australia)..
  */
 class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
 {

--- a/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/CircularHeadTest.php
@@ -52,7 +52,7 @@ class CircularHeadTest extends CircularHeadBaseTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'eightHourDay',
             'recreationDay',
             'burnieShow',

--- a/tests/Australia/Tasmania/Northwest/CircularHead/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/Northwest/CircularHead/QueensBirthdayTest.php
@@ -18,7 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Tasmania\Northwest\CircularHead;
 
 /**
- * Class for testing Queen's Birthday in Circular Head (Australia)..
+ * Class for testing Monarch's Birthday in Circular Head (Australia)..
  */
 class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\Northwest\QueensBirthdayTest
 {

--- a/tests/Australia/Tasmania/Northwest/NorthwestTest.php
+++ b/tests/Australia/Tasmania/Northwest/NorthwestTest.php
@@ -53,7 +53,7 @@ class NorthwestTest extends NorthwestBaseTestCase implements ProviderTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'eightHourDay',
             'recreationDay',
             'burnieShow',

--- a/tests/Australia/Tasmania/Northwest/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/Northwest/QueensBirthdayTest.php
@@ -18,7 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Tasmania\Northwest;
 
 /**
- * Class for testing Queen's Birthday in northwest Tasmania (Australia)..
+ * Class for testing Monarch's Birthday in northwest Tasmania (Australia)..
  */
 class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
 {

--- a/tests/Australia/Tasmania/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/QueensBirthdayTest.php
@@ -18,6 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Tasmania;
 
 use Yasumi\Holiday;
+use Yasumi\tests\Australia\MonarchsBirthdayTransitionTestTrait;
 use Yasumi\tests\HolidayTestCase;
 
 /**
@@ -25,6 +26,8 @@ use Yasumi\tests\HolidayTestCase;
  */
 class QueensBirthdayTest extends TasmaniaBaseTestCase implements HolidayTestCase
 {
+    use MonarchsBirthdayTransitionTestTrait;
+
     /**
      * The name of the holiday.
      */
@@ -57,7 +60,7 @@ class QueensBirthdayTest extends TasmaniaBaseTestCase implements HolidayTestCase
     /**
      * Returns a list of test dates.
      *
-     * @return array<array> list of test dates for the holiday defined in this test
+     * @return array<int, array{int, string}> list of test dates for the holiday defined in this test
      */
     public static function HolidayDataProvider(): array
     {

--- a/tests/Australia/Tasmania/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/QueensBirthdayTest.php
@@ -21,14 +21,14 @@ use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Queen's Birthday in Tasmania (Australia)..
+ * Class for testing Monarch's Birthday in Tasmania (Australia)..
  */
 class QueensBirthdayTest extends TasmaniaBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'queensBirthday';
+    public const HOLIDAY = 'monarchsBirthday';
 
     /**
      * The year in which the holiday was first established.
@@ -36,7 +36,7 @@ class QueensBirthdayTest extends TasmaniaBaseTestCase implements HolidayTestCase
     public const ESTABLISHMENT_YEAR = 1950;
 
     /**
-     * Tests Queen's Birthday.
+     * Tests Monarch's Birthday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -73,6 +73,12 @@ class QueensBirthdayTest extends TasmaniaBaseTestCase implements HolidayTestCase
             [2018, '2018-06-11'],
             [2019, '2019-06-10'],
             [2020, '2020-06-08'],
+            [2021, '2021-06-14'],
+            [2022, '2022-06-13'],
+            [2023, '2023-06-12'],
+            [2024, '2024-06-10'],
+            [2025, '2025-06-09'],
+            [2026, '2026-06-08'],
         ];
     }
 
@@ -86,8 +92,14 @@ class QueensBirthdayTest extends TasmaniaBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
             [self::LOCALE => 'Queen’s Birthday']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            static::generateRandomYear(2023),
+            [self::LOCALE => 'King’s Birthday']
         );
     }
 

--- a/tests/Australia/Tasmania/South/QueensBirthdayTest.php
+++ b/tests/Australia/Tasmania/South/QueensBirthdayTest.php
@@ -18,7 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Tasmania\South;
 
 /**
- * Class for testing Queen's Birthday in southe0rn Tasmania (Australia)..
+ * Class for testing Monarch's Birthday in southe0rn Tasmania (Australia)..
  */
 class QueensBirthdayTest extends \Yasumi\tests\Australia\Tasmania\QueensBirthdayTest
 {

--- a/tests/Australia/Tasmania/South/SouthTest.php
+++ b/tests/Australia/Tasmania/South/SouthTest.php
@@ -53,7 +53,7 @@ class SouthTest extends SouthBaseTestCase implements ProviderTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'eightHourDay',
             'recreationDay',
             'hobartShow',

--- a/tests/Australia/Tasmania/South/Southeast/SoutheastTest.php
+++ b/tests/Australia/Tasmania/South/Southeast/SoutheastTest.php
@@ -52,7 +52,7 @@ class SoutheastTest extends SoutheastBaseTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'eightHourDay',
             'hobartShow',
             'hobartRegatta',

--- a/tests/Australia/Tasmania/TasmaniaBaseTestCase.php
+++ b/tests/Australia/Tasmania/TasmaniaBaseTestCase.php
@@ -28,10 +28,10 @@ abstract class TasmaniaBaseTestCase extends AustraliaBaseTestCase
     use YasumiBase;
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'Australia/Tasmania';
+    public const TIMEZONE = 'Australia/Hobart';
 
     /** Name of the region (e.g. country / state) to be tested. */
     public string $region = 'Australia\Tasmania';
 
-    public string $timezone = 'Australia/Tasmania';
+    public string $timezone = 'Australia/Hobart';
 }

--- a/tests/Australia/Tasmania/TasmaniaTest.php
+++ b/tests/Australia/Tasmania/TasmaniaTest.php
@@ -53,7 +53,7 @@ class TasmaniaTest extends TasmaniaBaseTestCase implements ProviderTestCase
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'eightHourDay',
             'recreationDay',
         ];

--- a/tests/Australia/Victoria/AFLGrandFinalFridayTest.php
+++ b/tests/Australia/Victoria/AFLGrandFinalFridayTest.php
@@ -31,7 +31,7 @@ class AFLGrandFinalFridayTest extends VictoriaBaseTestCase implements HolidayTes
     public const HOLIDAY = 'aflGrandFinalFriday';
 
     public const ESTABLISHMENT_YEAR = 2015;
-    public const LAST_KNOWN_YEAR = 2020;
+    public const LAST_KNOWN_YEAR = 2025;
 
     /**
      * Tests AFL Grand Final Friday.
@@ -104,6 +104,11 @@ class AFLGrandFinalFridayTest extends VictoriaBaseTestCase implements HolidayTes
             [2018, '2018-09-28'],
             [2019, '2019-09-27'],
             [2020, '2020-09-25'],
+            [2021, '2021-09-24'],
+            [2022, '2022-09-23'],
+            [2023, '2023-09-29'],
+            [2024, '2024-09-27'],
+            [2025, '2025-09-26'],
         ];
     }
 }

--- a/tests/Australia/Victoria/QueensBirthdayTest.php
+++ b/tests/Australia/Victoria/QueensBirthdayTest.php
@@ -18,6 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\Victoria;
 
 use Yasumi\Holiday;
+use Yasumi\tests\Australia\MonarchsBirthdayTransitionTestTrait;
 use Yasumi\tests\HolidayTestCase;
 
 /**
@@ -25,6 +26,8 @@ use Yasumi\tests\HolidayTestCase;
  */
 class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
 {
+    use MonarchsBirthdayTransitionTestTrait;
+
     /**
      * The name of the holiday.
      */
@@ -57,7 +60,7 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
     /**
      * Returns a list of test dates.
      *
-     * @return array<array> list of test dates for the holiday defined in this test
+     * @return array<int, array{int, string}> list of test dates for the holiday defined in this test
      */
     public static function HolidayDataProvider(): array
     {

--- a/tests/Australia/Victoria/VictoriaBaseTestCase.php
+++ b/tests/Australia/Victoria/VictoriaBaseTestCase.php
@@ -28,10 +28,10 @@ abstract class VictoriaBaseTestCase extends AustraliaBaseTestCase
     use YasumiBase;
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'Australia/Victoria';
+    public const TIMEZONE = 'Australia/Melbourne';
 
     /** Name of the region (e.g. country / state) to be tested. */
     public string $region = 'Australia\Victoria';
 
-    public string $timezone = 'Australia/Victoria';
+    public string $timezone = 'Australia/Melbourne';
 }

--- a/tests/Australia/Victoria/VictoriaTest.php
+++ b/tests/Australia/Victoria/VictoriaTest.php
@@ -37,7 +37,7 @@ class VictoriaTest extends VictoriaBaseTestCase implements ProviderTestCase
      */
     protected function setUp(): void
     {
-        $this->year = static::generateRandomYear(2015, 2018);
+        $this->year = static::generateRandomYear(2015, 2026);
     }
 
     /**
@@ -55,11 +55,15 @@ class VictoriaTest extends VictoriaBaseTestCase implements ProviderTestCase
             'anzacDay',
             'easter',
             'easterSaturday',
-            'queensBirthday',
+            'monarchsBirthday',
             'labourDay',
-            'aflGrandFinalFriday',
             'melbourneCup',
         ];
+
+        if ($this->year <= 2025) {
+            $expectedHolidays[] = 'aflGrandFinalFriday';
+        }
+
         if (2022 === $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }

--- a/tests/Australia/WesternAustralia/AnzacDayMondayTest.php
+++ b/tests/Australia/WesternAustralia/AnzacDayMondayTest.php
@@ -15,28 +15,25 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-namespace Yasumi\tests\Australia\Victoria;
+namespace Yasumi\tests\Australia\WesternAustralia;
 
 use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Monarch's Birthday in Victoria (Australia)..
+ * Class for testing ANZAC Day Monday substitute in Western Australia (Australia).
+ *
+ * When ANZAC Day (April 25) falls on a Saturday or Sunday, the following Monday is a public holiday.
  */
-class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
+class AnzacDayMondayTest extends WesternAustraliaBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'monarchsBirthday';
+    public const HOLIDAY = 'anzacDayMonday';
 
     /**
-     * The year in which the holiday was first established.
-     */
-    public const ESTABLISHMENT_YEAR = 1950;
-
-    /**
-     * Tests Monarch's Birthday.
+     * Tests ANZAC Day Monday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -62,24 +59,23 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
     public static function HolidayDataProvider(): array
     {
         return [
-            [2010, '2010-06-14'],
-            [2011, '2011-06-13'],
-            [2012, '2012-06-11'],
-            [2013, '2013-06-10'],
-            [2014, '2014-06-09'],
-            [2015, '2015-06-08'],
-            [2016, '2016-06-13'],
-            [2017, '2017-06-12'],
-            [2018, '2018-06-11'],
-            [2019, '2019-06-10'],
-            [2020, '2020-06-08'],
-            [2021, '2021-06-14'],
-            [2022, '2022-06-13'],
-            [2023, '2023-06-12'],
-            [2024, '2024-06-10'],
-            [2025, '2025-06-09'],
-            [2026, '2026-06-08'],
+            [2015, '2015-04-27'], // April 25 = Saturday → Monday 27th
+            [2020, '2020-04-27'], // April 25 = Saturday → Monday 27th
+            [2021, '2021-04-26'], // April 25 = Sunday → Monday 26th
+            [2026, '2026-04-27'], // April 25 = Saturday → Monday 27th
         ];
+    }
+
+    /**
+     * Tests that ANZAC Day Monday is NOT a holiday when April 25 is a weekday.
+     *
+     * @throws \Exception
+     */
+    public function testNotHoliday(): void
+    {
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 1931);
+        // 2022: April 25 = Monday (weekday, no substitute)
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2022);
     }
 
     /**
@@ -92,14 +88,8 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
-            [self::LOCALE => 'Queen’s Birthday']
-        );
-        $this->assertTranslatedHolidayName(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(2023),
-            [self::LOCALE => 'King’s Birthday']
+            2026,
+            [self::LOCALE => 'ANZAC Day']
         );
     }
 
@@ -110,11 +100,6 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_OFFICIAL
-        );
+        $this->assertHolidayType($this->region, self::HOLIDAY, 2026, Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/WesternAustralia/EasterSundayTest.php
+++ b/tests/Australia/WesternAustralia/EasterSundayTest.php
@@ -15,28 +15,23 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-namespace Yasumi\tests\Australia\Victoria;
+namespace Yasumi\tests\Australia\WesternAustralia;
 
 use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Monarch's Birthday in Victoria (Australia)..
+ * Class for testing Easter Sunday in Western Australia (Australia).
  */
-class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
+class EasterSundayTest extends WesternAustraliaBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'monarchsBirthday';
+    public const HOLIDAY = 'easter';
 
     /**
-     * The year in which the holiday was first established.
-     */
-    public const ESTABLISHMENT_YEAR = 1950;
-
-    /**
-     * Tests Monarch's Birthday.
+     * Tests Easter Sunday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -58,28 +53,21 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      * Returns a list of test dates.
      *
      * @return array<array> list of test dates for the holiday defined in this test
+     *
+     * @throws \Exception
      */
     public static function HolidayDataProvider(): array
     {
-        return [
-            [2010, '2010-06-14'],
-            [2011, '2011-06-13'],
-            [2012, '2012-06-11'],
-            [2013, '2013-06-10'],
-            [2014, '2014-06-09'],
-            [2015, '2015-06-08'],
-            [2016, '2016-06-13'],
-            [2017, '2017-06-12'],
-            [2018, '2018-06-11'],
-            [2019, '2019-06-10'],
-            [2020, '2020-06-08'],
-            [2021, '2021-06-14'],
-            [2022, '2022-06-13'],
-            [2023, '2023-06-12'],
-            [2024, '2024-06-10'],
-            [2025, '2025-06-09'],
-            [2026, '2026-06-08'],
-        ];
+        $data = [];
+
+        for ($y = 0; $y < 50; ++$y) {
+            $year = static::generateRandomYear(2022);
+            $date = static::computeEaster($year, self::TIMEZONE);
+
+            $data[] = [$year, $date->format('Y-m-d')];
+        }
+
+        return $data;
     }
 
     /**
@@ -92,15 +80,17 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
-            [self::LOCALE => 'Queen’s Birthday']
+            static::generateRandomYear(2022),
+            [self::LOCALE => 'Easter Sunday']
         );
-        $this->assertTranslatedHolidayName(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(2023),
-            [self::LOCALE => 'King’s Birthday']
-        );
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testNotHoliday(): void
+    {
+        $this->assertNotHoliday($this->region, self::HOLIDAY, 2021);
     }
 
     /**
@@ -110,11 +100,6 @@ class QueensBirthdayTest extends VictoriaBaseTestCase implements HolidayTestCase
      */
     public function testHolidayType(): void
     {
-        $this->assertHolidayType(
-            $this->region,
-            self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2100),
-            Holiday::TYPE_OFFICIAL
-        );
+        $this->assertHolidayType($this->region, self::HOLIDAY, static::generateRandomYear(2022), Holiday::TYPE_OFFICIAL);
     }
 }

--- a/tests/Australia/WesternAustralia/QueensBirthdayTest.php
+++ b/tests/Australia/WesternAustralia/QueensBirthdayTest.php
@@ -18,6 +18,7 @@ declare(strict_types = 1);
 namespace Yasumi\tests\Australia\WesternAustralia;
 
 use Yasumi\Holiday;
+use Yasumi\tests\Australia\MonarchsBirthdayTransitionTestTrait;
 use Yasumi\tests\HolidayTestCase;
 
 /**
@@ -25,6 +26,8 @@ use Yasumi\tests\HolidayTestCase;
  */
 class QueensBirthdayTest extends WesternAustraliaBaseTestCase implements HolidayTestCase
 {
+    use MonarchsBirthdayTransitionTestTrait;
+
     /**
      * The name of the holiday.
      */
@@ -57,7 +60,7 @@ class QueensBirthdayTest extends WesternAustraliaBaseTestCase implements Holiday
     /**
      * Returns a list of test dates.
      *
-     * @return array<array> list of test dates for the holiday defined in this test
+     * @return array<int, array{int, string}> list of test dates for the holiday defined in this test
      */
     public static function HolidayDataProvider(): array
     {

--- a/tests/Australia/WesternAustralia/QueensBirthdayTest.php
+++ b/tests/Australia/WesternAustralia/QueensBirthdayTest.php
@@ -21,14 +21,14 @@ use Yasumi\Holiday;
 use Yasumi\tests\HolidayTestCase;
 
 /**
- * Class for testing Queen's Birthday in Western Australia (Australia)..
+ * Class for testing Monarch's Birthday in Western Australia (Australia)..
  */
 class QueensBirthdayTest extends WesternAustraliaBaseTestCase implements HolidayTestCase
 {
     /**
      * The name of the holiday.
      */
-    public const HOLIDAY = 'queensBirthday';
+    public const HOLIDAY = 'monarchsBirthday';
 
     /**
      * The year in which the holiday was first established.
@@ -36,7 +36,7 @@ class QueensBirthdayTest extends WesternAustraliaBaseTestCase implements Holiday
     public const ESTABLISHMENT_YEAR = 1950;
 
     /**
-     * Tests Queen's Birthday.
+     * Tests Monarch's Birthday.
      *
      * @param int    $year     the year for which the holiday defined in this test needs to be tested
      * @param string $expected the expected date
@@ -73,6 +73,12 @@ class QueensBirthdayTest extends WesternAustraliaBaseTestCase implements Holiday
             [2018, '2018-09-24'],
             [2019, '2019-09-30'],
             [2020, '2020-09-28'],
+            [2021, '2021-09-27'],
+            [2022, '2022-09-26'],
+            [2023, '2023-09-25'],
+            [2024, '2024-09-23'],
+            [2025, '2025-09-29'],
+            [2026, '2026-09-28'],
         ];
     }
 
@@ -86,8 +92,14 @@ class QueensBirthdayTest extends WesternAustraliaBaseTestCase implements Holiday
         $this->assertTranslatedHolidayName(
             $this->region,
             self::HOLIDAY,
-            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2022),
             [self::LOCALE => 'Queen’s Birthday']
+        );
+        $this->assertTranslatedHolidayName(
+            $this->region,
+            self::HOLIDAY,
+            static::generateRandomYear(2023),
+            [self::LOCALE => 'King’s Birthday']
         );
     }
 

--- a/tests/Australia/WesternAustralia/WesternAustraliaBaseTestCase.php
+++ b/tests/Australia/WesternAustralia/WesternAustraliaBaseTestCase.php
@@ -28,10 +28,10 @@ abstract class WesternAustraliaBaseTestCase extends AustraliaBaseTestCase
     use YasumiBase;
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'Australia/West';
+    public const TIMEZONE = 'Australia/Perth';
 
     /** Name of the region (e.g. country / state) to be tested. */
     public string $region = 'Australia\WesternAustralia';
 
-    public string $timezone = 'Australia/West';
+    public string $timezone = 'Australia/Perth';
 }

--- a/tests/Australia/WesternAustralia/WesternAustraliaTest.php
+++ b/tests/Australia/WesternAustralia/WesternAustraliaTest.php
@@ -53,13 +53,24 @@ class WesternAustraliaTest extends WesternAustraliaBaseTestCase implements Provi
             'secondChristmasDay',
             'australiaDay',
             'anzacDay',
-            'queensBirthday',
+            'monarchsBirthday',
             'labourDay',
             'westernAustraliaDay',
         ];
+
+        if ($this->year >= 2022) {
+            $expectedHolidays[] = 'easter';
+        }
+
         if (2022 === $this->year) {
             $expectedHolidays[] = 'nationalDayOfMourning';
         }
+
+        $anzacDay = new \DateTime("{$this->year}-04-25", new \DateTimeZone(self::TIMEZONE));
+        if ($this->year >= 1972 && in_array((int) $anzacDay->format('w'), [0, 6], true)) {
+            $expectedHolidays[] = 'anzacDayMonday';
+        }
+
         $this->assertDefinedHolidays($expectedHolidays, $this->region, $this->year, Holiday::TYPE_OFFICIAL);
     }
 


### PR DESCRIPTION
## Summary
 - update Australian state and territory providers to reflect current holiday rules and timezone handling
 - rename Queen's Birthday references to Monarch's Birthday and add the new translation data
 - add and update coverage for regional holiday behavior, including Anzac Day Monday observance and Easter Sunday/Saturday cases where applicable
 
 ## Testing
 - existing Australia provider tests updated to cover the revised holiday definitions
 - new tests added for state- and region-specific edge cases across affected providers
