### PR TITLE
feat: add Indonesia holiday provider

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -98,6 +98,10 @@
     <testsuite name="Hungary">
       <directory>./tests/Hungary</directory>
     </testsuite>
+    <!-- Test Suite for holidays in Indonesia -->
+    <testsuite name="Indonesia">
+      <directory>./tests/Indonesia</directory>
+    </testsuite>
     <!-- Test Suite for holidays in Iran -->
     <testsuite name="Iran">
       <directory>./tests/Iran</directory>

--- a/src/Yasumi/Provider/Indonesia.php
+++ b/src/Yasumi/Provider/Indonesia.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\Provider;
+
+use Yasumi\Exception\UnknownLocaleException;
+use Yasumi\Holiday;
+
+/**
+ * Provider for all holidays in Indonesia.
+ *
+ * Indonesia observes a mix of national, Christian, Islamic, Hindu and
+ * Buddhist holidays. Only the holidays that fall on a fixed date or can be
+ * algorithmically determined (the Christian holidays, based on the date of
+ * Easter) are included in this provider.
+ *
+ * Note: The holidays that follow the Islamic (Hijri), Balinese Saka and
+ * Buddhist lunar calendars - Islamic New Year, Isra Mi'raj, Eid al-Fitr, Eid
+ * al-Adha, the Prophet's Birthday, Nyepi (Balinese New Year), Vesak and
+ * Chinese New Year - are not part of this provider yet. Their dates are
+ * either based on the sighting of the moon or on complex lunar/lunisolar
+ * calendar calculations, and are gazetted only shortly in advance, following
+ * the same approach as the Turkey, Iran and Kenya providers.
+ *
+ * @see https://en.wikipedia.org/wiki/Public_holidays_in_Indonesia
+ */
+class Indonesia extends AbstractProvider
+{
+    use CommonHolidays;
+    use ChristianHolidays;
+
+    /**
+     * Code to identify this Holiday Provider. Typically, this is the ISO3166
+     * code corresponding to the respective country or sub-region.
+     */
+    public const ID = 'ID';
+
+    /**
+     * Year in which New Year's Day and Independence Day were first observed
+     * as national public holidays. This provider covers holidays from this
+     * year onwards.
+     */
+    public const ESTABLISHMENT_YEAR = 1946;
+
+    /**
+     * Initialize holidays for Indonesia.
+     *
+     * @throws \InvalidArgumentException
+     * @throws UnknownLocaleException
+     * @throws \Exception
+     */
+    public function initialize(): void
+    {
+        $this->timezone = 'Asia/Jakarta';
+
+        if ($this->year < self::ESTABLISHMENT_YEAR) {
+            return;
+        }
+
+        // Add common holidays
+        $this->addHoliday($this->newYearsDay($this->year, $this->timezone, $this->locale));
+
+        // Add common Christian holidays
+        $this->calculateGoodFriday();
+        $this->calculateAscensionDay();
+
+        // Calculate other holidays
+        $this->calculateInternationalWorkersDay();
+        $this->calculatePancasilaDay();
+        $this->calculateIndependenceDay();
+        $this->calculateChristmasDay();
+    }
+
+    /**
+     * The source of the holidays.
+     *
+     * @return string[] The source URLs
+     */
+    public function getSources(): array
+    {
+        return [
+            'https://en.wikipedia.org/wiki/Public_holidays_in_Indonesia',
+        ];
+    }
+
+    /**
+     * Good Friday.
+     *
+     * "Jumat Agung". Movable feast: the Friday before Easter Sunday. A
+     * national public holiday between 1953 and 1962, and reinforced as such
+     * since 1971.
+     *
+     * @throws \Exception
+     */
+    protected function calculateGoodFriday(): void
+    {
+        if ($this->year >= 1971) {
+            $this->addHoliday($this->goodFriday($this->year, $this->timezone, $this->locale));
+        }
+    }
+
+    /**
+     * Ascension Day.
+     *
+     * "Kenaikan Isa Almasih". Movable feast: the 39th day after Easter
+     * Sunday. A national public holiday between 1953 and 1962, and
+     * reinforced as such since 1968.
+     *
+     * @throws \Exception
+     */
+    protected function calculateAscensionDay(): void
+    {
+        if ($this->year >= 1968) {
+            $this->addHoliday($this->ascensionDay($this->year, $this->timezone, $this->locale));
+        }
+    }
+
+    /**
+     * International Workers' Day.
+     *
+     * "Hari Buruh Internasional". A national public holiday between 1953 and
+     * 1967, and reinforced as such since 2014.
+     *
+     * @throws \Exception
+     */
+    protected function calculateInternationalWorkersDay(): void
+    {
+        if ($this->year >= 2014) {
+            $this->addHoliday($this->internationalWorkersDay($this->year, $this->timezone, $this->locale));
+        }
+    }
+
+    /**
+     * Pancasila Day.
+     *
+     * "Hari Lahir Pancasila". Commemorates the day the Pancasila, the
+     * philosophical foundation of the Indonesian state, was first outlined
+     * by Sukarno on 1 June 1945. Declared a national public holiday by
+     * Presidential Decree No. 24 of 2016, first observed in 2017.
+     *
+     * @see https://en.wikipedia.org/wiki/Pancasila_Day
+     *
+     * @throws \Exception
+     */
+    protected function calculatePancasilaDay(): void
+    {
+        if ($this->year >= 2017) {
+            $this->addHoliday(new Holiday(
+                'pancasilaDay',
+                [],
+                new \DateTime("{$this->year}-06-01", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+                $this->locale
+            ));
+        }
+    }
+
+    /**
+     * Independence Day.
+     *
+     * "Hari Kemerdekaan Republik Indonesia". Commemorates the proclamation
+     * of Indonesian independence by Sukarno on 17 August 1945. A national
+     * public holiday since 1946.
+     *
+     * @see https://en.wikipedia.org/wiki/Indonesian_Declaration_of_Independence
+     *
+     * @throws \Exception
+     */
+    protected function calculateIndependenceDay(): void
+    {
+        $this->addHoliday(new Holiday(
+            'independenceDay',
+            [],
+            new \DateTime("{$this->year}-08-17", DateTimeZoneFactory::getDateTimeZone($this->timezone)),
+            $this->locale
+        ));
+    }
+
+    /**
+     * Christmas Day.
+     *
+     * "Hari Raya Natal". Fixed date: 25 December. A national public holiday
+     * since 1953.
+     *
+     * @throws \Exception
+     */
+    protected function calculateChristmasDay(): void
+    {
+        if ($this->year >= 1953) {
+            $this->addHoliday($this->christmasDay($this->year, $this->timezone, $this->locale));
+        }
+    }
+}

--- a/src/Yasumi/data/translations/ascensionDay.php
+++ b/src/Yasumi/data/translations/ascensionDay.php
@@ -25,6 +25,7 @@ return [
     'es' => 'Ascensión del Señor',
     'fi' => 'Helatorstai',
     'fr' => 'Ascension',
+    'id' => 'Kenaikan Isa Almasih',
     'it' => 'Ascensione',
     'nb' => 'Kristi himmelfartsdag',
     'nl' => 'Hemelvaart',

--- a/src/Yasumi/data/translations/christmasDay.php
+++ b/src/Yasumi/data/translations/christmasDay.php
@@ -35,6 +35,7 @@ return [
     'fr' => 'Noël',
     'hr' => 'Božić',
     'hu' => 'Karácsony',
+    'id' => 'Hari Raya Natal',
     'it' => 'Natale',
     'ko' => '기독탄신일',
     'lt' => 'Šv. Kalėdos',

--- a/src/Yasumi/data/translations/goodFriday.php
+++ b/src/Yasumi/data/translations/goodFriday.php
@@ -30,6 +30,7 @@ return [
     'fr' => 'Vendredi Saint',
     'ga' => 'Aoine an Chéasta',
     'hu' => 'Nagypéntek',
+    'id' => 'Jumat Agung',
     'it' => 'Venerdi Santo',
     'ja' => 'グッドフライデー',
     'lv' => 'Lielā Piektdiena',

--- a/src/Yasumi/data/translations/internationalWorkersDay.php
+++ b/src/Yasumi/data/translations/internationalWorkersDay.php
@@ -33,6 +33,7 @@ return [
     'fr' => 'Fête du Travail',
     'hr' => 'Praznik rada',
     'hu' => 'A munka ünnepe',
+    'id' => 'Hari Buruh Internasional',
     'it' => 'Festa del Lavoro',
     'it_CH' => 'Festa dei lavoratori',
     'ja' => '労働の日',

--- a/src/Yasumi/data/translations/newYearsDay.php
+++ b/src/Yasumi/data/translations/newYearsDay.php
@@ -35,6 +35,7 @@ return [
     'ga' => 'Lá Caille',
     'hr' => 'Nova godina',
     'hu' => 'Újév',
+    'id' => 'Tahun Baru Masehi',
     'it' => 'Capodanno',
     'ja' => '元日',
     'ka' => 'ახალი წელი',

--- a/src/Yasumi/data/translations/pancasilaDay.php
+++ b/src/Yasumi/data/translations/pancasilaDay.php
@@ -15,10 +15,8 @@ declare(strict_types = 1);
  * @author Sacha Telgenhof <me at sachatelgenhof dot com>
  */
 
-// Translations for Independence Day
+// Translations for Pancasila Day
 return [
-    'en' => 'Independence Day',
-    'hr' => 'Dan neovisnosti',
-    'id' => 'Hari Kemerdekaan Republik Indonesia',
-    'sl' => 'Dan samostojnosti in enotnosti',
+    'en' => 'Pancasila Day',
+    'id' => 'Hari Lahir Pancasila',
 ];

--- a/tests/Indonesia/AscensionDayTest.php
+++ b/tests/Indonesia/AscensionDayTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Indonesia;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Ascension Day in Indonesia.
+ *
+ * Movable feast: the 39th day after Easter Sunday. Reinforced as a national
+ * public holiday since 1968.
+ */
+class AscensionDayTest extends IndonesiaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'ascensionDay';
+
+    public const ESTABLISHMENT_YEAR = 1968;
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-05-09", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that no holidays are defined before the establishment year.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            self::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Kenaikan Isa Almasih']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Indonesia/ChristmasDayTest.php
+++ b/tests/Indonesia/ChristmasDayTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Indonesia;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Christmas Day in Indonesia.
+ *
+ * Fixed date: 25 December. A national public holiday since 1953.
+ */
+class ChristmasDayTest extends IndonesiaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'christmasDay';
+
+    public const ESTABLISHMENT_YEAR = 1953;
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-12-25", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that no holidays are defined before the establishment year.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            self::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Hari Raya Natal']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Indonesia/GoodFridayTest.php
+++ b/tests/Indonesia/GoodFridayTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Indonesia;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Good Friday in Indonesia.
+ *
+ * Movable feast: the Friday before Easter Sunday. Reinforced as a national
+ * public holiday since 1971.
+ */
+class GoodFridayTest extends IndonesiaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'goodFriday';
+
+    public const ESTABLISHMENT_YEAR = 1971;
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-03-29", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that no holidays are defined before the establishment year.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            self::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Jumat Agung']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Indonesia/IndependenceDayTest.php
+++ b/tests/Indonesia/IndependenceDayTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Indonesia;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Indonesia;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Independence Day in Indonesia.
+ *
+ * Fixed date: 17 August. Commemorates the proclamation of Indonesian
+ * independence on 17 August 1945. A national public holiday since 1946.
+ */
+class IndependenceDayTest extends IndonesiaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'independenceDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-08-17", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that no holidays are defined before the establishment year.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            Indonesia::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Indonesia::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Hari Kemerdekaan Republik Indonesia']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Indonesia::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Indonesia/IndonesiaBaseTestCase.php
+++ b/tests/Indonesia/IndonesiaBaseTestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Indonesia;
+
+use PHPUnit\Framework\TestCase;
+use Yasumi\tests\YasumiBase;
+
+/**
+ * Base class for Indonesia holiday tests.
+ */
+abstract class IndonesiaBaseTestCase extends TestCase
+{
+    use YasumiBase;
+
+    /** Country (name) to be tested. */
+    public const REGION = 'Indonesia';
+
+    /** Timezone in which this provider has holidays defined. */
+    public const TIMEZONE = 'Asia/Jakarta';
+
+    /** Locale that is considered common for this provider. */
+    public const LOCALE = 'id_ID';
+}

--- a/tests/Indonesia/IndonesiaTest.php
+++ b/tests/Indonesia/IndonesiaTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Indonesia;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Indonesia;
+use Yasumi\tests\ProviderTestCase;
+
+/**
+ * Class for testing holidays in Indonesia.
+ */
+class IndonesiaTest extends IndonesiaBaseTestCase implements ProviderTestCase
+{
+    /** @var int year random year number used for all tests in this Test Case */
+    protected int $year;
+
+    /**
+     * Initial setup of this Test Case.
+     *
+     * @throws \Exception
+     */
+    protected function setUp(): void
+    {
+        $this->year = static::generateRandomYear(Indonesia::ESTABLISHMENT_YEAR);
+    }
+
+    /**
+     * Tests if all official holidays in Indonesia are defined by the provider class.
+     */
+    public function testOfficialHolidays(): void
+    {
+        $holidays = [
+            'newYearsDay',
+            'independenceDay',
+        ];
+
+        if ($this->year >= 1953) {
+            $holidays[] = 'christmasDay';
+        }
+
+        if ($this->year >= 1968) {
+            $holidays[] = 'ascensionDay';
+        }
+
+        if ($this->year >= 1971) {
+            $holidays[] = 'goodFriday';
+        }
+
+        if ($this->year >= 2014) {
+            $holidays[] = 'internationalWorkersDay';
+        }
+
+        if ($this->year >= 2017) {
+            $holidays[] = 'pancasilaDay';
+        }
+
+        $this->assertDefinedHolidays($holidays, self::REGION, $this->year, Holiday::TYPE_OFFICIAL);
+    }
+
+    /**
+     * Tests if all observed holidays in Indonesia are defined by the provider class.
+     */
+    public function testObservedHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OBSERVANCE);
+    }
+
+    /**
+     * Tests if all seasonal holidays in Indonesia are defined by the provider class.
+     */
+    public function testSeasonalHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_SEASON);
+    }
+
+    /**
+     * Tests if all bank holidays in Indonesia are defined by the provider class.
+     */
+    public function testBankHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_BANK);
+    }
+
+    /**
+     * Tests if all other holidays in Indonesia are defined by the provider class.
+     */
+    public function testOtherHolidays(): void
+    {
+        $this->assertDefinedHolidays([], self::REGION, $this->year, Holiday::TYPE_OTHER);
+    }
+
+    /** @throws \Exception */
+    public function testSources(): void
+    {
+        $this->assertSources(self::REGION, 1);
+    }
+}

