### PR TITLE
Fix invalid timezone names

### DIFF
--- a/src/Yasumi/Provider/Canada/NorthwestTerritories.php
+++ b/src/Yasumi/Provider/Canada/NorthwestTerritories.php
@@ -46,7 +46,7 @@ class NorthwestTerritories extends Canada
     {
         parent::initialize();
 
-        $this->timezone = 'America/Yellowknife';
+        $this->timezone = 'America/Edmonton';
 
         $this->calculateCivicHoliday();
         $this->calculateNationalIndigenousPeoplesDay();

--- a/src/Yasumi/Provider/Ukraine.php
+++ b/src/Yasumi/Provider/Ukraine.php
@@ -48,7 +48,7 @@ class Ukraine extends AbstractProvider
      */
     public function initialize(): void
     {
-        $this->timezone = 'Europe/Kiev';
+        $this->timezone = 'Europe/Kyiv';
 
         // Add common holidays
         // New Years Day will not be substituted to an monday if it's on a weekend!

--- a/tests/Base/TimezoneTest.php
+++ b/tests/Base/TimezoneTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * This file is part of the 'Yasumi' package.
+ *
+ * The easy PHP Library for calculating holidays.
+ *
+ * Copyright (c) 2015 - 2026 AzuyaLabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author Sacha Telgenhof <me at sachatelgenhof dot com>
+ */
+
+namespace Yasumi\tests\Base;
+
+use PHPUnit\Framework\TestCase;
+use Yasumi\Provider\AbstractProvider;
+use Yasumi\tests\YasumiBase;
+use Yasumi\Yasumi;
+
+/**
+ * Class TimezoneTest.
+ *
+ * Verifies that holiday providers only use canonical timezone identifiers. PHP keeps a second set of
+ * identifiers (e.g. 'Europe/Kiev', 'Australia/ACT') around as links for backward compatibility only, and
+ * their use is discouraged. Depending on how PHP was compiled and which tzdata is present on the host
+ * system, these links may be absent altogether, resulting in a "Unknown or bad timezone" error.
+ *
+ * @see https://www.php.net/manual/en/timezones.others.php
+ * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+ */
+class TimezoneTest extends TestCase
+{
+    use YasumiBase;
+
+    /**
+     * @param string $class    the provider
+     * @param string $timezone the timezone identifier used by the provider
+     * @param string $source   where the timezone identifier originates from
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('timezoneProvider')]
+    public function testTimezoneIsCanonical(string $class, string $timezone, string $source): void
+    {
+        self::assertTrue(
+            \in_array($timezone, \DateTimeZone::listIdentifiers(), true),
+            sprintf(
+                'Provider "%s" uses timezone "%s" (%s). PHP only lists this identifier for backward '
+                . 'compatibility purposes and its use is discouraged; use its canonical name instead.',
+                $class,
+                $timezone,
+                $source
+            )
+        );
+    }
+
+    /**
+     * Provides test data for testTimezoneIsCanonical().
+     *
+     * @return array<string, array{string, string, string}> list of timezone identifiers per provider
+     *
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public static function timezoneProvider(): array
+    {
+        $tests = [];
+
+        foreach (Yasumi::getProviders() as $class) {
+            $provider = Yasumi::create($class, static::generateRandomYear());
+
+            /** @var string $declared */
+            $declared = (new \ReflectionProperty(AbstractProvider::class, 'timezone'))->getValue($provider);
+
+            $timezones = [$declared => 'declared timezone'];
+
+            foreach ($provider->getHolidays() as $holiday) {
+                $timezone = $holiday->getTimezone();
+
+                if (false === $timezone) {
+                    continue;
+                }
+
+                $timezones[$timezone->getName()] ??= sprintf('holiday "%s"', $holiday->getKey());
+            }
+
+            foreach ($timezones as $timezone => $source) {
+                $tests["{$class} - {$timezone}"] = [$class, (string) $timezone, $source];
+            }
+        }
+
+        return $tests;
+    }
+}

--- a/tests/Canada/NorthwestTerritories/NorthwestTerritoriesBaseTestCase.php
+++ b/tests/Canada/NorthwestTerritories/NorthwestTerritoriesBaseTestCase.php
@@ -31,7 +31,7 @@ abstract class NorthwestTerritoriesBaseTestCase extends CanadaBaseTestCase
     public const REGION = 'Canada\NorthwestTerritories';
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'America/Yellowknife';
+    public const TIMEZONE = 'America/Edmonton';
 
     /** Locale that is considered common for this provider. */
     public const LOCALE = 'en_CA';

--- a/tests/Ukraine/UkraineBaseTestCase.php
+++ b/tests/Ukraine/UkraineBaseTestCase.php
@@ -31,7 +31,7 @@ class UkraineBaseTestCase extends TestCase
     public const REGION = 'Ukraine';
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'Europe/Kiev';
+    public const TIMEZONE = 'Europe/Kyiv';
 
     /** Locale that is considered common for this provider. */
     public const LOCALE = 'uk_UA';

--- a/tests/UnitedKingdom/NorthernIreland/NorthernIrelandBaseTestCase.php
+++ b/tests/UnitedKingdom/NorthernIreland/NorthernIrelandBaseTestCase.php
@@ -31,7 +31,7 @@ abstract class NorthernIrelandBaseTestCase extends UnitedKingdomBaseTestCase
     public const REGION = 'UnitedKingdom\NorthernIreland';
 
     /** Timezone in which this provider has holidays defined. */
-    public const TIMEZONE = 'Europe/Belfast';
+    public const TIMEZONE = 'Europe/London';
 
     /** Locale that is considered common for this provider. */
     public const LOCALE = 'en_GB';


### PR DESCRIPTION
See https://github.com/azuyalabs/yasumi/issues/424

Seems my rant was partially outdated, as a fix for Australia was already merged but not yet released.

BTW this problem shows up on systems that do not ship

```
apt install tzdata-legacy
```