### PR TITLE
feat: add Kenya holiday provider

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -114,6 +114,10 @@
     <testsuite name="Japan">
       <directory>./tests/Japan</directory>
     </testsuite>
+    <!-- Test Suite for holidays in Kenya -->
+    <testsuite name="Kenya">
+      <directory>./tests/Kenya</directory>
+    </testsuite>
     <!-- Test Suite for holidays in Latvia -->
     <testsuite name="Latvia">
       <directory>./tests/Latvia</directory>

--- a/src/Yasumi/Provider/Kenya.php
+++ b/src/Yasumi/Provider/Kenya.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\Provider;
+
+use Yasumi\Exception\UnknownLocaleException;
+use Yasumi\Holiday;
+use Yasumi\SubstituteHoliday;
+
+/**
+ * Provider for all holidays in Kenya.
+ *
+ * Kenya's public holidays are established by the Public Holidays Act (Cap. 110).
+ * Section 4 of the Act determines that whenever a public holiday falls on a Sunday,
+ * the first succeeding day that is not itself a public holiday shall be a public
+ * holiday.
+ *
+ * Note: The Islamic holidays Idd-ul-Fitr (Part I of the Schedule) and Idd-ul-Azha
+ * (Part II of the Schedule) are not part of this provider yet. Their dates depend
+ * on the sighting of the moon and are gazetted only shortly in advance. Islamic
+ * holidays are quite complex and at first, an Islamic calendar provider needs to
+ * be in place.
+ *
+ * @see https://en.wikipedia.org/wiki/Public_holidays_in_Kenya
+ * @see https://new.kenyalaw.org/akn/ke/act/1912/21/
+ */
+class Kenya extends AbstractProvider
+{
+    use CommonHolidays;
+    use ChristianHolidays;
+
+    /**
+     * Code to identify this Holiday Provider. Typically, this is the ISO3166
+     * code corresponding to the respective country or sub-region.
+     */
+    public const ID = 'KE';
+
+    /**
+     * Year in which Kenya became a republic (12 December 1964). This provider
+     * covers holidays from this year onwards.
+     */
+    public const ESTABLISHMENT_YEAR = 1964;
+
+    /**
+     * Initialize holidays for Kenya.
+     *
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize(): void
+    {
+        $this->timezone = 'Africa/Nairobi';
+
+        if ($this->year < self::ESTABLISHMENT_YEAR) {
+            return;
+        }
+
+        // Add common holidays
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale)); // Labour Day
+
+        // Add common Christian holidays
+        $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->easterMonday($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
+        $this->addHoliday($this->secondChristmasDay($this->year, $this->timezone, $this->locale)); // Boxing Day
+
+        // Calculate other holidays
+        $this->calculateMadarakaDay();
+        $this->calculateMoiDay();
+        $this->calculateUtamaduniDay();
+        $this->calculateMazingiraDay();
+        $this->calculateKenyattaDay();
+        $this->calculateMashujaaDay();
+        $this->calculateJamhuriDay();
+
+        // Determine whether any of the holidays is substituted on another day
+        $this->calculateSubstituteHolidays();
+    }
+
+    /**
+     * The source of the holidays.
+     *
+     * @return string[] The source URLs
+     */
+    public function getSources(): array
+    {
+        return [
+            'https://en.wikipedia.org/wiki/Public_holidays_in_Kenya',
+            'https://new.kenyalaw.org/akn/ke/act/1912/21/',
+        ];
+    }
+
+    /**
+     * Madaraka Day.
+     *
+     * "Siku ya Madaraka". Commemorates the day Kenya attained internal
+     * self-rule on 1 June 1963, preceding full independence.
+     *
+     * @see https://en.wikipedia.org/wiki/Madaraka_Day
+     *
+     * @throws \Exception
+     */
+    protected function calculateMadarakaDay(): void
+    {
+        $this->addHoliday(new Holiday(
+            'madarakaDay',
+            ['en' => 'Madaraka Day', 'sw' => 'Siku ya Madaraka'],
+            new \DateTime("{$this->year}-06-01", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $this->locale
+        ));
+    }
+
+    /**
+     * Moi Day.
+     *
+     * "Siku ya Moi". Honoured the second president, Daniel arap Moi. First
+     * observed on 10 October 1989 and removed from the list of public holidays
+     * following the promulgation of the Constitution of Kenya in August 2010.
+     * On 8 November 2017 the High Court ruled that its removal violated the
+     * Public Holidays Act, restoring the holiday as of 2018. In 2020 it was
+     * renamed Utamaduni Day.
+     *
+     * @see https://en.wikipedia.org/wiki/Moi_Day
+     *
+     * @throws \Exception
+     */
+    protected function calculateMoiDay(): void
+    {
+        if (($this->year >= 1989 && $this->year <= 2009) || 2018 === $this->year || 2019 === $this->year) {
+            $this->addHoliday(new Holiday(
+                'moiDay',
+                ['en' => 'Moi Day', 'sw' => 'Siku ya Moi'],
+                new \DateTime("{$this->year}-10-10", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Utamaduni Day.
+     *
+     * "Siku ya Utamaduni" (Culture Day). In 2020, Moi Day was renamed
+     * Utamaduni Day to celebrate Kenya's rich cultural diversity. Renamed
+     * Mazingira Day in 2024.
+     *
+     * @see https://en.wikipedia.org/wiki/Mazingira_Day
+     *
+     * @throws \Exception
+     */
+    protected function calculateUtamaduniDay(): void
+    {
+        if ($this->year >= 2020 && $this->year <= 2023) {
+            $this->addHoliday(new Holiday(
+                'utamaduniDay',
+                ['en' => 'Utamaduni Day', 'sw' => 'Siku ya Utamaduni'],
+                new \DateTime("{$this->year}-10-10", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Mazingira Day.
+     *
+     * "Siku ya Mazingira" (Environment Day). Utamaduni Day was renamed
+     * Mazingira Day by the Statute Law (Miscellaneous Amendments) Act, 2024,
+     * assented to on 24 April 2024. The day is dedicated to environmental
+     * conservation activities such as tree planting.
+     *
+     * @see https://en.wikipedia.org/wiki/Mazingira_Day
+     *
+     * @throws \Exception
+     */
+    protected function calculateMazingiraDay(): void
+    {
+        if ($this->year >= 2024) {
+            $this->addHoliday(new Holiday(
+                'mazingiraDay',
+                ['en' => 'Mazingira Day', 'sw' => 'Siku ya Mazingira'],
+                new \DateTime("{$this->year}-10-10", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Kenyatta Day.
+     *
+     * "Siku ya Kenyatta". Commemorated the arrest of the Kapenguria Six,
+     * among them Jomo Kenyatta, on 20 October 1952. Renamed Mashujaa Day
+     * following the promulgation of the Constitution of Kenya in August 2010.
+     *
+     * @see https://en.wikipedia.org/wiki/Mashujaa_Day
+     *
+     * @throws \Exception
+     */
+    protected function calculateKenyattaDay(): void
+    {
+        if ($this->year <= 2009) {
+            $this->addHoliday(new Holiday(
+                'kenyattaDay',
+                ['en' => 'Kenyatta Day', 'sw' => 'Siku ya Kenyatta'],
+                new \DateTime("{$this->year}-10-20", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Mashujaa Day.
+     *
+     * "Siku ya Mashujaa" (Heroes' Day). Honours all those who contributed
+     * towards the struggle for Kenya's independence or positively contributed
+     * to post-independence Kenya. Known as Kenyatta Day until the promulgation
+     * of the Constitution of Kenya in August 2010.
+     *
+     * @see https://en.wikipedia.org/wiki/Mashujaa_Day
+     *
+     * @throws \Exception
+     */
+    protected function calculateMashujaaDay(): void
+    {
+        if ($this->year >= 2010) {
+            $this->addHoliday(new Holiday(
+                'mashujaaDay',
+                ['en' => 'Mashujaa Day', 'sw' => 'Siku ya Mashujaa'],
+                new \DateTime("{$this->year}-10-20", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Jamhuri Day.
+     *
+     * "Siku ya Jamhuri" (Republic Day). Commemorates the day Kenya was
+     * admitted into the Commonwealth as a republic on 12 December 1964, and
+     * the day Kenya obtained its independence on 12 December 1963.
+     *
+     * @see https://en.wikipedia.org/wiki/Jamhuri_Day
+     *
+     * @throws \Exception
+     */
+    protected function calculateJamhuriDay(): void
+    {
+        $this->addHoliday(new Holiday(
+            'jamhuriDay',
+            ['en' => 'Jamhuri Day', 'sw' => 'Siku ya Jamhuri'],
+            new \DateTime("{$this->year}-12-12", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $this->locale
+        ));
+    }
+
+    /**
+     * Calculate substitute holidays.
+     *
+     * Section 4 of the Public Holidays Act (Cap. 110) determines that whenever
+     * a public holiday falls on a Sunday, the first succeeding day that is not
+     * itself a public holiday shall be a public holiday. For example, when
+     * Christmas Day falls on a Sunday, the substitute day is Tuesday 27
+     * December, as Monday 26 December is already a public holiday (Boxing Day).
+     *
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    protected function calculateSubstituteHolidays(): void
+    {
+        $holidayDates = [];
+        foreach ($this->getHolidays() as $holiday) {
+            $holidayDates[$holiday->format('Y-m-d')] = true;
+        }
+
+        // Loop through all defined holidays
+        foreach ($this->getHolidays() as $holiday) {
+            if (! $holiday instanceof Holiday) {
+                continue;
+            }
+
+            // Substitute holiday is only given when the holiday falls on a Sunday
+            if (0 !== (int) $holiday->format('w')) {
+                continue;
+            }
+
+            $date = clone $holiday;
+            do {
+                $date->add(new \DateInterval('P1D'));
+            } while (isset($holidayDates[$date->format('Y-m-d')]));
+
+            $holidayDates[$date->format('Y-m-d')] = true;
+
+            $this->addHoliday(new SubstituteHoliday(
+                $holiday,
+                [],
+                $date,
+                $this->locale
+            ));
+        }
+    }
+}

--- a/src/Yasumi/data/translations/internationalWorkersDay.php
+++ b/src/Yasumi/data/translations/internationalWorkersDay.php
@@ -25,6 +25,7 @@ return [
     'de' => 'Tag der Arbeit',
     'de_AT' => 'Staatsfeiertag',
     'el' => 'Εργατική Πρωτομαγιά',
+    'en_KE' => 'Labour Day',
     'en_US' => 'International Workers’ Day',
     'en_ZA' => 'Workers’ Day',
     'es' => 'Día del Trabajador',

--- a/tests/Kenya/BoxingDayTest.php
+++ b/tests/Kenya/BoxingDayTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Kenya;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Boxing Day in Kenya.
+ *
+ * Fixed date: 26 December. Substituted when falling on a Sunday.
+ */
+class BoxingDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'secondChristmasDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-12-26", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the substitute holiday when Boxing Day falls on a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 2021 Boxing Day falls on a Sunday, so Monday 27 December is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2021,
+            new \DateTime('2021-12-27', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 2022 Boxing Day falls on a Monday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 2022);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Boxing Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/ChristmasDayTest.php
+++ b/tests/Kenya/ChristmasDayTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Kenya;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Christmas Day in Kenya.
+ *
+ * Fixed date: 25 December. When it falls on a Sunday, the substitute day is
+ * Tuesday 27 December, as Monday 26 December is already a public holiday
+ * (Boxing Day).
+ */
+class ChristmasDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'christmasDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-12-25", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the substitute holiday when Christmas Day falls on a Sunday.
+     *
+     * As Monday 26 December is already a public holiday (Boxing Day), the
+     * substitute day is given on Tuesday 27 December.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 2022 Christmas Day falls on a Sunday, so Tuesday 27 December is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2022,
+            new \DateTime('2022-12-27', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 2021 Christmas Day falls on a Saturday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 2021);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Christmas Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/EasterMondayTest.php
+++ b/tests/Kenya/EasterMondayTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Kenya;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Easter Monday in Kenya.
+ *
+ * Movable feast: the Monday after Easter Sunday.
+ */
+class EasterMondayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'easterMonday';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-04-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Easter Monday']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/GoodFridayTest.php
+++ b/tests/Kenya/GoodFridayTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Kenya;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Good Friday in Kenya.
+ *
+ * Movable feast: the Friday before Easter Sunday.
+ */
+class GoodFridayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'goodFriday';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-03-29", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Good Friday']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/JamhuriDayTest.php
+++ b/tests/Kenya/JamhuriDayTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Kenya;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Jamhuri Day in Kenya.
+ *
+ * Fixed date: 12 December. Commemorates the day Kenya became a republic in
+ * 1964 and the day Kenya obtained its independence in 1963.
+ */
+class JamhuriDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'jamhuriDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-12-12", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that no holidays are defined before the establishment year.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            Kenya::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /**
+     * Tests the substitute holiday when Jamhuri Day falls on a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 2021 Jamhuri Day falls on a Sunday, so Monday 13 December is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2021,
+            new \DateTime('2021-12-13', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 2024 Jamhuri Day falls on a Thursday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 2024);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Jamhuri Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/KenyaBaseTestCase.php
+++ b/tests/Kenya/KenyaBaseTestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use PHPUnit\Framework\TestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for Kenya holiday tests.
+ */
+abstract class KenyaBaseTestCase extends TestCase
+{
+    use YasumiBase;
+
+    /** Country (name) to be tested. */
+    public const REGION = 'Kenya';
+
+    /** Timezone in which this provider has holidays defined. */
+    public const TIMEZONE = 'Africa/Nairobi';
+
+    /** Locale that is considered common for this provider. */
+    public const LOCALE = 'en_KE';
+}

--- a/tests/Kenya/KenyaTest.php
+++ b/tests/Kenya/KenyaTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Kenya;
+use Yasumi\tests\ProviderTestCase;
+
+/**
+ * Class for testing holidays in Kenya.
+ */
+class KenyaTest extends KenyaBaseTestCase implements ProviderTestCase
+{
+    /** @var int year random year number used for all tests in this Test Case */
+    protected int $year;
+
+    /**
+     * Initial setup of this Test Case.
+     *
+     * @throws \Exception
+     */
+    protected function setUp(): void
+    {
+        $this->year = static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR);
+    }
+
+    /**
+     * Tests if all official holidays in Kenya are defined by the provider class.
+     */
+    public function testOfficialHolidays(): void
+    {
+        $holidays = [
+            'newYearsDay',
+            'goodFriday',
+            'easterMonday',
+            'internationalWorkersDay',
+            'madarakaDay',
+            'jamhuriDay',
+            'christmasDay',
+            'secondChristmasDay',
+        ];
+
+        $holidays[] = $this->year <= 2009 ? 'kenyattaDay' : 'mashujaaDay';
+
+        if (($this->year >= 1989 && $this->year <= 2009) || 2018 === $this->year || 2019 === $this->year) {
+            $holidays[] = 'moiDay';
+        } elseif ($this->year >= 2020 && $this->year <= 2023) {
+            $holidays[] = 'utamaduniDay';
+        } elseif ($this->year >= 2024) {
+            $holidays[] = 'mazingiraDay';
+        }
+
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Tests if all observed holidays in Kenya are defined by the provider class.
+     */
+    public function testObservedHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+    }
+
+    /**
+     * Tests if all seasonal holidays in Kenya are defined by the provider class.
+     */
+    public function testSeasonalHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_SEASON);
+    }
+
+    /**
+     * Tests if all bank holidays in Kenya are defined by the provider class.
+     */
+    public function testBankHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_BANK);
+    }
+
+    /**
+     * Tests if all other holidays in Kenya are defined by the provider class.
+     */
+    public function testOtherHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+    }
+
+    /** @throws \Exception */
+    public function testSources(): void
+    {
+        $this->assertSources(self::REGION, 2);
+    }
+}

--- a/tests/Kenya/KenyattaDayTest.php
+++ b/tests/Kenya/KenyattaDayTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Kenya;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Kenyatta Day in Kenya.
+ *
+ * Fixed date: 20 October. Renamed Mashujaa Day following the promulgation of
+ * the Constitution of Kenya in August 2010.
+ */
+class KenyattaDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'kenyattaDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 1995;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-10-20", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that Kenyatta Day is no longer observed after being renamed
+     * Mashujaa Day in 2010.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayAfterRenaming(): void
+    {
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, 2010);
+    }
+
+    /**
+     * Tests the substitute holiday when Kenyatta Day falls on a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 2002 Kenyatta Day falls on a Sunday, so Monday 21 October is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2002,
+            new \DateTime('2002-10-21', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 1995 Kenyatta Day falls on a Friday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 1995);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR, 2009),
+            [self::LOCALE => 'Kenyatta Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR, 2009),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/LabourDayTest.php
+++ b/tests/Kenya/LabourDayTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Kenya;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Labour Day in Kenya.
+ *
+ * Fixed date: 1 May. Substituted when falling on a Sunday.
+ */
+class LabourDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'internationalWorkersDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-05-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the substitute holiday when Labour Day falls on a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 2022 Labour Day falls on a Sunday, so Monday 2 May is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2022,
+            new \DateTime('2022-05-02', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 2024 Labour Day falls on a Wednesday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 2024);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Labour Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/MadarakaDayTest.php
+++ b/tests/Kenya/MadarakaDayTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Kenya;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Madaraka Day in Kenya.
+ *
+ * Fixed date: 1 June. Commemorates the attainment of internal self-rule in 1963.
+ */
+class MadarakaDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'madarakaDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-06-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that no holidays are defined before the establishment year.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            Kenya::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /**
+     * Tests the substitute holiday when Madaraka Day falls on a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 2025 Madaraka Day falls on a Sunday, so Monday 2 June is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2025,
+            new \DateTime('2025-06-02', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 2024 Madaraka Day falls on a Saturday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 2024);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Madaraka Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/MashujaaDayTest.php
+++ b/tests/Kenya/MashujaaDayTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Mashujaa Day in Kenya.
+ *
+ * Fixed date: 20 October. Known as Kenyatta Day until the promulgation of the
+ * Constitution of Kenya in August 2010.
+ */
+class MashujaaDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'mashujaaDay';
+
+    public const ESTABLISHMENT_YEAR = 2010;
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2023;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-10-20", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that Mashujaa Day is not observed before its establishment
+     * (the day was known as Kenyatta Day).
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            self::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /**
+     * Tests the substitute holiday when Mashujaa Day falls on a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 2024 Mashujaa Day falls on a Sunday, so Monday 21 October is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2024,
+            new \DateTime('2024-10-21', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 2023 Mashujaa Day falls on a Friday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 2023);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Mashujaa Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/MazingiraDayTest.php
+++ b/tests/Kenya/MazingiraDayTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Mazingira Day in Kenya.
+ *
+ * Fixed date: 10 October. Utamaduni Day was renamed Mazingira Day by the
+ * Statute Law (Miscellaneous Amendments) Act, 2024.
+ */
+class MazingiraDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'mazingiraDay';
+
+    public const ESTABLISHMENT_YEAR = 2024;
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-10-10", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that Mazingira Day is not observed before its establishment.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            self::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /**
+     * Tests the substitute holiday when Mazingira Day falls on a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 2027 Mazingira Day falls on a Sunday, so Monday 11 October is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2027,
+            new \DateTime('2027-10-11', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 2024 Mazingira Day falls on a Thursday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 2024);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Mazingira Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/MoiDayTest.php
+++ b/tests/Kenya/MoiDayTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Moi Day in Kenya.
+ *
+ * Fixed date: 10 October. First observed in 1989, removed from the list of
+ * public holidays following the promulgation of the Constitution of Kenya in
+ * August 2010, and restored by a High Court ruling as of 2018. Renamed
+ * Utamaduni Day in 2020.
+ */
+class MoiDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'moiDay';
+
+    public const ESTABLISHMENT_YEAR = 1989;
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 1995;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-10-10", new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // Restored by the High Court ruling of 8 November 2017.
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2018,
+            new \DateTime('2018-10-10', new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that Moi Day is not observed before its establishment, in the
+     * years following the promulgation of the Constitution of Kenya, and
+     * after being renamed Utamaduni Day.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayInYearsNotObserved(): void
+    {
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, self::ESTABLISHMENT_YEAR - 1);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, 2015);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, 2020);
+    }
+
+    /**
+     * Tests the substitute holiday when Moi Day falls on a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 1999 Moi Day falls on a Sunday, so Monday 11 October is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            1999,
+            new \DateTime('1999-10-11', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 1995 Moi Day falls on a Tuesday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 1995);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2009),
+            [self::LOCALE => 'Moi Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2009),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/NewYearsDayTest.php
+++ b/tests/Kenya/NewYearsDayTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Kenya;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing New Year's Day in Kenya.
+ *
+ * Fixed date: 1 January. Substituted when falling on a Sunday.
+ */
+class NewYearsDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'newYearsDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-01-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests the substitute holiday when New Year's Day falls on a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 2023 New Year's Day falls on a Sunday, so Monday 2 January is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2023,
+            new \DateTime('2023-01-02', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 2024 New Year's Day falls on a Monday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 2024);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'New Year’s Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Kenya::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Kenya/UtamaduniDayTest.php
+++ b/tests/Kenya/UtamaduniDayTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Kenya;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Utamaduni Day in Kenya.
+ *
+ * Fixed date: 10 October. Moi Day was renamed Utamaduni Day in 2020, which in
+ * turn was renamed Mazingira Day in 2024.
+ */
+class UtamaduniDayTest extends KenyaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'utamaduniDay';
+
+    public const ESTABLISHMENT_YEAR = 2020;
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2022;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-10-10", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that Utamaduni Day is not observed before 2020 (Moi Day) and
+     * after 2023 (Mazingira Day).
+     *
+     * @throws \Exception
+     */
+    public function testHolidayInYearsNotObserved(): void
+    {
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, self::ESTABLISHMENT_YEAR - 1);
+        $this->assertNotHoliday(self::REGION, self::HOLIDAY, 2024);
+    }
+
+    /**
+     * Tests the substitute holiday when Utamaduni Day falls on a Sunday.
+     *
+     * @throws \Exception
+     */
+    public function testSubstituteHoliday(): void
+    {
+        // In 2021 Utamaduni Day falls on a Sunday, so Monday 11 October is a public holiday.
+        $this->assertSubstituteHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            2021,
+            new \DateTime('2021-10-11', new \DateTimeZone(self::TIMEZONE))
+        );
+
+        // In 2022 Utamaduni Day falls on a Monday, so no substitute holiday is given.
+        $this->assertNotSubstituteHoliday(self::REGION, self::HOLIDAY, 2022);
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2023),
+            [self::LOCALE => 'Utamaduni Day']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR, 2023),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}


### PR DESCRIPTION
Closes #414

This PR adds a holiday provider for Kenya (`KE`), covering the public holidays
established by the Public Holidays Act (Cap. 110), along with a full test suite.

## Holidays included

| Date | Holiday |
| --- | --- |
| 1 January | New Year's Day |
| movable | Good Friday |
| movable | Easter Monday |
| 1 May | Labour Day |
| 1 June | Madaraka Day |
| 10 October | Moi Day / Utamaduni Day / Mazingira Day (see below) |
| 20 October | Kenyatta Day / Mashujaa Day (see below) |
| 12 December | Jamhuri Day |
| 25 December | Christmas Day |
| 26 December | Boxing Day |

The provider covers holidays from 1964 onwards (the year Kenya became a republic),
following the same approach as the South Africa provider (from 1994).

## Historical accuracy of the October holidays

- **10 October**: first observed in 1989 as *Moi Day*; removed following the
  promulgation of the Constitution of Kenya in August 2010; restored as of 2018
  by the High Court ruling of 8 November 2017; renamed *Utamaduni Day* in 2020;
  renamed *Mazingira Day* by the Statute Law (Miscellaneous Amendments) Act, 2024.
- **20 October**: known as *Kenyatta Day* until 2009; renamed *Mashujaa Day*
  following the promulgation of the 2010 Constitution.

## Sunday substitution rule

Section 4 of the Public Holidays Act: whenever a public holiday falls on a
Sunday, the first succeeding day **that is not itself a public holiday** becomes
a public holiday. Implemented with `SubstituteHoliday`, following the South
Africa provider. This includes the edge case where Christmas Day falls on a
Sunday and the substitute day is Tuesday 27 December, because Monday 26 December
is already a public holiday (Boxing Day) — matching how it was gazetted in 2022.

## Not included

Idd-ul-Fitr (Part I of the Schedule) and Idd-ul-Azha (Part II) are official
holidays whose dates depend on the sighting of the moon. They are omitted for
now, following the same approach as the Turkey and Iran providers, until an
Islamic calendar provider is in place.

## Other changes

- Added the `en_KE` translation "Labour Day" to `internationalWorkersDay.php`
  (same pattern as the existing `en_ZA` "Workers' Day" entry).
- Registered the `Kenya` test suite in `phpunit.xml.dist`.

## Checks

- [x] `composer cs` – clean
- [x] `composer phpstan` (level 8) – no errors
- [x] `composer test` – full suite passes (Kenya suite: 63 tests, also run
      repeatedly to guard against random-year flakiness)

## Sources

- https://new.kenyalaw.org/akn/ke/act/1912/21/ (Public Holidays Act, Cap. 110)
- https://en.wikipedia.org/wiki/Public_holidays_in_Kenya