--- a/tests/Indonesia/InternationalWorkersDayTest.php
+++ b/tests/Indonesia/InternationalWorkersDayTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Indonesia;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing International Workers' Day in Indonesia.
+ *
+ * Fixed date: 1 May. Reinforced as a national public holiday since 2014.
+ */
+class InternationalWorkersDayTest extends IndonesiaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'internationalWorkersDay';
+
+    public const ESTABLISHMENT_YEAR = 2014;
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-05-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that no holidays are defined before the establishment year.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            self::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Hari Buruh Internasional']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Indonesia/NewYearsDayTest.php
+++ b/tests/Indonesia/NewYearsDayTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Indonesia;
+
+use Yasumi\Holiday;
+use Yasumi\Provider\Indonesia;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing New Year's Day in Indonesia.
+ *
+ * Fixed date: 1 January.
+ */
+class NewYearsDayTest extends IndonesiaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'newYearsDay';
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-01-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that no holidays are defined before the establishment year.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            Indonesia::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Indonesia::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Tahun Baru Masehi']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(Indonesia::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}

--- a/tests/Indonesia/PancasilaDayTest.php
+++ b/tests/Indonesia/PancasilaDayTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Indonesia;
+
+use Yasumi\Holiday;
+use Yasumi\tests\HolidayTestCase;
+
+/**
+ * Class for testing Pancasila Day in Indonesia.
+ *
+ * Fixed date: 1 June. Declared a national public holiday by Presidential
+ * Decree No. 24 of 2016, first observed in 2017.
+ */
+class PancasilaDayTest extends IndonesiaBaseTestCase implements HolidayTestCase
+{
+    public const HOLIDAY = 'pancasilaDay';
+
+    public const ESTABLISHMENT_YEAR = 2017;
+
+    /** @throws \Exception */
+    public function testHoliday(): void
+    {
+        $year = 2024;
+        $this->assertHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            $year,
+            new \DateTime("{$year}-06-01", new \DateTimeZone(self::TIMEZONE))
+        );
+    }
+
+    /**
+     * Tests that no holidays are defined before the establishment year.
+     *
+     * @throws \Exception
+     */
+    public function testHolidayBeforeEstablishment(): void
+    {
+        $this->assertNotHoliday(
+            self::REGION,
+            self::HOLIDAY,
+            self::ESTABLISHMENT_YEAR - 1
+        );
+    }
+
+    /** @throws \Exception */
+    public function testTranslation(): void
+    {
+        $this->assertTranslatedHolidayName(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            [self::LOCALE => 'Hari Lahir Pancasila']
+        );
+    }
+
+    /** @throws \Exception */
+    public function testHolidayType(): void
+    {
+        $this->assertHolidayType(
+            self::REGION,
+            self::HOLIDAY,
+            static::generateRandomYear(self::ESTABLISHMENT_YEAR),
+            Holiday::TYPE_OFFICIAL
+        );
+    }
+}


### PR DESCRIPTION
Closes #415

This PR adds a holiday provider for Indonesia (`ID`), covering the national
public holidays that fall on a fixed date or can be algorithmically
determined, along with a full test suite.

## Holidays included

| Date | Holiday |
| --- | --- |
| 1 January | New Year's Day |
| movable | Good Friday |
| movable | Ascension Day |
| 1 May | International Workers' Day |
| 1 June | Pancasila Day |
| 17 August | Independence Day |
| 25 December | Christmas Day |

The provider covers holidays from 1946 onwards (the year New Year's Day and
Independence Day were first observed as national public holidays), following
the same approach as the South Africa (1994) and Kenya (1964) providers.

## Historical accuracy of the establishment years

Several holidays were designated as national public holidays in the 1950s,
later removed, and reinstated ("reinforced") decades later. Each holiday is
only returned from the year it has been continuously observed:

- **Good Friday**: a national public holiday between 1953 and 1962, and
  reinforced as such since 1971.
- **Ascension Day**: a national public holiday between 1953 and 1962, and
  reinforced as such since 1968.
- **International Workers' Day**: a national public holiday between 1953 and
  1967, and reinforced as such since 2014.
- **Pancasila Day**: declared a national public holiday by Presidential
  Decree No. 24 of 2016, first observed in 2017.
- **Christmas Day**: a national public holiday since 1953.

## Not included

The holidays that follow the Islamic (Hijri), Balinese Saka and Buddhist
lunar calendars — Islamic New Year, Isra Mi'raj, Eid al-Fitr, Eid al-Adha,
the Prophet's Birthday, Nyepi (Balinese New Year) and Vesak — as well as
Chinese New Year are omitted for now. Their dates are either based on the
sighting of the moon or on complex lunar/lunisolar calendar calculations,
and are gazetted only shortly in advance, following the same approach as the
Turkey, Iran and Kenya providers.

## Other changes

- Added the `id` translations to the six existing translation files
  (`newYearsDay`, `goodFriday`, `ascensionDay`, `internationalWorkersDay`,
  `independenceDay`, `christmasDay`).
- Added a new `pancasilaDay.php` translation file (`en`, `id`).
- Registered the `Indonesia` test suite in `phpunit.xml.dist`.

## Checks

- [x] `composer cs` – clean
- [x] `composer phpstan` (level 8) – no errors
- [x] `composer test` – full suite passes (Indonesia suite: 34 tests)

## Sources

- https://en.wikipedia.org/wiki/Public_holidays_in_Indonesia